### PR TITLE
Adding features to check_interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ python -m build --sdist
 This code is part of a [publication](https://doi.org/10.21203/rs.3.rs-4732459/v1), please cite it accordingly if you use this package in your work
 
 ```
-@article{poul2024automated,
-  title={Automated Generation of Structure Datasets for Machine Learning Potentials and Alloys},
-  author={Poul, Marvin and Huber, Liam and Neugebauer, J{\"o}rg},
-  year={2024}
+@article{poul2025automated,
+    title = {Automated generation of structure datasets for machine learning potentials and alloys},
+    journal = {npj Computational Materials},
+    author={Poul, Marvin and Huber, Liam and Neugebauer, J{\"o}rg},
+    journal = {npj Computational Materials},
+    volume = {11},
+    number = {1},
+    pages = {174},
+    year={2025},
+    doi = {10.1038/s41524-025-01669-4},
 }
+
 ```
 
 # Examples

--- a/landau/phases.py
+++ b/landau/phases.py
@@ -575,19 +575,19 @@ class SlowInterpolatingPhase(Phase):
         x = np.linspace(*self.concentration_range, samples)
 
         if plot_excess==True: 
-            p0 = min(self.phases, key=lambda p: p.fixed_concentration)
-            p1 = max(self.phases, key=lambda p: p.fixed_concentration)               
+            p_min = min(self.phases, key=lambda p: p.fixed_concentration)
+            p_max = max(self.phases, key=lambda p: p.fixed_concentration)               
 
-            f0=p0.free_energy(T,0)
-            f1=p1.free_energy(T,1)
+            f_min=p_min.line_free_energy(T)
+            f_max=p_max.line_free_energy(T)
 
-            free_energy = self.free_energy(T, x) - ((1-x)*f0 + x*f1)
+            free_energy = self.free_energy(T, x) - (((self.concentration_range[1]-self.concentration_range[0])-x)*f_min + x*f_max)
 
             plt.plot(x, free_energy, label=self.name)
 
             for p in self.phases:
                 line_free_energy = p.line_free_energy(T)- (
-                    (1-p.line_concentration)*f0 + p.line_concentration*f1
+                    ((self.concentration_range[1]-self.concentration_range[0])-p.line_concentration)*f_min + p.line_concentration*f_max
                 )
 
                 if self.add_entropy==True:

--- a/landau/phases.py
+++ b/landau/phases.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import lru_cache, cache
 from typing import Iterable
-import warnings
 from pyiron_snippets.deprecate import deprecate
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This pull request can be accepted once the function is finished. Not yet.

* Renamed `check_interpolation` to `check_interpolation_over_concentration`. Added a deprecation warning for `check_interpolation`.
* Added a new argument `respect_add_entropy`. If `respect_add_entropy==False`, the ideal entropy is removed from the free energy fit, only for those phases where `self.add_entropy==True`  The scatter plot of the original free energy values remains the same.

For example:
```
AlMg_fcc_solid_interpolated = ldp.SlowInterpolatingPhase(
    'FCC', 
    fcc_line_phases_list, 
    num_coeffs=2, 
    add_entropy=True
    )
```

`AlMg_fcc_solid_interpolated.check_interpolation_over_concentration(1000, respect_add_entropy=True)` gives:
<img width="390" height="390" alt="image" src="https://github.com/user-attachments/assets/5b0cf482-5019-4536-b127-a44bd21540e0" />

and, `AlMg_fcc_solid_interpolated.check_interpolation_over_concentration(1000, respect_add_entropy=False)` gives:
<img width="390" height="390" alt="image" src="https://github.com/user-attachments/assets/55c38cfb-280f-479c-89cd-e4d2eeb2b2b2" />

