### PR TITLE
🧪 Add edge case tests and fix scalar TypeError in Sprime utility

### DIFF
--- a/landau/phases.py
+++ b/landau/phases.py
@@ -40,10 +40,13 @@ def S(c):
 
 
 def Sprime(c):
-    with np.errstate(divide="ignore"):
-        s = -kB * (np.log(c / (1 - c)))
-    s[np.isclose(c, 0)] = +np.inf
-    s[np.isclose(c, 1)] = -np.inf
+    c_arr = np.atleast_1d(c)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        s = -kB * (np.log(c_arr / (1 - c_arr)))
+    s[np.isclose(c_arr, 0)] = +np.inf
+    s[np.isclose(c_arr, 1)] = -np.inf
+    if np.isscalar(c):
+        return s.item()
     return s
 
 

--- a/tests/unit/test_phases_utils.py
+++ b/tests/unit/test_phases_utils.py
@@ -1,0 +1,48 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from landau.phases import Sprime
+
+def test_Sprime_scalar():
+    # Sprime(c) = -kB * np.log(c / (1 - c))
+    # where c is between 0 and 1
+    # Edge cases
+    assert Sprime(0.0) == np.inf
+    assert Sprime(1.0) == -np.inf
+    assert Sprime(0.5) == 0.0
+
+def test_Sprime_array():
+    # Array inputs including edge cases
+    c_arr = np.array([0.0, 0.5, 1.0])
+    expected = np.array([np.inf, 0.0, -np.inf])
+    res = Sprime(c_arr)
+    assert isinstance(res, np.ndarray)
+    assert_allclose(res, expected, atol=1e-10)
+
+def test_Sprime_list():
+    # List input should be handled correctly
+    c_list = [0.0, 0.5, 1.0]
+    expected = np.array([np.inf, 0.0, -np.inf])
+    res = Sprime(c_list)
+    assert isinstance(res, np.ndarray)
+    assert_allclose(res, expected, atol=1e-10)
+
+def test_Sprime_close_to_edges():
+    # Values close to 0 and 1 should still return +/- inf
+    # based on np.isclose defaults (rtol=1e-05, atol=1e-08)
+
+    # Very close to 0
+    assert Sprime(1e-10) == np.inf
+
+    # Very close to 1
+    assert Sprime(1.0 - 1e-10) == -np.inf
+
+    # Not quite close enough to 0 (e.g., 1e-7 which > atol)
+    # Should calculate a valid negative number, not infinity
+    # But np.isclose with default atol=1e-8 might trigger if we are very close
+
+    # For a generic value
+    res = Sprime(0.1)
+    # log(0.1 / 0.9) = log(1/9) < 0. So Sprime(0.1) > 0.
+    assert res > 0
+    assert np.isfinite(res)


### PR DESCRIPTION
🎯 **What:** The `Sprime` utility function had missing edge case tests. In writing these tests, it was discovered that `Sprime` would throw a `TypeError` if a scalar float was passed, because it tried to perform item assignment (`s[np.isclose(c, 0)] = ...`) on a `np.float64` result. 

📊 **Coverage:** 
- Modified `Sprime` to cast `c` via `np.atleast_1d`, then process array logic, returning a scalar `.item()` if a scalar was provided.
- Added test coverage in `tests/unit/test_phases_utils.py` for arrays, scalar values (`0.0`, `0.5`, `1.0`), lists, and near-edge proximity values (e.g. `1e-10` and `1.0 - 1e-10`).

✨ **Result:** The `Sprime` utility is now robust for both scalar and array inputs, and the edge case behavior (returning `np.inf` or `-np.inf` near borders) is strictly tested.

---
*PR created automatically by Jules for task [8879193580874105153](https://jules.google.com/task/8879193580874105153) started by @pmrv*