### PR TITLE
Fix pandas 3.0 crash: replace include_groups=True in groupby.apply

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -245,7 +245,7 @@ def refine_phase_diagram(df, phases, min_c=0, max_c=1):
         if multiple_mus:
             mdf = (
                 df.groupby("T", group_keys=True)
-                .apply(find_all_points, phases=phases, by="mu", include_groups=True)
+                .apply(lambda g: find_all_points(g.assign(T=g.name), phases=phases, by="mu"), include_groups=False)
                 .reset_index()
             )
             mdf["stable"] = True
@@ -255,7 +255,7 @@ def refine_phase_diagram(df, phases, min_c=0, max_c=1):
         if multiple_ts:
             Tdf = (
                 df.groupby("mu", group_keys=True)
-                .apply(find_all_points, phases=phases, by="T", include_groups=True)
+                .apply(lambda g: find_all_points(g.assign(mu=g.name), phases=phases, by="T"), include_groups=False)
                 .reset_index()
             )
             Tdf["stable"] = True

--- a/tests/regression/test_pandas_groupby.py
+++ b/tests/regression/test_pandas_groupby.py
@@ -1,0 +1,37 @@
+# Regression tests for pandas 3.0 compatibility: groupby.apply with include_groups
+# https://github.com/eisenforschung/landau/pull/64
+import numpy as np
+import pytest
+
+from landau.phases import LinePhase, IdealSolution
+from landau.calculate import calc_phase_diagram
+
+
+@pytest.fixture
+def two_phase_system():
+    l1 = LinePhase("A", 0, 0, 0)
+    l2 = LinePhase("B", 1, 0.1, 0)
+    sol = IdealSolution("sol", l1, l2)
+    return [l1, l2, sol]
+
+
+def test_single_T_multiple_mu(two_phase_system):
+    """calc_phase_diagram with a single T and multiple mu values must not raise ValueError.
+
+    Previously crashed with pandas 3.0 due to include_groups=True in groupby.apply.
+    """
+    pdf = calc_phase_diagram(two_phase_system, Ts=1000.0, mu=np.linspace(-0.2, 0.2, 10))
+    assert len(pdf) > 0
+    assert "phase" in pdf.columns
+    assert "c" in pdf.columns
+
+
+def test_multiple_T_single_mu(two_phase_system):
+    """calc_phase_diagram with multiple T values and a single mu must not raise ValueError.
+
+    Previously crashed with pandas 3.0 due to include_groups=True in groupby.apply.
+    """
+    pdf = calc_phase_diagram(two_phase_system, Ts=np.linspace(100, 2000, 10), mu=0.05)
+    assert len(pdf) > 0
+    assert "phase" in pdf.columns
+    assert "c" in pdf.columns


### PR DESCRIPTION
pandas 3.0 removed support for include_groups=True in GroupBy.apply, raising ValueError. The two affected call sites in refine_phase_diagram (single-T-multiple-mu and single-mu-multiple-T paths) now pass the groupby key back into the group via g.assign(key=g.name) so that find_all_points can still access it, using include_groups=False.

Also adds two regression tests covering these previously untested paths.