### PR TITLE
🔒 [security fix] replace assert with explicit exception for validation

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -64,7 +64,8 @@ def find_all_points(stable_df, phases, by="mu"):
     """
     Map find_one_point over all estimated equilibria at a given T or mu.
     """
-    assert by in ["T", "mu"], "Wrong by value"
+    if by not in ["T", "mu"]:
+        raise ValueError("Invalid value for 'by'. Expected 'T' or 'mu'.")
     stable_df = stable_df.sort_values(by).reset_index(drop=True)
     boundary_guesses = stable_df.index[(stable_df.phase != stable_df.phase.shift(-1).ffill())]
     if by == "mu":

--- a/landau/interpolate.py
+++ b/landau/interpolate.py
@@ -117,7 +117,8 @@ class SGTE(TemperatureInterpolator):
     nparam: int
 
     def __post_init__(self):
-        assert self.nparam > 1, "Must fit at least two parameters!"
+        if self.nparam <= 1:
+            raise ValueError("Must fit at least two parameters!")
 
     def fit(self, x, y):
         parameters, *_ = so.curve_fit(G_calphad, x, y, p0=[0] * self.nparam)
@@ -134,7 +135,8 @@ class RedlichKister(ConcentrationInterpolator):
     nparam: int
 
     def __post_init__(self):
-        assert self.nparam > 0, "Must fit at least one parameter!"
+        if self.nparam <= 0:
+            raise ValueError("Must fit at least one parameter!")
 
     def fit(self, c, f):
         """
@@ -144,7 +146,8 @@ class RedlichKister(ConcentrationInterpolator):
         I = c.argsort()
         f = f[I]
         c = c[I]
-        assert np.isclose(c[0], 0) and np.isclose(c[-1], 1), "Must include terminals when fitting Redlich-Kister!"
+        if not (np.isclose(c[0], 0) and np.isclose(c[-1], 1)):
+            raise ValueError("Must include terminals when fitting Redlich-Kister!")
         f0 = f[0]
         df = f[-1] - f[0]
         f -= f0 + df * c
@@ -275,7 +278,8 @@ class SoftplusFit(ConcentrationInterpolator, TemperatureInterpolator):
 
         # 3. Build model with n softplus terms
         def model(xn, *params):
-            assert len(params) == 3 * self.n_softplus + 1
+            if len(params) != 3 * self.n_softplus + 1:
+                raise ValueError(f"Expected {3 * self.n_softplus + 1} parameters, but got {len(params)}.")
             out = 0
             for i in range(self.n_softplus):
                 a = params[3*i]

--- a/landau/phases.py
+++ b/landau/phases.py
@@ -222,7 +222,8 @@ class IdealSolution(Phase):
 
     def __post_init__(self, *args, **kwargs):
         phase1, phase2 = sorted((self.phase1, self.phase2), key=lambda p: p.line_concentration)
-        assert phase1.line_concentration == 0 and phase2.line_concentration == 1, "Must give terminal phases!"
+        if not (phase1.line_concentration == 0 and phase2.line_concentration == 1):
+            raise ValueError("Must give terminal phases!")
         # bypass frozen=True for the sake of init only
         object.__setattr__(self, "phase1", phase1)
         object.__setattr__(self, "phase2", phase2)
@@ -278,12 +279,12 @@ class RegularSolution(Phase):
         object.__setattr__(self, "phases", tuple(self.phases))
         object.__setattr__(self, "num_coeffs", min(len(self.phases) - 2, self.num_coeffs))
         concs = tuple(p.line_concentration for p in self.phases)
-        assert 0 in concs and 1 in concs, "Must give the terminal phases!"
+        if 0 not in concs or 1 not in concs:
+            raise ValueError("Must give the terminal phases!")
         left_terminals = sum(c == 0 for c in concs)
         right_terminals = sum(c == 1 for c in concs)
-        assert left_terminals == 1 and right_terminals == 1, (
-            "Cannot pass multiple terminal phases of the same concentration!"
-        )
+        if not (left_terminals == 1 and right_terminals == 1):
+            raise ValueError("Cannot pass multiple terminal phases of the same concentration!")
 
     @lru_cache(maxsize=250)
     def _get_interpolation(self, T):
@@ -360,7 +361,8 @@ class RegularSolution(Phase):
         if raw:
             return f, c, M, p
 
-        assert np.median(abs(np.diff(M))) <= limit, "Weird"
+        if np.median(abs(np.diff(M))) > limit:
+            raise RuntimeError("Sampling of chemical potential did not converge to required precision.")
 
         # schon etwas dreist, aber naja
         pi = si.interp1d(


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR addresses a security vulnerability where `assert` statements were used for input validation and critical runtime checks. In Python, `assert` statements are stripped out when the interpreter is run with optimizations (using the `-O` or `-OO` flags), which could lead to a bypass of these essential checks.

### ⚠️ Risk: The potential impact if left unfixed
If left unfixed, an attacker or a user running the library in a production (optimized) environment could provide invalid inputs that would have otherwise been caught. This could lead to:
- Corrupted data or invalid thermodynamic calculations.
- Unexpected crashes or undefined behavior in downstream processes.
- Potential security bypasses if any of these checks were intended to prevent malicious input from reaching sensitive operations.

### 🛡️ Solution: How the fix addresses the vulnerability
All instances of `assert` used for validation in `landau/phases.py`, `landau/calculate.py`, and `landau/interpolate.py` have been replaced with explicit `if not condition: raise Exception(...)` blocks. 
- `ValueError` is used for input-related validation (e.g., checking for terminal phases or valid parameters).
- `RuntimeError` is used for internal state checks that should have been reached (e.g., convergence of numerical sampling).

This ensures that the validation logic is always enforced, regardless of whether Python is run with optimizations.


---
*PR created automatically by Jules for task [11815920236608790707](https://jules.google.com/task/11815920236608790707) started by @pmrv*