### PR TITLE
Value-based equality and hashing for AsePhase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 dist/
 build/
 *.egg-info
+landau/_version.py

--- a/landau/phases/asewrapper.py
+++ b/landau/phases/asewrapper.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 from dataclasses import dataclass
 
@@ -12,6 +14,10 @@ from . import AbstractLinePhase
 class AsePhase(AbstractLinePhase):
     """
     Phase wrapper for ASE's ThermoChem classes.
+
+    Equality and hashing compare ``thermochem`` by its pickled bytes so two
+    ``AsePhase`` instances built from equivalent inputs compare equal even
+    though ASE's ``ThermoChem`` defaults to identity-based equality.
     """
     fixed_concentration: float
     thermochem: 'ThermoChem'
@@ -41,3 +47,19 @@ class AsePhase(AbstractLinePhase):
         if res.ndim == 0:
             return res.item()
         return res
+
+    def _key(self):
+        return (
+            self.name,
+            self.fixed_concentration,
+            self.pressure,
+            pickle.dumps(self.thermochem),
+        )
+
+    def __eq__(self, other):
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        return self._key() == other._key()
+
+    def __hash__(self):
+        return hash(self._key())

--- a/tests/unit/phases/test_ase.py
+++ b/tests/unit/phases/test_ase.py
@@ -44,3 +44,46 @@ def test_ase_thermo_phase_helmholtz():
     T_array = np.array([300, 400])
     F_array = phase.line_free_energy(T_array)
     assert F_array.shape == (2,)
+
+
+@pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
+def test_ase_phase_equality_harmonic():
+    # ASE's HarmonicThermo defaults to identity equality, so identically
+    # constructed instances are not ==.  AsePhase must look past that.
+    ht1 = HarmonicThermo(vib_energies=[0.1])
+    ht2 = HarmonicThermo(vib_energies=[0.1])
+    assert ht1 is not ht2
+    assert ht1 != ht2
+
+    p1 = AsePhase("ht", 0.3, thermochem=ht1)
+    p2 = AsePhase("ht", 0.3, thermochem=ht2)
+    assert p1 == p2
+    assert hash(p1) == hash(p2)
+
+
+@pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
+def test_ase_phase_equality_idealgas():
+    ig1 = IdealGasThermo(vib_energies=[0.1], geometry='linear', atoms=molecule('H2'), symmetrynumber=2, spin=0)
+    ig2 = IdealGasThermo(vib_energies=[0.1], geometry='linear', atoms=molecule('H2'), symmetrynumber=2, spin=0)
+
+    p1 = AsePhase("ig", 0.5, thermochem=ig1, pressure=1e5)
+    p2 = AsePhase("ig", 0.5, thermochem=ig2, pressure=1e5)
+    assert p1 == p2
+    assert hash(p1) == hash(p2)
+
+
+@pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
+def test_ase_phase_inequality():
+    ht = HarmonicThermo(vib_energies=[0.1])
+    base = AsePhase("ht", 0.3, thermochem=ht)
+    assert base != AsePhase("other", 0.3, thermochem=ht)
+    assert base != AsePhase("ht", 0.4, thermochem=ht)
+    assert base != AsePhase("ht", 0.3, thermochem=ht, pressure=1e5)
+    assert base != AsePhase("ht", 0.3, thermochem=HarmonicThermo(vib_energies=[0.2]))
+
+
+@pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
+def test_ase_phase_set_dedup():
+    p1 = AsePhase("ht", 0.3, thermochem=HarmonicThermo(vib_energies=[0.1]))
+    p2 = AsePhase("ht", 0.3, thermochem=HarmonicThermo(vib_energies=[0.1]))
+    assert {p1, p2} == {p1}


### PR DESCRIPTION
## Summary

Addresses point #2 of the Claude review on PR #68: `frozen=True` auto-generates `__hash__` from all fields including `thermochem`, but ASE's `ThermoChem` subclasses (`HarmonicThermo`, `IdealGasThermo`, ...) inherit identity-based equality from `object`. Two `AsePhase` objects built from equivalent inputs therefore compared unequal and lived in separate hash buckets.

## Implementation

`landau/phases/asewrapper.py`:

- `AsePhase.__eq__` and `__hash__` delegate to a `_key()` tuple that includes `pickle.dumps(self.thermochem)`. Pickling produces deterministic bytes that compare equal for equivalently constructed instances and naturally handles `numpy` arrays, `Atoms`, and nested `HarmonicMode` objects — without needing a bespoke recursive comparator.
- Returns `NotImplemented` for cross-type comparisons.

The `__eq__` ↔ `__hash__` contract holds: equal objects share a hash. The trade-off is that any non-pickleable attribute someone slips into a `ThermoChem` subclass would raise instead of silently degrading; this is the right failure mode.

## Tests

`tests/unit/phases/test_ase.py` adds:

- `test_ase_phase_equality_harmonic` — asserts ASE's own `HarmonicThermo` instances aren't `==`, then asserts `AsePhase` wraps them into equal objects with equal hashes.
- `test_ase_phase_equality_idealgas` — same, but for `IdealGasThermo` (exercises `Atoms` inside the pickle).
- `test_ase_phase_inequality` — flips each meaningful field one at a time and confirms inequality.
- `test_ase_phase_set_dedup` — equivalent phases collapse in a `set`.

## Notes

- The earlier `_value_equal` recursive helper (initial implementation) was replaced by `pickle.dumps` after review feedback, giving a net simpler result.
- Other review points (`np.vectorize` rebuild, `*args, **kwargs` in `__post_init__`, version pinning, etc.) are left for follow-ups.

https://claude.ai/code/session_019M5f6NrvE6HfUGsHLjh2xR

---
_Generated by [Claude Code](https://claude.ai/code/session_019M5f6NrvE6HfUGsHLjh2xR)_