### PR TITLE
Remove unreachable early return in get_phase_colors

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -222,8 +222,6 @@ def get_phase_colors(phase_names, override: dict[str, str] | None = None):
         override = {}
     # the default map
     color_map = dict(zip(phase_names, sns.palettes.SEABORN_PALETTES["pastel"]))
-    if override is None:
-        return color_map
     # disregard overriden phases that are not present
     override = {p: c for p, c in override.items() if p in color_map}
     # if the override uses the same colors as the default map, multiple phases


### PR DESCRIPTION
## Summary

- Lines 221-222 of `landau/plot.py` already set `override = {}` when `None` is passed, so the subsequent `if override is None: return color_map` check at the former lines 225-226 could never be True.
- Removed those two dead lines; an empty dict falls through correctly to the rest of the function.

## Test plan

- [ ] Existing `get_phase_colors` unit tests in `tests/unit/plot/test_colors.py` still pass
- [ ] No behaviour change: `override=None` now reaches the same code path as `override={}`

https://claude.ai/code/session_01GUL9rh9e4fRsvRTLssZtWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUL9rh9e4fRsvRTLssZtWH)_