### PR TITLE
fix: add include_groups=False to all remaining groupby().apply() calls

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -438,7 +438,7 @@ def get_transitions(df):
     bdf = df.query("border")
     # go from a table of mu/c/T points that are on the phase boundaries to a table where the two points that are at the same mu/T are grouped together
     # use this information to add 'transition' column; handles also the case where border points are at mu=+-inf, there we have only one point
-    tdf = bdf.groupby(["mu", "T"])[["c", "phase"]].apply(reduce)
+    tdf = bdf.groupby(["mu", "T"])[["c", "phase"]].apply(reduce, include_groups=False)
     # immediately explode again to go back to our familiar representation, but now with the added 'transition' column
     tdf = tdf.reset_index().explode(["c", "phase"]).infer_objects().reset_index(drop=True)
 

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -124,7 +124,7 @@ def _plot_tielines(df, ax=None):
                 ax.hlines(Tmax, da.c.min(), da.c.max(), color="k", zorder=-2, alpha=0.5, lw=4)
 
         # FIXME: WARNING reuses local var define in if branch
-        tdf.groupby("border_segment").apply(plot_tie)
+        tdf.groupby("border_segment").apply(plot_tie, include_groups=False)
     else:
         # count the numbers of distinct phases per T, it changes there *must* be a triple
         # point, draw tie lines only there
@@ -142,7 +142,7 @@ def _plot_tielines(df, ax=None):
             cl, cr = sorted(dd.c)
             ax.plot([cl, cr], dd["T"], color="k", zorder=-2, alpha=0.5, lw=4)
 
-        df.groupby(["T", "mu"]).apply(plot_tie)
+        df.groupby(["T", "mu"]).apply(plot_tie, include_groups=False)
 
 
 def _plot_phase_diagram(

--- a/landau/poly.py
+++ b/landau/poly.py
@@ -53,7 +53,7 @@ class AbstractPolyMethod(abc.ABC):
 
     def apply(self, df: pd.DataFrame, variables: list[str] = ["c", "T"]) -> pd.Series:
         return self.prepare(df).groupby(['phase', 'phase_unit']).apply(
-                self.make, variables=variables
+                self.make, variables=variables, include_groups=False
 
         ).dropna()
 


### PR DESCRIPTION
Fixes pandas 3.0 deprecation warning in four locations that were missing `include_groups=False`:

- `plot.py:86` — `tdf.groupby("border_segment").apply(plot_tie)`
- `plot.py:104` — `df.groupby(["T", "mu"]).apply(plot_tie)`
- `poly.py:56` — `groupby(['phase', 'phase_unit']).apply(self.make, ...)`
- `calculate.py:441` — `bdf.groupby(["mu", "T"])[["c", "phase"]].apply(reduce)`

Closes #87.

Generated with [Claude Code](https://claude.ai/code)