### PR TITLE
test: add unit tests from PR #80 discussion + fix two source bugs

### DIFF
--- a/landau/interpolate/basic.py
+++ b/landau/interpolate/basic.py
@@ -21,7 +21,7 @@ kB = Boltzmann / eV
 
 
 def G_calphad(T, pl, *p):
-    with np.errstate(divide="ignore"):
+    with np.errstate(divide="ignore", invalid="ignore"):
         g = T * np.log(T) * pl + sum(pi * T**i for i, pi in enumerate(p))
     if isinstance(T, np.ndarray) and T.ndim > 0:
         g[np.isclose(T, 0)] = p[0]
@@ -164,7 +164,9 @@ class RedlichKisterInterpolation:
         pre = x * (1 - x)
         xi = 2 * x - 1
         x2 = xi**2
-        ds = np.stack([(2 * k * pre - x2) * xi ** (k - 1) for k in range(len(L))])
+        # k=0: algebraically simplifies (0 - xi^2)*xi^(-1) = -xi, avoids 0^(-1) at x=0.5
+        terms = [-xi] + [(2 * k * pre - x2) * xi ** (k - 1) for k in range(1, len(L))]
+        ds = np.stack(terms)
         if len(ds.shape) == 1:
             return (L * ds).sum()
         else:

--- a/tests/unit/interpolate/test_g_calphad.py
+++ b/tests/unit/interpolate/test_g_calphad.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from landau.interpolate import G_calphad
 from hypothesis import given, strategies as st
@@ -29,3 +30,11 @@ def test_G_calphad_at_zero(pl, p):
     # T=0 edge case should return p[0]
     assert np.isclose(G_calphad(0.0, pl, *p), p[0])
     assert np.allclose(G_calphad(np.array([0.0, 1.0]), pl, *p), [p[0], G_calphad(1.0, pl, *p)])
+
+
+def test_G_calphad_no_warnings_at_zero():
+    """T=0 in an array should not produce RuntimeWarnings even with non-zero pl."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        G_calphad(np.array([0.0, 1.0, 2.0]), 3.5, 1.0, -0.5)
+        G_calphad(0.0, -2.0, 1.0)

--- a/tests/unit/interpolate/test_redlich_kister.py
+++ b/tests/unit/interpolate/test_redlich_kister.py
@@ -26,3 +26,35 @@ def test_RedlichKister_hypothesis(L, f0, df):
     assert np.isclose(fit.f0, f0, atol=1e-5)
     assert np.isclose(fit.df, df, atol=1e-5)
     assert np.allclose(fit.rk_parameters, L, atol=1e-5)
+
+
+def test_eval_mix_derivative_scalar():
+    """_eval_mix_derivative at scalar x should match finite-difference gradient of _eval_mix."""
+    L = np.array([0.5, -0.3])
+    x = 0.4
+    eps = 1e-6
+    fd = (RedlichKisterInterpolation._eval_mix(x + eps, *L) - RedlichKisterInterpolation._eval_mix(x - eps, *L)) / (2 * eps)
+    deriv = RedlichKisterInterpolation._eval_mix_derivative(x, *L)
+    assert np.isclose(deriv, fd, rtol=1e-4)
+
+
+def test_eval_mix_derivative_array():
+    """_eval_mix_derivative on an array should match element-wise finite differences."""
+    L = np.array([0.8, -0.2, 0.1])
+    c = np.linspace(0.1, 0.9, 15)
+    eps = 1e-6
+    fd = (RedlichKisterInterpolation._eval_mix(c + eps, *L) - RedlichKisterInterpolation._eval_mix(c - eps, *L)) / (2 * eps)
+    deriv = RedlichKisterInterpolation._eval_mix_derivative(c, *L)
+    assert np.allclose(deriv, fd, rtol=1e-4)
+
+
+@given(
+    L=arrays(dtype=float, shape=st.integers(min_value=1, max_value=3), elements=st.floats(min_value=-1, max_value=1)),
+    x=st.floats(min_value=0.05, max_value=0.95)
+)
+def test_eval_mix_derivative_hypothesis(L, x):
+    """_eval_mix_derivative should agree with finite differences for any L and interior x."""
+    eps = 1e-6
+    fd = (RedlichKisterInterpolation._eval_mix(x + eps, *L) - RedlichKisterInterpolation._eval_mix(x - eps, *L)) / (2 * eps)
+    deriv = RedlichKisterInterpolation._eval_mix_derivative(x, *L)
+    assert np.isclose(deriv, fd, rtol=1e-3, atol=1e-6)

--- a/tests/unit/interpolate/test_softplus_fit.py
+++ b/tests/unit/interpolate/test_softplus_fit.py
@@ -14,3 +14,30 @@ def test_SoftplusFit_hypothesis(n_softplus, slope, offset):
     sf = SoftplusFit(n_softplus=n_softplus, max_nfev=50)
     fit = sf.fit(x, y)
     assert np.allclose(fit(x), y, atol=0.2)
+
+
+def test_SoftplusFit_step_function():
+    """SoftplusFit should fit a soft step (Heaviside-like) better than a constant predictor."""
+    x = np.linspace(0, 1, 60)
+    y = 1.0 / (1.0 + np.exp(-20 * (x - 0.5)))  # sigmoid step at 0.5
+    sf = SoftplusFit(n_softplus=2, max_nfev=500)
+    fit = sf.fit(x, y)
+    pred = fit(x)
+
+    # Must do better than predicting the mean
+    mse_fit = np.mean((pred - y) ** 2)
+    mse_mean = np.mean((np.full_like(y, y.mean()) - y) ** 2)
+    assert mse_fit < mse_mean
+
+    # Should capture the low and high plateaus
+    assert pred[0] < 0.3
+    assert pred[-1] > 0.7
+
+
+def test_SoftplusFit_monotone_data():
+    """SoftplusFit should recover a simple monotone ramp reasonably well."""
+    x = np.linspace(0, 1, 40)
+    y = x  # linear ramp
+    sf = SoftplusFit(n_softplus=1, max_nfev=200)
+    fit = sf.fit(x, y)
+    np.testing.assert_allclose(fit(x), y, atol=0.1)

--- a/tests/unit/interpolate/test_stitched_fit.py
+++ b/tests/unit/interpolate/test_stitched_fit.py
@@ -1,5 +1,5 @@
 import numpy as np
-from landau.interpolate import StitchedFit, PolyFit
+from landau.interpolate import StitchedFit, PolyFit, SGTE, G_calphad
 from hypothesis import given, strategies as st
 
 @given(
@@ -50,3 +50,34 @@ def test_stitched_fit_properties(t_min, t_max, a, b, c, edge):
     grad_mid_upp = (fit(t_max - dt) - fit(t_max - 2*dt)) / dt
     grad_upp = (fit(t_max + 2*dt) - fit(t_max + dt)) / dt
     assert np.isclose(grad_mid_upp, grad_upp, atol=1e-1)
+
+
+def test_stitched_fit_sgte_mid_accuracy():
+    """SGTE(2) fits T*log(T) exactly; StitchedFit mid-region should recover the data to high precision."""
+    T = np.linspace(300, 1000, 50)
+    y = G_calphad(T, 1.0, 0.0)  # = T*log(T)
+    sf = StitchedFit(interpolating=SGTE(2), low=None, upp=None)
+    fit = sf.fit(T, y)
+    np.testing.assert_allclose(fit(T), y, rtol=1e-3)
+
+
+def test_stitched_fit_scalar_input():
+    """StitchedFit should handle scalar input without error."""
+    T = np.linspace(300, 1000, 50)
+    y = T * np.log(T)
+    sf = StitchedFit(interpolating=PolyFit(nparam=3), low=None, upp=PolyFit(2))
+    fit = sf.fit(T, y)
+    result = fit(500.0)
+    assert np.isfinite(result)
+
+
+def test_stitched_fit_low_branch():
+    """When low= is set, temperatures below tmin should use the low interpolator."""
+    T = np.linspace(300, 1000, 50)
+    y = 0.001 * T**2 - T + 10.0
+    sf = StitchedFit(interpolating=PolyFit(nparam=3), low=PolyFit(nparam=2), upp=None, edge=10)
+    fit = sf.fit(T, y)
+    # Values inside the range should match closely
+    np.testing.assert_allclose(fit(T), y, atol=0.1)
+    # Value just below tmin should be finite (served by low branch)
+    assert np.isfinite(fit(299.0))


### PR DESCRIPTION
## Summary

Based on the review discussion in #80, this PR adds new unit tests and fixes two bugs uncovered by those tests:

**Bug fixes in `landau/interpolate/basic.py`:**
- `G_calphad`: add `invalid="ignore"` to `np.errstate` — `0 * log(0)` triggers a `RuntimeWarning: invalid value` even with `divide="ignore"` already set
- `RedlichKisterInterpolation._eval_mix_derivative`: fix `ZeroDivisionError` at `x=0.5` (where `xi=0`) in the `k=0` term; the formula `(-xi²)·xi⁻¹` simplifies algebraically to `-xi`, which avoids the singularity

**New tests:**
- `test_g_calphad.py`: smoke test that no `RuntimeWarning` is raised when `T=0` appears in an array with nonzero `pl`
- `test_redlich_kister.py`: scalar, array, and Hypothesis tests for `_eval_mix_derivative` validating against finite differences (these tests also caught the `k=0` bug above)
- `test_stitched_fit.py`: deterministic SGTE mid-region accuracy test, scalar-input test, and explicit `low=` branch coverage (gap identified in #80)
- `test_softplus_fit.py`: step-function test (verifies fit beats constant predictor and captures plateaus) and monotone-ramp test (tighter than the previous `atol=0.2` check)

## Test plan

- [x] All 48 tests in `tests/unit/interpolate/` and `tests/unit/test_whitney.py` pass locally

https://claude.ai/code/session_01DXoH6ZJksQfpMiUvrwjJkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXoH6ZJksQfpMiUvrwjJkr)_