### PR TITLE
fix: reduce RegularSolution concentration stencil step from 1e-3 to 1e-4

### DIFF
--- a/landau/phases.py
+++ b/landau/phases.py
@@ -392,7 +392,7 @@ class RegularSolution(Phase):
 
     def concentration(self, T, dmu):
         if not isinstance(dmu, np.ndarray) or dmu.size == 1:
-            dmus = np.linspace(-1, 1, 5) * 1e-3 + dmu
+            dmus = np.linspace(-1, 1, 5) * 1e-4 + dmu
             res = self.concentration(T, dmus)[2]
             return np.array([res]) if isinstance(dmu, np.ndarray) else res
         return np.clip(-np.gradient(self.semigrand_potential(T, dmu), dmu, edge_order=2), 0, 1)


### PR DESCRIPTION
Reduces the 5-point finite-difference stencil in `RegularSolution.concentration()` from ±1 meV to ±0.1 meV.

The old step caused branch-smearing within ~1 meV of μ*, returning spurious ~0.5 values instead of the correct branch concentrations.

Addresses issue #92.

Generated with [Claude Code](https://claude.ai/code)