### PR TITLE
fix: avoid division by zero in Segments sort key

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -168,6 +168,7 @@ class Segments(AbstractPolyMethod):
 
         com = df[[x_col, y_col]].mean()
         norm = np.ptp(df[[x_col, y_col]], axis=0).values
+        norm = np.where(norm == 0, 1, norm)
 
         # Step 1: PCA Projection
         def pca_projection(group):


### PR DESCRIPTION
When all points share the same x or y coordinate, `np.ptp` returns 0, causing a `RuntimeWarning` in the `arctan2` sort key. Replace zero norm components with 1 — numerator is also 0 in that case so result is unchanged.

Closes #54

Generated with [Claude Code](https://claude.ai/code)