### PR TITLE
Warn when PolyMethod._make produces an invalid polygon

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -64,6 +64,10 @@ class AbstractPolyMethod(abc.ABC):
             shape = self._make(pp_scaled, border, segment_label)
             if shape is None:
                 return None
+            if isinstance(shape, shapely.Polygon) and not shape.is_valid:
+                warn(f"{type(self).__name__}._make produced an invalid polygon "
+                     f"({shapely.is_valid_reason(shape)}); plotting will buffer it but "
+                     f"the result may be inaccurate.")
 
         if shape.is_empty:
             return None


### PR DESCRIPTION
## Summary
- `AbstractPolyMethod.make` now checks `shape.is_valid` on the geometry returned by `_make` and emits a warning naming both the implementing class and the shapely "is-valid reason" (e.g. self-intersection coordinates) when it isn't valid.
- The downstream `buffer(min_c_width / 2)` step still heals minor invalidity so plotting keeps working — this just stops the invalidity from being silently hidden.

## Why
Spun out from #94: while benchmarking the new segment-clustered TSP poly methods I noticed `is_valid` was reliably `False` on their raw output (tiny self-intersections at segment joins). The buffer cleanup was masking it. Surfacing the warning makes such issues visible across all `PolyMethod` implementations, current and future.

## Test plan
- [x] Manual repro: a `_make` that returns a bowtie polygon now triggers `"...produced an invalid polygon (Self-intersection[0.5 0.5])..."`
- [x] Valid polygons (covered by existing `tests/unit/test_poly.py` Hypothesis cases) produce no warning

https://claude.ai/code/session_01Q1KBSDHbzNW2FzPXeHd5A1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1KBSDHbzNW2FzPXeHd5A1)_