### PR TITLE
fix: replace print() with deprecate() for TemperatureDepandantLinePhase typo alias

### DIFF
--- a/landau/phases.py
+++ b/landau/phases.py
@@ -210,8 +210,8 @@ class TemperatureDependentLinePhase(AbstractLinePhase):
         plt.scatter(self.temperatures[::n], self.free_energies[::n], c=l.get_color())
 
 
+@deprecate("use TemperatureDependentLinePhase instead", version="2.0")
 def TemperatureDepandantLinePhase(*args, **kwargs):
-    print("TYPO ALERT!")
     return TemperatureDependentLinePhase(*args, **kwargs)
 
 


### PR DESCRIPTION
Replace the unfriendly `print("TYPO ALERT!")` side-effect in the `TemperatureDepandantLinePhase` typo alias with a proper `@deprecate` decorator from `pyiron_snippets`. The alias is now marked as not guaranteed to be in service after version 2.0.

Closes #104

Generated with [Claude Code](https://claude.ai/code)