### PR TITLE
refactor: remove scalar-vs-array branching in three places

### DIFF
--- a/landau/interpolate/basic.py
+++ b/landau/interpolate/basic.py
@@ -21,12 +21,12 @@ kB = Boltzmann / eV
 
 
 def G_calphad(T, pl, *p):
+    T_arr = np.asarray(T)
     with np.errstate(divide="ignore", invalid="ignore"):
-        g = T * np.log(T) * pl + sum(pi * T**i for i, pi in enumerate(p))
-    if isinstance(T, np.ndarray) and T.ndim > 0:
-        g[np.isclose(T, 0)] = p[0]
-    elif np.isclose(T, 0.0):
-        g = p[0]
+        g = T_arr * np.log(T_arr) * pl + sum(pi * T_arr**i for i, pi in enumerate(p))
+    g = np.where(np.isclose(T_arr, 0), p[0], g)
+    if T_arr.ndim == 0:
+        return g.item()
     return g
 
 

--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -101,11 +101,8 @@ class AbstractLinePhase(Phase):
         return self.line_free_energy(T)
 
     def concentration(self, T, dmu):
-        ones = np.ones(np.broadcast(T, dmu).shape)
-        if ones.shape != ():
-            return self.line_concentration * ones
-        else:
-            return self.line_concentration
+        result = np.full(np.broadcast(T, dmu).shape, self.line_concentration)
+        return result.item() if result.ndim == 0 else result
 
     def semigrand_potential(self, T, dmu):
         f = self.line_free_energy(T)
@@ -127,11 +124,7 @@ class LinePhase(AbstractLinePhase):
         return self.fixed_concentration
 
     def line_free_energy(self, T):
-        if isinstance(T, np.ndarray):
-            U = self.line_energy * np.ones_like(T)
-        else:
-            U = self.line_energy
-        return U - T * self.line_entropy
+        return self.line_energy - T * self.line_entropy
 
 
 @dataclass(frozen=True)

--- a/tests/unit/interpolate/test_g_calphad.py
+++ b/tests/unit/interpolate/test_g_calphad.py
@@ -38,3 +38,17 @@ def test_G_calphad_no_warnings_at_zero():
         warnings.simplefilter("error")
         G_calphad(np.array([0.0, 1.0, 2.0]), 3.5, 1.0, -0.5)
         G_calphad(0.0, -2.0, 1.0)
+
+
+def test_G_calphad_0d_array_parity():
+    """0-d numpy arrays should give the same result as Python scalars."""
+    pl, p = 2.0, [1.0, -0.5, 0.1]
+    T_scalar = 1.5
+    T_0d = np.array(1.5)
+    assert np.isclose(G_calphad(T_scalar, pl, *p), G_calphad(T_0d, pl, *p))
+
+
+def test_G_calphad_0d_array_at_zero():
+    """0-d numpy array at T=0 must clamp to p[0], not return NaN."""
+    result = G_calphad(np.array(0.0), 3.5, 2.0, -0.5)
+    assert np.isclose(result, 2.0)

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -20,6 +20,40 @@ def _make_tdlp(c=0.5, T=None, f=None):
     )
 
 
+def test_line_phase_free_energy_scalar():
+    phase = _make_line_phase(energy=2.0, entropy=0.5, c=0.3)
+    result = phase.line_free_energy(300.0)
+    assert np.isclose(result, 2.0 - 300.0 * 0.5)
+    assert not isinstance(result, np.ndarray)
+
+
+def test_line_phase_free_energy_array():
+    phase = _make_line_phase(energy=2.0, entropy=0.5, c=0.3)
+    T = np.array([100.0, 200.0, 300.0])
+    result = phase.line_free_energy(T)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (3,)
+    assert_allclose(result, 2.0 - T * 0.5)
+
+
+def test_line_phase_free_energy_zero_entropy():
+    phase = LinePhase("test", 0.5, 3.0)
+    T = np.array([0.0, 100.0, 500.0])
+    assert_allclose(phase.line_free_energy(T), 3.0)
+
+
+def test_line_phase_free_energy_scalar_array_parity():
+    phase = _make_line_phase(energy=2.0, entropy=0.5, c=0.3)
+    T_vals = [100.0, 300.0, 500.0]
+    scalar_results = [phase.line_free_energy(T) for T in T_vals]
+    assert_allclose(phase.line_free_energy(np.array(T_vals)), scalar_results)
+
+
+def test_line_phase_free_energy_0d_array():
+    phase = _make_line_phase(energy=2.0, entropy=0.5, c=0.3)
+    assert np.isclose(phase.line_free_energy(np.array(300.0)), phase.line_free_energy(300.0))
+
+
 def test_line_phase_semigrand_potential_at_zero_mu():
     T = np.array([300.0, 600.0, 900.0])
     phase = _make_line_phase()
@@ -34,29 +68,59 @@ def test_line_phase_semigrand_potential_scalar():
 
 
 def test_line_phase_concentration_scalar():
-    phase = _make_line_phase(c=0.25)
-    c = phase.concentration(500.0, 0.0)
-    assert c == 0.25
+    phase = _make_line_phase(c=0.3, energy=2.0, entropy=0.5)
+    result = phase.concentration(300.0, 0.5)
+    assert np.isclose(result, 0.3)
+    assert not isinstance(result, np.ndarray)
 
 
-def test_line_phase_concentration_array():
-    phase = _make_line_phase(c=0.25)
-    T = np.array([300.0, 600.0, 900.0])
-    dmu = np.array([0.0, 0.1, -0.1])
-    c = phase.concentration(T, dmu)
-    assert isinstance(c, np.ndarray)
-    assert c.dtype != object
-    assert_allclose(c, 0.25)
+def test_line_phase_concentration_array_T():
+    phase = _make_line_phase(c=0.3, energy=2.0, entropy=0.5)
+    T = np.array([100.0, 200.0, 300.0])
+    result = phase.concentration(T, 0.5)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype != object
+    assert result.shape == (3,)
+    assert_allclose(result, 0.3)
 
 
-def test_line_phase_concentration_broadcast():
+def test_line_phase_concentration_array_dmu():
     # scalar T, array dmu — result should be array, not object
     phase = _make_line_phase(c=0.25)
     dmu = np.linspace(-1, 1, 5)
-    c = phase.concentration(500.0, dmu)
-    assert isinstance(c, np.ndarray)
-    assert c.dtype != object
-    assert_allclose(c, 0.25)
+    result = phase.concentration(500.0, dmu)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype != object
+    assert result.shape == (5,)
+    assert_allclose(result, 0.25)
+
+
+def test_line_phase_concentration_both_array():
+    phase = _make_line_phase(c=0.3, energy=2.0, entropy=0.5)
+    T = np.array([100.0, 200.0, 300.0])
+    dmu = np.array([0.0, 0.1, -0.1])
+    result = phase.concentration(T, dmu)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype != object
+    assert result.shape == (3,)
+    assert_allclose(result, 0.3)
+
+
+def test_line_phase_concentration_scalar_array_parity():
+    phase = _make_line_phase(c=0.3, energy=2.0, entropy=0.5)
+    T_arr = np.array([300.0, 400.0])
+    dmu_arr = np.array([0.5, 0.5])
+    array_result = phase.concentration(T_arr, dmu_arr)
+    for i, (T, dmu) in enumerate(zip(T_arr, dmu_arr)):
+        assert np.isclose(array_result[i], phase.concentration(T, dmu))
+
+
+def test_line_phase_concentration_0d_array():
+    phase = _make_line_phase(c=0.3, energy=2.0, entropy=0.5)
+    assert np.isclose(
+        phase.concentration(np.array(300.0), np.array(0.5)),
+        phase.concentration(300.0, 0.5),
+    )
 
 
 def test_temperature_dependent_line_phase_interpolates_through_samples():
@@ -79,88 +143,3 @@ def test_temperature_dependent_line_phase_hash_equal_instances():
     phase1 = _make_tdlp(T=T, f=f)
     phase2 = _make_tdlp(T=T, f=f)
     assert hash(phase1) == hash(phase2)
-
-def _make_phase(line_energy=2.0, line_entropy=0.5, fixed_concentration=0.3):
-    return LinePhase("test", fixed_concentration, line_energy, line_entropy)
-
-
-class TestLinePhaseFreeEnergy:
-    def test_scalar(self):
-        phase = _make_phase()
-        result = phase.line_free_energy(300.0)
-        assert np.isclose(result, 2.0 - 300.0 * 0.5)
-        assert not isinstance(result, np.ndarray)
-
-    def test_array(self):
-        phase = _make_phase()
-        T = np.array([100.0, 200.0, 300.0])
-        result = phase.line_free_energy(T)
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (3,)
-        assert_allclose(result, 2.0 - T * 0.5)
-
-    def test_zero_entropy(self):
-        phase = LinePhase("test", 0.5, 3.0)
-        T = np.array([0.0, 100.0, 500.0])
-        result = phase.line_free_energy(T)
-        assert_allclose(result, 3.0)
-
-    def test_scalar_array_parity(self):
-        phase = _make_phase()
-        T_vals = [100.0, 300.0, 500.0]
-        scalar_results = [phase.line_free_energy(T) for T in T_vals]
-        array_result = phase.line_free_energy(np.array(T_vals))
-        assert_allclose(array_result, scalar_results)
-
-    def test_0d_array(self):
-        phase = _make_phase()
-        result_scalar = phase.line_free_energy(300.0)
-        result_0d = phase.line_free_energy(np.array(300.0))
-        assert np.isclose(result_0d, result_scalar)
-
-
-class TestAbstractLinePhaseConcentration:
-    def test_scalar_returns_scalar(self):
-        phase = _make_phase()
-        result = phase.concentration(300.0, 0.5)
-        assert np.isclose(result, 0.3)
-        assert not isinstance(result, np.ndarray)
-
-    def test_array_T(self):
-        phase = _make_phase()
-        T = np.array([100.0, 200.0, 300.0])
-        result = phase.concentration(T, 0.5)
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (3,)
-        assert_allclose(result, 0.3)
-
-    def test_array_dmu(self):
-        phase = _make_phase()
-        dmu = np.array([0.1, 0.2, 0.3])
-        result = phase.concentration(300.0, dmu)
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (3,)
-        assert_allclose(result, 0.3)
-
-    def test_both_array(self):
-        phase = _make_phase()
-        T = np.array([100.0, 200.0])
-        dmu = np.array([0.1, 0.2])
-        result = phase.concentration(T, dmu)
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (2,)
-        assert_allclose(result, 0.3)
-
-    def test_scalar_array_parity(self):
-        phase = _make_phase()
-        T_arr = np.array([300.0, 400.0])
-        dmu_arr = np.array([0.5, 0.5])
-        array_result = phase.concentration(T_arr, dmu_arr)
-        for i, (T, dmu) in enumerate(zip(T_arr, dmu_arr)):
-            assert np.isclose(array_result[i], phase.concentration(T, dmu))
-
-    def test_0d_array_inputs(self):
-        phase = _make_phase()
-        result_scalar = phase.concentration(300.0, 0.5)
-        result_0d = phase.concentration(np.array(300.0), np.array(0.5))
-        assert np.isclose(result_0d, result_scalar)

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -79,3 +79,88 @@ def test_temperature_dependent_line_phase_hash_equal_instances():
     phase1 = _make_tdlp(T=T, f=f)
     phase2 = _make_tdlp(T=T, f=f)
     assert hash(phase1) == hash(phase2)
+
+def _make_phase(line_energy=2.0, line_entropy=0.5, fixed_concentration=0.3):
+    return LinePhase("test", fixed_concentration, line_energy, line_entropy)
+
+
+class TestLinePhaseFreeEnergy:
+    def test_scalar(self):
+        phase = _make_phase()
+        result = phase.line_free_energy(300.0)
+        assert np.isclose(result, 2.0 - 300.0 * 0.5)
+        assert not isinstance(result, np.ndarray)
+
+    def test_array(self):
+        phase = _make_phase()
+        T = np.array([100.0, 200.0, 300.0])
+        result = phase.line_free_energy(T)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3,)
+        assert_allclose(result, 2.0 - T * 0.5)
+
+    def test_zero_entropy(self):
+        phase = LinePhase("test", 0.5, 3.0)
+        T = np.array([0.0, 100.0, 500.0])
+        result = phase.line_free_energy(T)
+        assert_allclose(result, 3.0)
+
+    def test_scalar_array_parity(self):
+        phase = _make_phase()
+        T_vals = [100.0, 300.0, 500.0]
+        scalar_results = [phase.line_free_energy(T) for T in T_vals]
+        array_result = phase.line_free_energy(np.array(T_vals))
+        assert_allclose(array_result, scalar_results)
+
+    def test_0d_array(self):
+        phase = _make_phase()
+        result_scalar = phase.line_free_energy(300.0)
+        result_0d = phase.line_free_energy(np.array(300.0))
+        assert np.isclose(result_0d, result_scalar)
+
+
+class TestAbstractLinePhaseConcentration:
+    def test_scalar_returns_scalar(self):
+        phase = _make_phase()
+        result = phase.concentration(300.0, 0.5)
+        assert np.isclose(result, 0.3)
+        assert not isinstance(result, np.ndarray)
+
+    def test_array_T(self):
+        phase = _make_phase()
+        T = np.array([100.0, 200.0, 300.0])
+        result = phase.concentration(T, 0.5)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3,)
+        assert_allclose(result, 0.3)
+
+    def test_array_dmu(self):
+        phase = _make_phase()
+        dmu = np.array([0.1, 0.2, 0.3])
+        result = phase.concentration(300.0, dmu)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3,)
+        assert_allclose(result, 0.3)
+
+    def test_both_array(self):
+        phase = _make_phase()
+        T = np.array([100.0, 200.0])
+        dmu = np.array([0.1, 0.2])
+        result = phase.concentration(T, dmu)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert_allclose(result, 0.3)
+
+    def test_scalar_array_parity(self):
+        phase = _make_phase()
+        T_arr = np.array([300.0, 400.0])
+        dmu_arr = np.array([0.5, 0.5])
+        array_result = phase.concentration(T_arr, dmu_arr)
+        for i, (T, dmu) in enumerate(zip(T_arr, dmu_arr)):
+            assert np.isclose(array_result[i], phase.concentration(T, dmu))
+
+    def test_0d_array_inputs(self):
+        phase = _make_phase()
+        result_scalar = phase.concentration(300.0, 0.5)
+        result_0d = phase.concentration(np.array(300.0), np.array(0.5))
+        assert np.isclose(result_0d, result_scalar)


### PR DESCRIPTION
Removes the `isinstance`/`ndim` dispatch pattern in three spots, replacing with uniform numpy idioms (`np.where`, `np.full`, `.item()`, direct arithmetic broadcasting).

Closes #105

Generated with [Claude Code](https://claude.ai/code)