### PR TITLE
test: pull shared phase fixtures into tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from landau.phases import LinePhase, IdealSolution, RegularSolution
+
+
+@pytest.fixture
+def two_phase_ideal():
+    """Two terminal LinePhases bridged by an IdealSolution (A at c=0, B at c=1)."""
+    l1 = LinePhase("A", 0, 0, 0)
+    l2 = LinePhase("B", 1, 0.1, 0)
+    sol = IdealSolution("sol", l1, l2)
+    return [l1, l2, sol]
+
+
+@pytest.fixture
+def three_phase_regular_solution():
+    """Three LinePhases (A, B, C) with a RegularSolution fitting through all three."""
+    p1 = LinePhase("A", 0, 0)
+    p2 = LinePhase("B", 1, 0)
+    p3 = LinePhase("C", 0.5, 0)
+    return RegularSolution(name="sol", phases=[p1, p2, p3])

--- a/tests/regression/test_issue_1.py
+++ b/tests/regression/test_issue_1.py
@@ -1,41 +1,27 @@
 # https://github.com/eisenforschung/landau/issues/1
-from landau.phases import RegularSolution, LinePhase
 import numpy as np
 import pytest
 
-def test_regular_solution_concentration_array_len_1():
-    p1 = LinePhase("A", 0, 0)
-    p2 = LinePhase("B", 1, 0)
-    p3 = LinePhase("C", 0.5, 0)
-    # With 3 phases, num_coeffs = min(3-2, 4) = 1.
-    r = RegularSolution(name="sol", phases=[p1, p2, p3])
 
-    # Test with 1-element array
+def test_regular_solution_concentration_array_len_1(three_phase_regular_solution):
+    r = three_phase_regular_solution
     res = r.concentration(333, np.array([0]))
     assert isinstance(res, np.ndarray)
     assert res.shape == (1,)
     assert np.isclose(res[0], 0.5)
 
-def test_regular_solution_concentration_scalar():
-    p1 = LinePhase("A", 0, 0)
-    p2 = LinePhase("B", 1, 0)
-    p3 = LinePhase("C", 0.5, 0)
-    r = RegularSolution(name="sol", phases=[p1, p2, p3])
 
-    # Test with scalar
+def test_regular_solution_concentration_scalar(three_phase_regular_solution):
+    r = three_phase_regular_solution
     res = r.concentration(333, 0)
     assert isinstance(res, (float, np.float64, np.ndarray))
     if isinstance(res, np.ndarray):
         assert res.shape == () or res.size == 1
     assert np.isclose(res, 0.5)
 
-def test_regular_solution_concentration_large_array():
-    p1 = LinePhase("A", 0, 0)
-    p2 = LinePhase("B", 1, 0)
-    p3 = LinePhase("C", 0.5, 0)
-    r = RegularSolution(name="sol", phases=[p1, p2, p3])
 
-    # Test with multi-element array
+def test_regular_solution_concentration_large_array(three_phase_regular_solution):
+    r = three_phase_regular_solution
     dmus = np.linspace(-0.1, 0.1, 10)
     res = r.concentration(333, dmus)
     assert isinstance(res, np.ndarray)

--- a/tests/regression/test_pandas_groupby.py
+++ b/tests/regression/test_pandas_groupby.py
@@ -3,35 +3,26 @@
 import numpy as np
 import pytest
 
-from landau.phases import LinePhase, IdealSolution
 from landau.calculate import calc_phase_diagram
 
 
-@pytest.fixture
-def two_phase_system():
-    l1 = LinePhase("A", 0, 0, 0)
-    l2 = LinePhase("B", 1, 0.1, 0)
-    sol = IdealSolution("sol", l1, l2)
-    return [l1, l2, sol]
-
-
-def test_single_T_multiple_mu(two_phase_system):
+def test_single_T_multiple_mu(two_phase_ideal):
     """calc_phase_diagram with a single T and multiple mu values must not raise ValueError.
 
     Previously crashed with pandas 3.0 due to include_groups=True in groupby.apply.
     """
-    pdf = calc_phase_diagram(two_phase_system, Ts=1000.0, mu=np.linspace(-0.2, 0.2, 10))
+    pdf = calc_phase_diagram(two_phase_ideal, Ts=1000.0, mu=np.linspace(-0.2, 0.2, 10))
     assert len(pdf) > 0
     assert "phase" in pdf.columns
     assert "c" in pdf.columns
 
 
-def test_multiple_T_single_mu(two_phase_system):
+def test_multiple_T_single_mu(two_phase_ideal):
     """calc_phase_diagram with multiple T values and a single mu must not raise ValueError.
 
     Previously crashed with pandas 3.0 due to include_groups=True in groupby.apply.
     """
-    pdf = calc_phase_diagram(two_phase_system, Ts=np.linspace(100, 2000, 10), mu=0.05)
+    pdf = calc_phase_diagram(two_phase_ideal, Ts=np.linspace(100, 2000, 10), mu=0.05)
     assert len(pdf) > 0
     assert "phase" in pdf.columns
     assert "c" in pdf.columns


### PR DESCRIPTION
Pull repeated inline phase-system setup from regression tests into shared pytest fixtures in `tests/conftest.py`, reducing duplication across the test suite.

Two fixtures added:
- `two_phase_ideal` — two terminal LinePhases + IdealSolution
- `three_phase_regular_solution` — three LinePhases + RegularSolution

Closes #102 (item 7)

Generated with [Claude Code](https://claude.ai/code)