### PR TITLE
refactor: split cluster into cluster_T_c and cluster_T_c_mu

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -18,7 +18,7 @@ from .refine import Refiner, default_refiners, _find_one_point as find_one_point
 kB = Boltzmann / eV
 
 
-__all__ = ["calc_phase_diagram", "get_transitions"]
+__all__ = ["calc_phase_diagram", "get_transitions", "cluster_T_c", "cluster_T_c_mu"]
 
 
 def _split_stable(df):
@@ -213,32 +213,59 @@ def reduce(dd):
     )
 
 
-def cluster(dd, eps=0.01, use_mu=True):
-    t = dd["T"]
-    # Guard against isothermal segments
-    if t.min() != t.max():
-        t = (t - t.min()) / (t.max() - t.min())
-    ids = pd.Series(np.zeros_like(dd.index), index=dd.index)
-    cluster = AgglomerativeClustering(
+def _rescale_T(t):
+    tmin, tmax = t.min(), t.max()
+    if tmin != tmax:
+        return (t - tmin) / (tmax - tmin)
+    return t
+
+
+def _agglomerative_clusterer():
+    return AgglomerativeClustering(
         n_clusters=None,
-        # FIXME: hand optimized value; smaller values tend to partition the
+        # FIXME: hand-optimized value; smaller values tend to partition the
         # same transition too often
         distance_threshold=0.5,
         linkage="single",
     )
-    if use_mu:
-        # on the left and right side of the phase diagram refining adds points with
-        # mu +- inf, which chokes the cluster methods, but we know they should be
-        # their own segments, so special case them below
-        F = np.isfinite(dd.mu)
-        if F.any() and sum(F) >= 2:
-            ids.loc[F] = cluster.fit_predict(np.transpose([t.loc[F], dd.c.loc[F], dd.mu.loc[F]]))
-        m = ids.max()
-        ids.loc[dd.mu == +np.inf] = m + 1
-        ids.loc[dd.mu == -np.inf] = m + 2
-    else:
-        ids.loc[:] = cluster.fit_predict(np.transpose([t, dd.c]))
+
+
+def cluster_T_c(dd, eps=0.01) -> pd.Series:
+    """Cluster points by (T, c) coordinates; used by cluster_phase."""
+    if dd.empty:
+        return pd.Series(dtype=np.intp)
+    t = _rescale_T(dd["T"])
+    ids = _agglomerative_clusterer().fit_predict(np.transpose([t, dd["c"]]))
+    return pd.Series(ids, index=dd.index)
+
+
+def cluster_T_c_mu(dd, eps=0.01) -> pd.Series:
+    """Cluster points by (T, c, mu); rows with mu=±inf get their own distinct labels.
+
+    Used by get_transitions. The mu=±inf rows are border edges from _border_edges
+    and must not be fed to AgglomerativeClustering.
+    """
+    if dd.empty:
+        return pd.Series(dtype=np.intp)
+    t = _rescale_T(dd["T"])
+    ids = pd.Series(np.zeros(len(dd), dtype=np.intp), index=dd.index)
+    F = np.isfinite(dd["mu"])
+    if F.any() and F.sum() >= 2:
+        ids.loc[F] = _agglomerative_clusterer().fit_predict(
+            np.transpose([t.loc[F], dd["c"].loc[F], dd["mu"].loc[F]])
+        )
+    m = ids.max()
+    ids.loc[dd["mu"] == +np.inf] = m + 1
+    ids.loc[dd["mu"] == -np.inf] = m + 2
     return ids
+
+
+def cluster(dd, eps=0.01, use_mu=True):
+    """Thin dispatch to cluster_T_c or cluster_T_c_mu; prefer calling those directly."""
+    if use_mu:
+        return cluster_T_c_mu(dd, eps=eps)
+    else:
+        return cluster_T_c(dd, eps=eps)
 
 
 def get_transitions(df):
@@ -258,7 +285,7 @@ def get_transitions(df):
     # cluster points that are assigned as one transition, because the same transition can appear multiple times in "disconnected" manner in a phase
     # diagram, e.g. a solid solution in contact with the melt interrupted by a higher melting intermetallic
     if not tdf.empty:
-        res = tdf.groupby("transition", group_keys=False).apply(cluster, include_groups=False)
+        res = tdf.groupby("transition", group_keys=False).apply(cluster_T_c_mu, include_groups=False)
         if isinstance(res, pd.DataFrame):
              # sometimes pandas returns a DataFrame instead of a Series when only one group exists
              res = res.stack().reset_index(level=0, drop=True)

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import numpy as np
 
-from .calculate import get_transitions, cluster
+from .calculate import get_transitions, cluster, cluster_T_c
 import landau.poly as poly
 
 
@@ -35,7 +35,7 @@ def cluster_phase(df):
     # the callable instead is the documented path that combines consistently across
     # pandas 2 and 3 (see "Flexible apply" in the pandas user guide).
     df["phase_unit"] = df.groupby("phase", group_keys=False).apply(
-        lambda g: cluster(g, use_mu=False).to_frame("phase_unit"),
+        lambda g: cluster_T_c(g).to_frame("phase_unit"),
         include_groups=False,
     )["phase_unit"]
     df["phase_id"] = df[["phase", "phase_unit"]].apply(

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from landau.calculate import find_one_point
+import pandas as pd
+from landau.calculate import find_one_point, cluster_T_c, cluster_T_c_mu
 from unittest.mock import MagicMock
 
 def test_find_one_point_success():
@@ -45,3 +46,64 @@ def test_find_one_point_no_root():
     # Search in interval (1, 10) where there is no root and signs are the same (all positive)
     with pytest.raises(ValueError, match=r"f\(a\) and f\(b\) must have different signs"):
         find_one_point(phase1, phase2, mock_potential, (1, 10))
+
+
+# --- cluster_T_c tests ---
+
+def test_cluster_T_c_single_blob():
+    # 10-point diagonal stripe: consecutive distance ~0.11 < distance_threshold=0.5
+    # so single linkage chains all points into one cluster
+    dd = pd.DataFrame({
+        "T": np.linspace(300, 400, 10),
+        "c": np.linspace(0.0, 0.2, 10),
+    })
+    labels = cluster_T_c(dd)
+    assert labels.nunique() == 1
+
+
+def test_cluster_T_c_two_blobs():
+    # Two diagonal stripes separated by a gap > 0.5 in c
+    T = np.concatenate([np.linspace(300, 400, 10), np.linspace(300, 400, 10)])
+    c = np.concatenate([np.linspace(0.0, 0.1, 10), np.linspace(0.7, 0.8, 10)])
+    labels = cluster_T_c(pd.DataFrame({"T": T, "c": c}))
+    assert labels.nunique() == 2
+
+
+def test_cluster_T_c_empty():
+    dd = pd.DataFrame({"T": [], "c": []})
+    labels = cluster_T_c(dd)
+    assert len(labels) == 0
+    assert labels.dtype.kind == "i"
+
+
+# --- cluster_T_c_mu tests ---
+
+def test_cluster_T_c_mu_inf_get_own_labels():
+    dd = pd.DataFrame({
+        "T": [300, 400, 300, 400],
+        "c": [0.0, 0.0, 1.0, 1.0],
+        "mu": [-np.inf, -np.inf, np.inf, np.inf],
+    })
+    labels = cluster_T_c_mu(dd)
+    pos_label = labels.loc[dd["mu"] == +np.inf].iloc[0]
+    neg_label = labels.loc[dd["mu"] == -np.inf].iloc[0]
+    assert labels.loc[dd["mu"] == +np.inf].nunique() == 1
+    assert labels.loc[dd["mu"] == -np.inf].nunique() == 1
+    assert pos_label != neg_label
+
+
+def test_cluster_T_c_mu_degenerate_T():
+    dd = pd.DataFrame({
+        "T": [300, 300, 300, 300],
+        "c": [0.1, 0.2, 0.8, 0.9],
+        "mu": [-0.1, 0.0, 0.0, 0.1],
+    })
+    labels = cluster_T_c_mu(dd)
+    assert len(labels) == 4
+
+
+def test_cluster_T_c_mu_empty():
+    dd = pd.DataFrame({"T": [], "c": [], "mu": []})
+    labels = cluster_T_c_mu(dd)
+    assert len(labels) == 0
+    assert labels.dtype.kind == "i"


### PR DESCRIPTION
Splits the overloaded `cluster(use_mu=...)` in `calculate.py` into two single-purpose functions:

- `cluster_T_c(dd, eps=0.01)` — clusters by (T, c); used by cluster_phase
- `cluster_T_c_mu(dd, eps=0.01)` — clusters by (T, c, mu) with mu=±inf special-cased; used by get_transitions

Shared private helpers `_rescale_T` and `_agglomerative_clusterer` avoid duplication. The original `cluster()` is kept as a thin dispatch wrapper. Both call sites updated to call the new functions directly.

Closes #119

Generated with [Claude Code](https://claude.ai/code)