### PR TITLE
refactor(plot): extract _set_axis_for from _plot_phase_diagram

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -154,6 +154,41 @@ def _plot_tielines(df, ax=None):
         df.groupby(["T", "mu"]).apply(plot_tie, include_groups=False)
 
 
+def _set_axis_for(axis_var: str, df_stable, element: str | None, ax) -> None:
+    """Configure the x-axis of a phase diagram based on the axis variable.
+
+    Args:
+        axis_var: The x-axis variable name, either ``"c"`` (concentration) or ``"mu"``
+            (chemical potential).
+        df_stable: Stable-phase rows of the diagram DataFrame (used only for ``"mu"``
+            to determine finite x-limits).
+        element: Optional element symbol used to build the axis label.
+        ax: The :class:`matplotlib.axes.Axes` to configure.
+
+    Raises:
+        ValueError: If ``axis_var`` is not ``"c"`` or ``"mu"``.
+    """
+    if axis_var == "c":
+        ax.set_xlim(0, 1)
+        if element is not None:
+            ax.set_xlabel(rf"$c_\mathrm{{{element}}}$")
+        else:
+            ax.set_xlabel("$c$")
+    elif axis_var == "mu":
+        mus = df_stable["mu"].unique()
+        mus = mus[np.isfinite(mus)]
+        if len(mus) > 0:
+            ax.set_xlim(mus.min(), mus.max())
+        if element is not None:
+            ax.set_xlabel(rf"$\Delta\mu_\mathrm{{{element}}}$ [eV]")
+        else:
+            ax.set_xlabel(r"$\Delta\mu$ [eV]")
+    else:
+        raise ValueError(
+            f"Unknown coordinate system: variables[0]={axis_var!r}. Expected 'c' or 'mu'."
+        )
+
+
 def _plot_phase_diagram(
     df,
     alpha=0.1,
@@ -179,25 +214,7 @@ def _plot_phase_diagram(
     if tielines and variables[0] == "c":
         _plot_tielines(df, ax=ax)
 
-    if variables[0] == "c":
-        ax.set_xlim(0, 1)
-        if element is not None:
-            ax.set_xlabel(rf"$c_\mathrm{{{element}}}$")
-        else:
-            ax.set_xlabel("$c$")
-    elif variables[0] == "mu":
-        mus = df_stable["mu"].unique()
-        mus = mus[np.isfinite(mus)]
-        if len(mus) > 0:
-            ax.set_xlim(mus.min(), mus.max())
-        if element is not None:
-            ax.set_xlabel(rf"$\Delta\mu_\mathrm{{{element}}}$ [eV]")
-        else:
-            ax.set_xlabel(r"$\Delta\mu$ [eV]")
-    else:
-        raise ValueError(
-            f"Unknown coordinate system: variables[0]={variables[0]!r}. Expected 'c' or 'mu'."
-        )
+    _set_axis_for(variables[0], df_stable, element, ax)
 
     ax.set_ylim(df_stable["T"].min(), df_stable["T"].max())
     ax.legend(ncols=2)

--- a/tests/unit/plot/test_axis.py
+++ b/tests/unit/plot/test_axis.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock
+
+from landau.plot import _set_axis_for
+
+
+def _ax():
+    return MagicMock()
+
+
+def _df(mus):
+    return pd.DataFrame({"mu": mus})
+
+
+class TestSetAxisForConcentration:
+    def test_sets_xlim_zero_one(self):
+        ax = _ax()
+        _set_axis_for("c", pd.DataFrame(), None, ax)
+        ax.set_xlim.assert_called_once_with(0, 1)
+
+    def test_default_xlabel(self):
+        ax = _ax()
+        _set_axis_for("c", pd.DataFrame(), None, ax)
+        ax.set_xlabel.assert_called_once_with("$c$")
+
+    def test_with_element(self):
+        ax = _ax()
+        _set_axis_for("c", pd.DataFrame(), "Fe", ax)
+        ax.set_xlabel.assert_called_once_with(r"$c_\mathrm{Fe}$")
+
+
+class TestSetAxisForMu:
+    def test_default_xlabel(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([0.1, 0.2, 0.3]), None, ax)
+        ax.set_xlabel.assert_called_once_with(r"$\Delta\mu$ [eV]")
+
+    def test_with_element(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([0.1, 0.2]), "Al", ax)
+        ax.set_xlabel.assert_called_once_with(r"$\Delta\mu_\mathrm{Al}$ [eV]")
+
+    def test_finite_mus_sets_xlim(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([0.1, 0.5, 0.3]), None, ax)
+        ax.set_xlim.assert_called_once_with(0.1, 0.5)
+
+    def test_all_nonfinite_no_xlim(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([np.inf, -np.inf, np.nan]), None, ax)
+        ax.set_xlim.assert_not_called()
+
+    def test_mixed_finite_nonfinite_xlim(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([0.2, np.inf, 0.8, np.nan]), None, ax)
+        ax.set_xlim.assert_called_once_with(0.2, 0.8)
+
+    def test_element_with_nonfinite_mus(self):
+        ax = _ax()
+        _set_axis_for("mu", _df([np.inf, np.nan]), "Cu", ax)
+        ax.set_xlim.assert_not_called()
+        ax.set_xlabel.assert_called_once_with(r"$\Delta\mu_\mathrm{Cu}$ [eV]")
+
+
+def test_unknown_axis_raises():
+    ax = _ax()
+    with pytest.raises(ValueError, match="Unknown coordinate system"):
+        _set_axis_for("x", pd.DataFrame(), None, ax)


### PR DESCRIPTION
Pull the x-axis configuration block out of `_plot_phase_diagram` into a standalone `_set_axis_for(axis_var, df_stable, element, ax)` helper.

This separates concerns (polygon building vs. axis labelling) and gives the axis logic a testable surface without needing a full figure or calc pipeline.

**Changes:**
- `landau/plot.py`: new `_set_axis_for` function, `_plot_phase_diagram` delegates to it
- `tests/unit/plot/test_axis.py`: 10 unit tests covering all branches from #117

Closes #117.

Generated with [Claude Code](https://claude.ai/code)