### PR TITLE
feat: QuasiChemicalPhase (pair QCA, SRO beyond Bragg-Williams)

### DIFF
--- a/landau/__init__.py
+++ b/landau/__init__.py
@@ -3,6 +3,7 @@ from .phases import (
     TemperatureDepandantLinePhase,
     TemperatureDependentLinePhase,
     IdealSolution,
+    QuasiChemicalPhase,
     RegularSolution,
     InterpolatingPhase,
     SlowInterpolatingPhase,

--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "LinePhase",
     "TemperatureDependentLinePhase",
     "IdealSolution",
+    "QuasiChemicalPhase",
     "RegularSolution",
     "InterpolatingPhase",
     "SlowInterpolatingPhase",
@@ -247,6 +248,131 @@ class IdealSolution(Phase):
         df = f2 - f1
         with np.errstate(divide='ignore', over='ignore'):
             return 1 / (1 + np.exp(+(df - dmu) / kB / T))
+
+
+@dataclass(frozen=True, eq=True)
+class QuasiChemicalPhase(Phase):
+    """
+    Binary alloy phase using the quasi-chemical (pair) approximation.
+
+    Accounts for nearest-neighbour short-range order (SRO) beyond the Bragg-Williams
+    mean field.  The equilibrium AB pair fraction is obtained analytically from the
+    quasi-chemical condition (Guggenheim 1952), which yields a quadratic equation.
+
+    Parameters map directly to the pair-interaction Hamiltonian:
+
+        V = V_AA + V_BB - 2*V_AB   (eV / bond)
+        z  ... coordination number  (12 = FCC, 8 = BCC)
+
+    V > 0  →  ordering tendency (AB bonds preferred)
+    V < 0  →  phase-separation tendency (like bonds preferred)
+
+    Reference: Rao & Curtin, Acta Materialia 228 (2022) 117621.
+    """
+
+    phase_A: AbstractLinePhase
+    """Terminal phase at c = 0."""
+    phase_B: AbstractLinePhase
+    """Terminal phase at c = 1."""
+    V: float
+    """Pair-interaction ordering energy V = V_AA + V_BB − 2·V_AB (eV/bond)."""
+    z: int = 12
+    """Coordination number: 12 for FCC, 8 for BCC."""
+    num_samples: int = 100
+    """Grid resolution used in the semigrand-potential minimisation."""
+
+    def __post_init__(self):
+        phase_A, phase_B = sorted(
+            (self.phase_A, self.phase_B), key=lambda p: p.line_concentration
+        )
+        if phase_A.line_concentration != 0 or phase_B.line_concentration != 1:
+            raise ValueError("phase_A must have c=0 and phase_B must have c=1")
+        object.__setattr__(self, "phase_A", phase_A)
+        object.__setattr__(self, "phase_B", phase_B)
+
+    def _y_AB(self, c, T):
+        """Equilibrium AB pair fraction at composition c and temperature T."""
+        c = np.asarray(c, dtype=float)
+        T = np.asarray(T, dtype=float)
+        beta = np.exp(np.clip(self.V / (kB * T), -500, 500))
+        a = 1.0 - beta / 4.0
+        b = beta / 2.0
+        d = -beta * c * (1.0 - c)
+        disc = np.maximum(b * b - 4.0 * a * d, 0.0)
+        sqrt_disc = np.sqrt(disc)
+        # For |a| → 0 (β → 4), fall back to the linear solution
+        small_a = np.abs(a) < 1e-10
+        y_linear = np.where(np.abs(b) > 0, -d / b, 2.0 * c * (1.0 - c))
+        # For a > 0 (β < 4) take the +√ root; for a < 0 (β > 4) the −√ root
+        # both cases simplify to (-b + sign(a)*sqrt_disc) / (2*a) when a ≠ 0
+        y_quad = (-b + np.where(a >= 0, sqrt_disc, -sqrt_disc)) / (2.0 * a)
+        y = np.where(small_a, y_linear, y_quad)
+        y_max = 2.0 * np.minimum(c, 1.0 - c)
+        return np.clip(y, 0.0, y_max)
+
+    def free_energy(self, T, c):
+        """Free energy per atom in the quasi-chemical pair approximation."""
+        c = np.asarray(c, dtype=float)
+        T = np.asarray(T, dtype=float)
+
+        F_A = self.phase_A.line_free_energy(T)
+        F_B = self.phase_B.line_free_energy(T)
+
+        y_AB = self._y_AB(c, T)
+        y_AA = np.maximum((1.0 - c) - y_AB / 2.0, 0.0)
+        y_BB = np.maximum(c - y_AB / 2.0, 0.0)
+        y_AB_s = y_AB
+        c_s = c
+
+        # se.entr(x) = -x*log(x), so x*log(x) = -se.entr(x); se.entr(0) = 0 (no NaN at boundaries)
+        pair_log_sum = -(se.entr(y_AA) + se.entr(y_AB_s) + se.entr(y_BB))
+        site_log_sum = -(se.entr(c_s) + se.entr(1.0 - c_s))
+
+        return (
+            (1.0 - c) * F_A
+            + c * F_B
+            - (self.z / 4.0) * self.V * y_AB
+            + T * (self.z / 2.0) * kB * pair_log_sum
+            + T * (self.z / 2.0 - 1.0) * kB * site_log_sum
+        )
+
+    def _find_phi_c(self, T, dmu):
+        output_shape = np.broadcast_shapes(np.shape(T), np.shape(dmu))
+        T_arr = np.atleast_1d(np.asarray(T, dtype=float))[..., np.newaxis]
+        dmu_arr = np.atleast_1d(np.asarray(dmu, dtype=float))[..., np.newaxis]
+
+        conc = np.linspace(0.0, 1.0, self.num_samples)
+        ff = self.free_energy(T_arr, conc)
+        phi = ff - conc * dmu_arr
+
+        I = phi.argmin(axis=-1, keepdims=True)
+        phi_min = np.take_along_axis(phi, I, axis=-1)[..., 0]
+        c_min = conc[I[..., 0]]
+
+        df = np.take_along_axis(np.gradient(ff, conc, axis=-1, edge_order=2), I, axis=-1)
+        d2f = np.take_along_axis(
+            np.gradient(np.gradient(ff, conc, axis=-1, edge_order=2), conc, axis=-1, edge_order=2),
+            I, axis=-1,
+        )
+        dc = (dmu_arr - df) / d2f
+        c_new = np.clip(c_min + dc[..., 0], 0.0, 1.0)
+        phi_min -= (c_new - c_min) * (dmu_arr[..., 0] - df[..., 0])
+        c_min = c_new
+
+        c_min = c_min.reshape(output_shape)
+        phi_min = phi_min.reshape(output_shape)
+
+        if c_min.ndim == 0:
+            c_min = c_min.item()
+        if phi_min.ndim == 0:
+            phi_min = phi_min.item()
+        return phi_min, c_min
+
+    def semigrand_potential(self, T, dmu):
+        return self._find_phi_c(T, dmu)[0]
+
+    def concentration(self, T, dmu):
+        return self._find_phi_c(T, dmu)[1]
 
 
 @dataclass(frozen=True, eq=True)

--- a/tests/unit/test_quasi_chemical_phase.py
+++ b/tests/unit/test_quasi_chemical_phase.py
@@ -1,0 +1,184 @@
+"""
+Tests for QuasiChemicalPhase (quasi-chemical / pair approximation).
+"""
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.constants import Boltzmann, eV
+
+from landau import QuasiChemicalPhase, LinePhase
+
+kB = Boltzmann / eV
+
+
+def _make_symmetric(V=0.0, z=12):
+    """Symmetric binary with equal terminal energies, convenient for testing."""
+    phase_A = LinePhase("A", fixed_concentration=0, line_energy=-1.0)
+    phase_B = LinePhase("B", fixed_concentration=1, line_energy=-1.0)
+    return QuasiChemicalPhase("test", phase_A=phase_A, phase_B=phase_B, V=V, z=z)
+
+
+# --- construction -----------------------------------------------------------
+
+
+def test_terminal_order_normalised():
+    """Phase accepts terminals in any order and stores them canonically."""
+    phase_A = LinePhase("A", fixed_concentration=0, line_energy=-1.0)
+    phase_B = LinePhase("B", fixed_concentration=1, line_energy=-1.0)
+    p1 = QuasiChemicalPhase("p", phase_A=phase_A, phase_B=phase_B, V=0.0)
+    p2 = QuasiChemicalPhase("p", phase_A=phase_B, phase_B=phase_A, V=0.0)
+    assert p1.phase_A.line_concentration == 0
+    assert p2.phase_A.line_concentration == 0
+
+
+def test_bad_terminals_raise():
+    non_terminal = LinePhase("X", fixed_concentration=0.5, line_energy=0.0)
+    terminal = LinePhase("B", fixed_concentration=1, line_energy=0.0)
+    with pytest.raises(ValueError):
+        QuasiChemicalPhase("bad", phase_A=non_terminal, phase_B=terminal, V=0.0)
+
+
+# --- free energy limits ------------------------------------------------------
+
+
+def test_free_energy_terminals():
+    """Free energy at pure endpoints equals terminal free energies."""
+    T = 1000.0
+    phase = _make_symmetric(V=0.05)
+    assert_allclose(phase.free_energy(T, 0.0), -1.0, rtol=1e-10)
+    assert_allclose(phase.free_energy(T, 1.0), -1.0, rtol=1e-10)
+
+
+def test_free_energy_symmetric():
+    """Symmetric alloy: F(c) == F(1-c)."""
+    T = 800.0
+    phase = _make_symmetric(V=0.03)
+    c = np.linspace(0.05, 0.95, 9)
+    f = phase.free_energy(T, c)
+    assert_allclose(f, phase.free_energy(T, 1.0 - c), rtol=1e-6)
+
+
+def test_free_energy_array_T():
+    """free_energy broadcasts correctly over T and c arrays."""
+    phase = _make_symmetric(V=0.02)
+    T = np.array([500.0, 1000.0, 1500.0])
+    c = np.linspace(0.1, 0.9, 4)
+    T_grid = T[:, np.newaxis]
+    c_grid = c[np.newaxis, :]
+    f = phase.free_energy(T_grid, c_grid)
+    assert f.shape == (3, 4)
+
+
+# --- pair fraction -----------------------------------------------------------
+
+
+def test_y_AB_V0_symmetric():
+    """At V=0, c=0.5: QCA pair equilibrium gives y_AB = 1/3 (Bethe-lattice result)."""
+    phase = _make_symmetric(V=0.0, z=12)
+    y = phase._y_AB(0.5, 1000.0)
+    assert_allclose(y, 1.0 / 3.0, rtol=1e-5)
+
+
+def test_y_AB_increases_with_V():
+    """Positive V (ordering) increases y_AB compared to V=0."""
+    T = 1000.0
+    c = 0.5
+    y0 = _make_symmetric(V=0.0)._y_AB(c, T)
+    yp = _make_symmetric(V=0.05)._y_AB(c, T)
+    assert yp > y0
+
+
+def test_y_AB_decreases_with_negative_V():
+    """Negative V (segregation) decreases y_AB compared to V=0."""
+    T = 1000.0
+    c = 0.5
+    y0 = _make_symmetric(V=0.0)._y_AB(c, T)
+    yn = _make_symmetric(V=-0.05)._y_AB(c, T)
+    assert yn < y0
+
+
+def test_y_AB_conservation():
+    """Pair fractions satisfy y_AA = (1-c) - y_AB/2 and y_BB = c - y_AB/2 >= 0."""
+    phase = _make_symmetric(V=0.04)
+    c = np.linspace(0.01, 0.99, 20)
+    T = 900.0
+    y_AB = phase._y_AB(c, T)
+    y_AA = (1.0 - c) - y_AB / 2.0
+    y_BB = c - y_AB / 2.0
+    assert np.all(y_AA >= -1e-12)
+    assert np.all(y_BB >= -1e-12)
+    assert_allclose(y_AA + y_AB + y_BB, 1.0, atol=1e-10)
+
+
+def test_y_AB_equilibrium_condition():
+    """Equilibrium pair fractions satisfy y_AB^2 / (y_AA * y_BB) = exp(V / kB / T)."""
+    T = 1200.0
+    V = 0.03
+    c = 0.4
+    phase = _make_symmetric(V=V)
+    y_AB = phase._y_AB(c, T)
+    y_AA = (1.0 - c) - y_AB / 2.0
+    y_BB = c - y_AB / 2.0
+    expected_ratio = np.exp(V / (kB * T))
+    assert_allclose(y_AB**2 / (y_AA * y_BB), expected_ratio, rtol=1e-6)
+
+
+# --- concentration symmetry and monotonicity ---------------------------------
+
+
+def test_concentration_symmetric_at_zero_dmu():
+    """Symmetric alloy at dmu=0 has c=0.5."""
+    phase = _make_symmetric(V=0.04)
+    c = phase.concentration(1000.0, 0.0)
+    assert_allclose(c, 0.5, atol=1e-3)
+
+
+def test_concentration_increases_with_dmu():
+    """Concentration is a non-decreasing function of dmu."""
+    phase = _make_symmetric(V=0.04)
+    dmu = np.linspace(-0.5, 0.5, 20)
+    c = phase.concentration(1000.0, dmu)
+    assert np.all(np.diff(c) >= -1e-6)
+
+
+def test_semigrand_decreases_with_T():
+    """Semigrand potential at dmu=0 decreases as T rises (entropy lowers free energy)."""
+    phase = _make_symmetric(V=0.03)
+    dmu = 0.0
+    phi_low = phase.semigrand_potential(500.0, dmu)
+    phi_high = phase.semigrand_potential(2000.0, dmu)
+    assert phi_high < phi_low
+
+
+# --- FCC vs BCC --------------------------------------------------------------
+
+
+def test_coordination_number_matters():
+    """FCC (z=12) and BCC (z=8) give different free energies for the same V."""
+    T = 1000.0
+    c = 0.5
+    p_fcc = _make_symmetric(V=0.05, z=12)
+    p_bcc = _make_symmetric(V=0.05, z=8)
+    assert not np.isclose(p_fcc.free_energy(T, c), p_bcc.free_energy(T, c))
+
+
+# --- scalar / array API ------------------------------------------------------
+
+
+def test_semigrand_scalar_returns_scalar():
+    phase = _make_symmetric()
+    result = phase.semigrand_potential(1000.0, 0.0)
+    assert np.isscalar(result) or (isinstance(result, np.ndarray) and result.ndim == 0)
+
+
+def test_concentration_scalar_returns_scalar():
+    phase = _make_symmetric()
+    result = phase.concentration(1000.0, 0.0)
+    assert np.isscalar(result) or (isinstance(result, np.ndarray) and result.ndim == 0)
+
+
+def test_semigrand_array_shape():
+    phase = _make_symmetric()
+    dmu = np.linspace(-0.3, 0.3, 5)
+    phi = phase.semigrand_potential(1000.0, dmu)
+    assert phi.shape == (5,)


### PR DESCRIPTION
Implements `QuasiChemicalPhase` from the quasi-chemical (pair) approximation described in Rao & Curtin, Acta Materialia 228 (2022) 117621.

The equilibrium AB pair fraction is solved analytically from the quadratic arising from ∂F/∂y_AB = 0. Parameters: terminal phases (c=0, c=1), ordering energy V (eV/bond), coordination number z (12=FCC, 8=BCC).

Closes #81.

Generated with [Claude Code](https://claude.ai/code)