### PR TITLE
test(plots): add 2D T-mu phase diagram to testplots

### DIFF
--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -147,12 +147,52 @@ def plot_2d_toy(out_dir: Path) -> Path:
     return _save(fig, out_dir, "2d_toy_phase_diagram")
 
 
+def plot_2d_toy_mu(out_dir: Path) -> Path:
+    """2D T-mu diagram with a regular-solution liquid + intermediate solid, from Toy.ipynb."""
+    l1 = ldp.TemperatureDependentLinePhase(
+        "l0", fixed_concentration=0, temperatures=[1, 750, 1000],
+        free_energies=[2.00, 1.80, 1.00], interpolator=ldi.PolyFit(3),
+    )
+    l2 = ldp.TemperatureDependentLinePhase(
+        "l1", fixed_concentration=1, temperatures=[1, 750, 1000],
+        free_energies=[3.00, 2.80, 2.00], interpolator=ldi.PolyFit(3),
+    )
+    l3 = ldp.TemperatureDependentLinePhase(
+        "l2", fixed_concentration=0.5, temperatures=[1, 750, 1000],
+        free_energies=[2.45, 2.00, 1.42], interpolator=ldi.PolyFit(3),
+    )
+    s1 = ldp.TemperatureDependentLinePhase(
+        "s0", fixed_concentration=0, temperatures=[1, 750, 1000],
+        free_energies=[1.9, 1.6, 1.2], interpolator=ldi.SGTE(2),
+    )
+    s2 = ldp.TemperatureDependentLinePhase(
+        "s1", fixed_concentration=1, temperatures=[1, 750, 1000],
+        free_energies=[2.9, 2.6, 2.2], interpolator=ldi.SGTE(2),
+    )
+    s3 = ldp.TemperatureDependentLinePhase(
+        "s3", fixed_concentration=0.4, temperatures=[1, 750, 1000],
+        free_energies=np.array([2.4, 1.85, 1.45]) - 0.05, interpolator=ldi.SGTE(3),
+    )
+    rliq = ldp.RegularSolution("liquid", [l1, l3, l2])
+    sol = ldp.IdealSolution("solid", s1, s2)
+
+    c = np.linspace(0, 1, 75)[1:-1]
+    mu = 1 + ldp.kB * 4000 * np.log(c / (1 - c))
+    df = ldc.calc_phase_diagram([rliq, sol, s3], np.linspace(500, 1000, 40), mu, refine=True)
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    lpl.plot_mu_phase_diagram(df, ax=ax)
+    ax.set_title(r"2D T-$\mu$ diagram (regular-solution liquid + intermediate solid)")
+    return _save(fig, out_dir, "2d_toy_mu_phase_diagram")
+
+
 PLOTS = {
     "1d_T": plot_1d_T,
     "1d_mu": plot_1d_mu,
     "2d_basics": plot_2d_basics,
     "2d_basics_mu": plot_2d_basics_mu,
     "2d_toy": plot_2d_toy,
+    "2d_toy_mu": plot_2d_toy_mu,
 }
 
 

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -86,6 +86,28 @@ def plot_2d_basics(out_dir: Path) -> Path:
     return _save(fig, out_dir, "2d_basics_phase_diagram")
 
 
+def plot_2d_basics_mu(out_dir: Path) -> Path:
+    """2D T-mu phase diagram (hcp / fcc / liquid ideal solutions) from Basics.ipynb."""
+    fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
+    fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.00, line_entropy=1.1 * ldp.kB)
+    hcpa = ldp.LinePhase("hcpA", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
+    hcpb = ldp.LinePhase("hcpB", fixed_concentration=1, line_energy=-1.95, line_entropy=1.1 * ldp.kB)
+    lqda = ldp.LinePhase("liquidA", fixed_concentration=0, line_energy=-2.75, line_entropy=5.0 * ldp.kB)
+    lqdb = ldp.LinePhase("liquidB", fixed_concentration=1, line_energy=-1.75, line_entropy=4.4 * ldp.kB)
+    fcc = ldp.IdealSolution("fcc", fcca, fccb)
+    hcp = ldp.IdealSolution("hcp", hcpa, hcpb)
+    lqd = ldp.IdealSolution("liquid", lqda, lqdb)
+
+    Ts = np.linspace(200, 1000, 100)
+    mus = np.linspace(0.5, 1.5, 100)
+    df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts, mu=mus)
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    lpl.plot_mu_phase_diagram(df, ax=ax)
+    ax.set_title(r"2D T-$\mu$ diagram (hcp / fcc / liquid ideal solutions)")
+    return _save(fig, out_dir, "2d_basics_mu_phase_diagram")
+
+
 def plot_2d_toy(out_dir: Path) -> Path:
     """2D c-T diagram with a regular-solution liquid + intermediate solid, from Toy.ipynb."""
     l1 = ldp.TemperatureDependentLinePhase(
@@ -129,6 +151,7 @@ PLOTS = {
     "1d_T": plot_1d_T,
     "1d_mu": plot_1d_mu,
     "2d_basics": plot_2d_basics,
+    "2d_basics_mu": plot_2d_basics_mu,
     "2d_toy": plot_2d_toy,
 }
 


### PR DESCRIPTION
## Summary

- Adds `plot_2d_basics_mu` to `tests/integration/testplots.py`, rendering a T-mu phase diagram for the hcp / fcc / liquid ideal-solution system from `notebooks/Basics.ipynb` (the "Can also plot in mu/T space." section).
- Registered as `2d_basics_mu` in the `PLOTS` registry so the `testplot` workflow picks it up alongside the existing c-T diagrams.

## Test plan

- [x] `python tests/integration/testplots.py --only 2d_basics_mu` renders `2d_basics_mu_phase_diagram.png` showing the expected hcp/fcc/liquid regions in T-Δμ space.
- [ ] Apply the `testplot` label to confirm the CI workflow picks up and posts the new plot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YLr7gm91zHJSet8NDv9L1g)_