### PR TITLE
fix(poly): clean up apex residual after overlap subtraction

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -7,6 +7,7 @@ from warnings import warn
 from pyiron_snippets.import_alarm import ImportAlarm
 
 import shapely
+import shapely.ops
 import numpy as np
 import pandas as pd
 from matplotlib.patches import Polygon
@@ -112,6 +113,11 @@ class AbstractPolyMethod(abc.ABC):
         creates an overlap strip; here we subtract from every polygon its
         neighbours' un-buffered shapes so the seam lands on the original
         shared boundary.
+
+        Where two phases touch at a single point (e.g. a eutectic apex)
+        the rounded buffer cap extends past the apex into the gap and
+        leaves a small residual overlap that the plain subtract can't
+        reach; :func:`_split_apex_residual` finishes those off.
         """
         if len(shapes) < 2:
             return shapes
@@ -133,6 +139,29 @@ class AbstractPolyMethod(abc.ABC):
             if isinstance(trimmed, shapely.MultiPolygon):
                 trimmed = max(trimmed.geoms, key=shapely.area)
             out[k] = trimmed
+
+        keys = list(out.keys())
+        for i, ki in enumerate(keys):
+            for kj in keys[i + 1:]:
+                residual = out[ki].intersection(out[kj])
+                if residual.is_empty or residual.area == 0:
+                    continue
+                if not isinstance(residual, (shapely.Polygon, shapely.MultiPolygon)):
+                    # numerical-noise residual (line / point / mixed
+                    # collection from a buffer round-trip): not worth
+                    # trying to split, and shapely.ops.split chokes on it
+                    continue
+                out[ki], out[kj] = _split_apex_residual(out[ki], out[kj], residual, r)
+
+        # split / difference can leave a GeometryCollection mixing the
+        # main Polygon with tiny line/point slivers; downstream rendering
+        # only takes a single Polygon so we reduce to the largest one.
+        for k, v in out.items():
+            if isinstance(v, shapely.Polygon):
+                continue
+            polys = [g for g in getattr(v, "geoms", ())
+                     if isinstance(g, shapely.Polygon) and not g.is_empty]
+            out[k] = max(polys, key=shapely.area) if polys else shapely.Polygon()
         return pd.Series(out, name=shapes.name).reindex(shapes.index)
 
     @staticmethod
@@ -299,6 +328,58 @@ class Segments(AbstractPolyMethod):
             return None
 
         return shapely.Polygon(coords)
+
+
+def _split_apex_residual(
+        a: shapely.Polygon, b: shapely.Polygon,
+        residual: shapely.Geometry, r: float,
+) -> tuple[shapely.Polygon, shapely.Polygon]:
+    """Split ``residual = a ∩ b`` through the point-tangent apex of
+    the two un-buffered originals and remove each half from the wrong
+    polygon.
+
+    Used to finish the trim after :meth:`AbstractPolyMethod._trim_overlaps`
+    has subtracted neighbours' un-buffered shapes: a tiny lens-shaped
+    residual is left when the originals touch at a single point and the
+    rounded buffer cap peeks past it.  The cut is a long line through
+    the apex perpendicular to the line connecting the originals'
+    centroids -- which bisects the lens symmetrically for the common
+    case of two convex phases meeting head-on.  No-op if the cut can't
+    be constructed.
+    """
+    oa, ob = a.buffer(-r), b.buffer(-r)
+    if oa.is_empty or ob.is_empty:
+        return a, b
+    # Apex = midpoint of the closest-approach pair on the un-buffered
+    # originals (exactly on both if they truly touch, very close otherwise).
+    p, q = shapely.ops.nearest_points(oa, ob)
+    apex = (0.5 * (p.x + q.x), 0.5 * (p.y + q.y))
+    ca, cb = oa.centroid, ob.centroid
+    dx, dy = cb.x - ca.x, cb.y - ca.y
+    n = (dx * dx + dy * dy) ** 0.5
+    if n == 0:
+        return a, b
+    minx, miny, maxx, maxy = residual.bounds
+    reach = (((maxx - minx) ** 2 + (maxy - miny) ** 2) ** 0.5 + r) * 4
+    perp = (-dy / n * reach, dx / n * reach)
+    cut = shapely.LineString([
+        (apex[0] - perp[0], apex[1] - perp[1]),
+        (apex[0] + perp[0], apex[1] + perp[1]),
+    ])
+    try:
+        pieces = shapely.ops.split(residual, cut).geoms
+    except Exception:
+        return a, b
+    a_out, b_out = a, b
+    for piece in pieces:
+        if piece.is_empty or piece.area == 0:
+            continue
+        rp = piece.representative_point()
+        if oa.distance(rp) < ob.distance(rp):
+            b_out = b_out.difference(piece)
+        else:
+            a_out = a_out.difference(piece)
+    return a_out, b_out
 
 
 def _pca_sort_segment(pts: np.ndarray) -> np.ndarray:

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -1,8 +1,16 @@
 import pandas as pd
+import shapely
 from hypothesis import given, strategies as st, settings
-from landau.poly import Concave, Segments, handle_poly_method
+from landau.poly import AbstractPolyMethod, Concave, Segments, handle_poly_method
 import pytest
 from matplotlib.patches import Polygon
+
+
+class _StubPoly(AbstractPolyMethod):
+    """Minimal subclass for exercising :meth:`_trim_overlaps` directly."""
+
+    def _make(self, pp, border, segment_label):
+        return None
 
 # Check if optional dependencies are available
 try:
@@ -155,6 +163,27 @@ def test_segment_fast_tsp(df):
     if isinstance(res, pd.Series):
         for p in res:
             assert isinstance(p, Polygon)
+
+
+def test_trim_overlaps_apex_residual_split():
+    """Two solid-solution phases tangent at a eutectic apex: after the
+    plain subtract leaves a small lens residual at the tip, the apex
+    cleanup should split it symmetrically and remove the residual
+    overlap from both polygons."""
+    r = 0.02
+    eutectic = (0.5, 800.0)
+    alpha = shapely.Polygon([(0.0, 200), eutectic, (0.0, 900)]).buffer(r)
+    beta = shapely.Polygon([(1.0, 200), (1.0, 900), eutectic]).buffer(r)
+    shapes = pd.Series({"alpha": alpha, "beta": beta})
+
+    trimmed = _StubPoly(min_c_width=2 * r)._trim_overlaps(shapes)
+
+    overlap = trimmed["alpha"].intersection(trimmed["beta"]).area
+    assert overlap < 1e-9, f"overlap area {overlap} should be ~0"
+    assert abs(trimmed["alpha"].area - trimmed["beta"].area) < 1e-3
+    apex = shapely.Point(eutectic)
+    assert trimmed["alpha"].distance(apex) < 1e-3
+    assert trimmed["beta"].distance(apex) < 1e-3
 
 
 def test_handle_poly_method():


### PR DESCRIPTION
## Summary

A small cleanup pass on top of the symmetric subtract that landed in #127, addressing the only case it can't reach: two phases that touch at a single point (a eutectic apex). The rounded buffer cap extends past the apex into the gap and falls outside any neighbour's un-buffered shape, so the plain ``b.buffer(-r)`` subtraction leaves a small lens-shaped residual at the tip.

After the existing subtract pass, walk every still-overlapping pair and split each residual through the apex with a long line perpendicular to the segment between the two un-buffered originals' centroids (which bisects the lens symmetrically for the common case of two convex phases meeting head-on). Each half is removed from the polygon it doesn't belong to.

The cleanup is a no-op on:
- shared-edge cases (the subtract pass already lands the seam on the original boundary)
- residuals that are numerical noise — lines, points, or mixed collections from a buffer round-trip, which `shapely.ops.split` chokes on anyway

Also reduce every output to its largest Polygon component before returning: `Polygon.difference` / `shapely.ops.split` can return a `GeometryCollection` mixing the main polygon with tiny line/point slivers and the downstream `_to_mpl_polygon` only takes a single `Polygon` (without this, the toy T-μ testplot drops the s3 phase entirely).

This is the lightweight follow-up to the conversation on #125 / #129; the heavier boundary-Voronoi alternative is parked on `claude/voronoi-demo-issue-125` for reference.

## Test plan

- [x] `tests/unit/test_poly.py::test_trim_overlaps_apex_residual_split` — eutectic apex: residual overlap area ~0, symmetric trimmed areas, apex on the seam.
- [x] `pytest tests/unit/test_poly.py tests/unit/plot/test_polygons.py` passes (the pre-existing `test_concave` failure on a hypothesis edge case for `shapely.concave_hull` is unrelated).
- [x] Manual render of `tests/integration/testplots.py` shows `2d_basics`, `2d_basics_mu`, `2d_toy`, `2d_toy_mu` visually identical to main except the apex sliver is gone.

https://claude.ai/code/session_01WHKb72aizv9o6sep7jij7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHKb72aizv9o6sep7jij7u)_