### PR TITLE
refactor: DRY the phase_unit join/split string format

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -21,6 +21,27 @@ kB = Boltzmann / eV
 __all__ = ["calc_phase_diagram", "get_transitions", "cluster_T_c", "cluster_T_c_mu"]
 
 
+_PHASE_UNIT_SEP = "_"
+
+
+def _join_phase_unit(phase: pd.Series, unit: pd.Series) -> pd.Series:
+    """Encode ``(phase, unit)`` pairs as ``f"{phase}{_PHASE_UNIT_SEP}{unit}"`` strings.
+
+    Inverse is :func:`_split_phase_unit`. The two functions round-trip as long as
+    the unit-side string is a valid integer literal — the split uses ``rsplit``
+    with ``n=1``, so underscores inside ``phase`` are preserved.
+    """
+    return phase.astype(str) + _PHASE_UNIT_SEP + unit.astype(str)
+
+
+def _split_phase_unit(combined: pd.Series) -> tuple[pd.Series, pd.Series]:
+    """Inverse of :func:`_join_phase_unit`. Returns ``(phase, unit)``."""
+    parts = combined.str.rsplit(_PHASE_UNIT_SEP, n=1)
+    phase = parts.map(lambda x: x[0])
+    unit = parts.map(lambda x: int(x[1]))
+    return phase, unit
+
+
 def _split_stable(df):
     udf = df.query("not stable").reset_index(drop=True)
     udf["border"] = False
@@ -290,9 +311,7 @@ def get_transitions(df):
              # sometimes pandas returns a DataFrame instead of a Series when only one group exists
              res = res.stack().reset_index(level=0, drop=True)
         tdf["transition_unit"] = res
-        tdf["border_segment"] = tdf[["transition", "transition_unit"]].apply(
-            lambda r: "_".join(map(str, r.tolist())), axis="columns"
-        )
+        tdf["border_segment"] = _join_phase_unit(tdf["transition"], tdf["transition_unit"])
     else:
         tdf["transition_unit"] = []
         tdf["border_segment"] = []

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import numpy as np
 
-from .calculate import get_transitions, cluster, cluster_T_c
+from .calculate import get_transitions, cluster, cluster_T_c, _join_phase_unit
 import landau.poly as poly
 
 
@@ -38,9 +38,7 @@ def cluster_phase(df):
         lambda g: cluster_T_c(g).to_frame("phase_unit"),
         include_groups=False,
     )["phase_unit"]
-    df["phase_id"] = df[["phase", "phase_unit"]].apply(
-        lambda r: "_".join(map(str, r.tolist())), axis="columns"
-    )
+    df["phase_id"] = _join_phase_unit(df["phase"], df["phase_unit"])
     return df
 
 def get_polygons(

--- a/landau/poly.py
+++ b/landau/poly.py
@@ -14,7 +14,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import pairwise_distances
 from sklearn.decomposition import PCA
 
-from .calculate import get_transitions
+from .calculate import get_transitions, _split_phase_unit
 
 
 @dataclass
@@ -182,8 +182,7 @@ class Segments(AbstractPolyMethod):
             raise ValueError("Segments methods requires refined phase boundaries!")
         df.loc[:, "phase"] = df.phase_id
         tdf = get_transitions(df)
-        tdf["phase_unit"] = tdf.phase.str.rsplit('_', n=1).map(lambda x: int(x[1]))
-        tdf["phase"] = tdf.phase.str.rsplit('_', n=1).map(lambda x: x[0])
+        tdf["phase"], tdf["phase_unit"] = _split_phase_unit(tdf["phase"])
         return tdf
 
     @staticmethod

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -1,7 +1,14 @@
 import pytest
 import numpy as np
 import pandas as pd
-from landau.calculate import find_one_point, cluster_T_c, cluster_T_c_mu
+from hypothesis import given, strategies as st
+from landau.calculate import (
+    find_one_point,
+    cluster_T_c,
+    cluster_T_c_mu,
+    _join_phase_unit,
+    _split_phase_unit,
+)
 from unittest.mock import MagicMock
 
 def test_find_one_point_success():
@@ -107,3 +114,53 @@ def test_cluster_T_c_mu_empty():
     labels = cluster_T_c_mu(dd)
     assert len(labels) == 0
     assert labels.dtype.kind == "i"
+
+
+# --- _join_phase_unit / _split_phase_unit tests ---
+
+
+def test_join_phase_unit_basic():
+    phase = pd.Series(["alpha", "beta", "gamma"])
+    unit = pd.Series([0, 1, 2])
+    out = _join_phase_unit(phase, unit)
+    assert out.tolist() == ["alpha_0", "beta_1", "gamma_2"]
+
+
+def test_split_phase_unit_basic():
+    combined = pd.Series(["alpha_0", "beta_1", "gamma_2"])
+    phase, unit = _split_phase_unit(combined)
+    assert phase.tolist() == ["alpha", "beta", "gamma"]
+    assert unit.tolist() == [0, 1, 2]
+    assert unit.map(type).eq(int).all()
+
+
+@given(
+    phase=st.lists(
+        st.text(alphabet=st.characters(blacklist_characters="_"), min_size=1, max_size=8),
+        min_size=1,
+        max_size=10,
+    ),
+    unit=st.lists(st.integers(min_value=0, max_value=99), min_size=1, max_size=10),
+)
+def test_phase_unit_round_trip(phase, unit):
+    n = min(len(phase), len(unit))
+    p = pd.Series(phase[:n])
+    u = pd.Series(unit[:n])
+    p_out, u_out = _split_phase_unit(_join_phase_unit(p, u))
+    pd.testing.assert_series_equal(p_out, p, check_names=False)
+    pd.testing.assert_series_equal(u_out, u, check_names=False)
+
+
+def test_phase_unit_round_trip_underscore_in_name():
+    # rsplit(n=1) preserves underscores inside the phase name; only the final
+    # `_<int>` segment is interpreted as the unit.
+    p = pd.Series(["foo_bar", "baz_42"])
+    u = pd.Series([3, 7])
+    p_out, u_out = _split_phase_unit(_join_phase_unit(p, u))
+    assert p_out.tolist() == ["foo_bar", "baz_42"]
+    assert u_out.tolist() == [3, 7]
+
+
+def test_split_phase_unit_rejects_non_integer_unit():
+    with pytest.raises(ValueError):
+        _split_phase_unit(pd.Series(["alpha_not_an_int"]))


### PR DESCRIPTION
Closes #118.

## What changes

Two module-private helpers in `landau/calculate.py`:

```python
def _join_phase_unit(phase: pd.Series, unit: pd.Series) -> pd.Series: ...
def _split_phase_unit(combined: pd.Series) -> tuple[pd.Series, pd.Series]: ...
```

Three call sites now go through them:

- `landau/plot.py:cluster_phase` (was a row-wise `apply` building `phase_id`)
- `landau/calculate.py:get_transitions` (same row-wise `apply` building `border_segment`)
- `landau/poly.py:Segments.prepare` (was `rsplit('_', n=1)` invoked twice on the same column; now once)

No behavioural change at any of the sites — the encoding is unchanged. The full test suite passes (165 passed, 4 skipped — the four skips are pre-existing ASE/optional-dep skips).

## Tests

Added to `tests/unit/test_calculate.py`:

- `test_join_phase_unit_basic` / `test_split_phase_unit_basic` — explicit examples and the integer dtype on the unit side.
- `test_phase_unit_round_trip` — hypothesis property, random phase names (no `_`) and unit integers, `_split(_join(p, u)) == (p, u)`.
- `test_phase_unit_round_trip_underscore_in_name` — documents that `rsplit(n=1)` makes the encoding tolerant of underscores inside `phase` (sub-issue mentioned this as a "known-failure" case but it actually round-trips; this test pins the current behaviour).
- `test_split_phase_unit_rejects_non_integer_unit` — encoding constraint on the unit side.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FupponwLpvq2ELk6Nw8vwK)_