### PR TITLE
fix: defer AsePhase construction via fixture in test_vectorize

### DIFF
--- a/tests/unit/phases/test_vectorize.py
+++ b/tests/unit/phases/test_vectorize.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
 from hypothesis.extra.numpy import arrays, mutually_broadcastable_shapes
 
 from pyiron_snippets.import_alarm import ImportAlarm
@@ -18,6 +18,7 @@ def ase_phase():
 
 @pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
 @given(data=st.data())
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_semigrand_potential_vectorization(ase_phase, data):
     shapes = data.draw(mutually_broadcastable_shapes(num_shapes=2, max_dims=3, max_side=3))
 

--- a/tests/unit/phases/test_vectorize.py
+++ b/tests/unit/phases/test_vectorize.py
@@ -10,15 +10,15 @@ with ImportAlarm() as ase_alarm:
     from ase.thermochemistry import HarmonicThermo
     from landau.phases.asewrapper import AsePhase
 
-def get_ase_phase():
-    if ase_alarm.message is None:
-        return AsePhase("ht_phase", 0.5, thermochem=HarmonicThermo(vib_energies=[0.1]), pressure=None)
-    return None
+
+@pytest.fixture
+def ase_phase():
+    return AsePhase("ht_phase", 0.5, thermochem=HarmonicThermo(vib_energies=[0.1]), pressure=None)
+
 
 @pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
-@pytest.mark.parametrize("phase", [get_ase_phase()])
 @given(data=st.data())
-def test_semigrand_potential_vectorization(phase, data):
+def test_semigrand_potential_vectorization(ase_phase, data):
     shapes = data.draw(mutually_broadcastable_shapes(num_shapes=2, max_dims=3, max_side=3))
 
     T = data.draw(arrays(float, shapes.input_shapes[0], elements=st.floats(100, 1000)))
@@ -26,20 +26,19 @@ def test_semigrand_potential_vectorization(phase, data):
 
     expected_shape = shapes.result_shape
 
-    res = phase.semigrand_potential(T, dmu)
+    res = ase_phase.semigrand_potential(T, dmu)
     if expected_shape == ():
         assert np.isscalar(res) and not isinstance(res, np.ndarray)
     else:
         assert res.shape == expected_shape
 
-    f = phase.line_free_energy(T)
-    c = phase.line_concentration
+    f = ase_phase.line_free_energy(T)
+    c = ase_phase.line_concentration
     expected_res = f - c * dmu
     np.testing.assert_allclose(res, expected_res)
 
 
 @pytest.mark.skipif(ase_alarm.message is not None, reason="ASE is not installed")
-@pytest.mark.parametrize("phase", [get_ase_phase()])
 @pytest.mark.parametrize("T, dmu, expected_shape", [
     (300.0, 0.0, ()),
     (np.array([300, 400]), 0.0, (2,)),
@@ -48,14 +47,14 @@ def test_semigrand_potential_vectorization(phase, data):
     (np.array([300, 400])[:, None], np.array([-0.1, 0.0, 0.1]), (2, 3)),
     (np.array([[300], [400]]), np.array([[-0.1, 0.0, 0.1]]), (2, 3)),
 ])
-def test_semigrand_potential_vectorization_examples(phase, T, dmu, expected_shape):
-    res = phase.semigrand_potential(T, dmu)
+def test_semigrand_potential_vectorization_examples(ase_phase, T, dmu, expected_shape):
+    res = ase_phase.semigrand_potential(T, dmu)
     if expected_shape == ():
         assert np.isscalar(res) and not isinstance(res, np.ndarray)
     else:
         assert res.shape == expected_shape
 
-    f = phase.line_free_energy(T)
-    c = phase.line_concentration
+    f = ase_phase.line_free_energy(T)
+    c = ase_phase.line_concentration
     expected_res = f - c * dmu
     np.testing.assert_allclose(res, expected_res)


### PR DESCRIPTION
Replace `get_ase_phase()` + `@pytest.mark.parametrize` with an `ase_phase` fixture so that `AsePhase(...)` is never evaluated at collection time when ASE is absent.

Closes #133.

Generated with [Claude Code](https://claude.ai/code)