### PR TITLE
fix: deduplicate triple points in DelaunayTripleRefiner

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -403,6 +403,9 @@ class DelaunayTripleRefiner(Refiner):
 
     label = "delaunay-triple"
 
+    def __init__(self):
+        self._found: list[TMuPoint] = []
+
     def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
         for simplex, n in _delaunay_simplices(df):
             if n == 3:
@@ -413,6 +416,8 @@ class DelaunayTripleRefiner(Refiner):
         T0, mu0 = tr[["T", "mu"]].mean()
         names = tuple(tr.phase.unique())
         p1, p2, p3 = (phases[n] for n in names)
+        T_tol = float(tr["T"].max() - tr["T"].min())
+        mu_tol = float(tr["mu"].max() - tr["mu"].min())
 
         def triplemin(x):
             T, mu = x
@@ -422,30 +427,11 @@ class DelaunayTripleRefiner(Refiner):
             return abs(phi1 - phi2) + abs(phi2 - phi3) + abs(phi3 - phi1)
 
         T, mu = so.fmin(triplemin, (T0, mu0), disp=False)
+        if any(abs(T - fT) <= T_tol and abs(mu - fmu) <= mu_tol
+               for fT, fmu in self._found):
+            return []
+        self._found.append((T, mu))
         return [RefinedPoint(T=T, mu=mu, phases=names)]
-
-    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
-        rows: list[dict] = []
-        found: list[TMuPoint] = []
-        for cand in self.propose(df):
-            simplex = cand.simplex
-            T_tol = float(simplex["T"].max() - simplex["T"].min())
-            mu_tol = float(simplex["mu"].max() - simplex["mu"].min())
-            for pt in self.solve(cand, phases):
-                if pt.T < 0 or _dominated(pt, phases):
-                    continue
-                if any(abs(pt.T - fT) <= T_tol and abs(pt.mu - fmu) <= mu_tol
-                       for fT, fmu in found):
-                    continue
-                found.append((pt.T, pt.mu))
-                rows.extend(pt.to_rows(phases))
-        out = pd.DataFrame(rows)
-        if out.empty:
-            return out
-        out["stable"] = True
-        out["border"] = True
-        out["refined"] = self.label
-        return out
 
 
 # -- Clausius-Clapeyron tracers ----------------------------------------------

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -424,6 +424,29 @@ class DelaunayTripleRefiner(Refiner):
         T, mu = so.fmin(triplemin, (T0, mu0), disp=False)
         return [RefinedPoint(T=T, mu=mu, phases=names)]
 
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        rows: list[dict] = []
+        found: list[TMuPoint] = []
+        for cand in self.propose(df):
+            simplex = cand.simplex
+            T_tol = float(simplex["T"].max() - simplex["T"].min())
+            mu_tol = float(simplex["mu"].max() - simplex["mu"].min())
+            for pt in self.solve(cand, phases):
+                if pt.T < 0 or _dominated(pt, phases):
+                    continue
+                if any(abs(pt.T - fT) <= T_tol and abs(pt.mu - fmu) <= mu_tol
+                       for fT, fmu in found):
+                    continue
+                found.append((pt.T, pt.mu))
+                rows.extend(pt.to_rows(phases))
+        out = pd.DataFrame(rows)
+        if out.empty:
+            return out
+        out["stable"] = True
+        out["border"] = True
+        out["refined"] = self.label
+        return out
+
 
 # -- Clausius-Clapeyron tracers ----------------------------------------------
 #

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -10,6 +10,7 @@ from landau.refine import (
     ClausiusClapeyronRefiner,
     MiscibilityGapRefiner,
     DelaunayLineRefiner,
+    DelaunayTripleRefiner,
     RefinedPoint,
     RefinedMiscibilityGap,
 )
@@ -17,6 +18,7 @@ from landau.refine import (
     _point_on_line,
     _simplex_straddles,
     _InterCandidate,
+    _delaunay_simplices,
 )
 
 
@@ -424,3 +426,58 @@ def test_clausius_clapeyron_refiner_no_two_phase_simplex():
     # have no c-spread (all c=0.5), so it also yields nothing.
     gap_out = MiscibilityGapRefiner().run(df, {"solo": p})
     assert gap_out.empty
+
+
+def _three_phase_system():
+    """Three LinePhases with a single triple point at (T=300 K, mu=0.2 eV).
+
+    Coexistence curves (derived from equal-phi conditions):
+      A-B: mu = 0.002*T - 0.4
+      A-C: mu = 0.003*T - 0.7
+      B-C: mu = 0.004*T - 1.0
+    All three meet at T=300, mu=0.2.
+    """
+    ph_a = LinePhase(name='A', fixed_concentration=0.0,
+                     line_energy=-1.0, line_entropy=0.004)
+    ph_b = LinePhase(name='B', fixed_concentration=0.5,
+                     line_energy=-1.2, line_entropy=0.003)
+    ph_c = LinePhase(name='C', fixed_concentration=1.0,
+                     line_energy=-1.7, line_entropy=0.001)
+    return {'A': ph_a, 'B': ph_b, 'C': ph_c}
+
+
+def _coarse_df(phases, Ts, mus):
+    rows = []
+    for T in Ts:
+        for mu in mus:
+            phis = {n: float(p.semigrand_potential(T, mu))
+                    for n, p in phases.items()}
+            name = min(phis, key=phis.get)
+            rows.append({"T": T, "mu": mu, "phi": phis[name],
+                         "c": float(phases[name].concentration(T, mu)),
+                         "phase": name, "stable": True})
+    return pd.DataFrame(rows)
+
+
+def test_delaunay_triple_refiner_deduplicates():
+    """Triple refiner emits each triple point exactly once even when
+    multiple three-phase Delaunay simplices independently detect it."""
+    phases = _three_phase_system()
+    # Coarse grid: step ~50 K × ~0.1 eV, triple point (300, 0.2) lies
+    # between grid lines so several adjacent simplices are three-phase.
+    Ts = np.linspace(220.0, 480.0, 6)
+    mus = np.linspace(-0.05, 0.55, 7)
+    df = _coarse_df(phases, Ts, mus)
+
+    n_triple = sum(1 for _, n in _delaunay_simplices(df) if n == 3)
+    assert n_triple > 1, "grid should produce multiple three-phase simplices"
+
+    out = DelaunayTripleRefiner().run(df, phases)
+
+    assert not out.empty
+    assert (out["refined"] == "delaunay-triple").all()
+    # Exactly one triple point → 3 rows (one per phase).
+    assert len(out) == 3
+    assert set(out["phase"]) == {"A", "B", "C"}
+    assert np.allclose(out["T"], 300.0, atol=10.0)
+    assert np.allclose(out["mu"], 0.2, atol=0.05)


### PR DESCRIPTION
Multiple three-phase Delaunay simplices near the same triple point each independently call fmin and converge to slightly different (T, mu) values, producing duplicate rows tagged delaunay-triple (issue #142).

Override run() in DelaunayTripleRefiner to maintain a list of accepted (T, mu) points. After fmin converges, a result is rejected if it falls within the enclosing simplex's T and mu extents of any already-accepted point.

Adds test_delaunay_triple_refiner_deduplicates: constructs a three-phase LinePhase system with a known triple point at (T=300 K, mu=0.2 eV), verifies the coarse grid produces multiple three-phase simplices, and asserts the output is exactly 3 rows (one per phase).

Closes #142

Generated with [Claude Code](https://claude.ai/code)