### PR TITLE
fix: repair invalid polygons from _make and guard _trim_overlaps against GEOSException

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -67,8 +67,12 @@ class AbstractPolyMethod(abc.ABC):
                 return None
             if isinstance(shape, shapely.Polygon) and not shape.is_valid:
                 warn(f"{type(self).__name__}._make produced an invalid polygon "
-                     f"({shapely.is_valid_reason(shape)}); plotting will buffer it but "
-                     f"the result may be inaccurate.")
+                     f"({shapely.is_valid_reason(shape)}); repairing it.")
+                shape = shapely.make_valid(shape)
+                if isinstance(shape, shapely.MultiPolygon):
+                    shape = max(shape.geoms, key=shapely.area)
+                elif not isinstance(shape, shapely.Polygon):
+                    return None
 
         if shape.is_empty:
             return None
@@ -127,11 +131,14 @@ class AbstractPolyMethod(abc.ABC):
                 b_orig = b.buffer(-r)
                 if b_orig.is_empty:
                     continue
-                new = trimmed.difference(b_orig)
+                try:
+                    new = trimmed.difference(b_orig)
+                except shapely.errors.GEOSException:
+                    continue
                 if not new.is_empty:
                     trimmed = new
-            if isinstance(trimmed, shapely.MultiPolygon):
-                trimmed = max(trimmed.geoms, key=shapely.area)
+                if isinstance(trimmed, shapely.MultiPolygon):
+                    trimmed = max(trimmed.geoms, key=shapely.area)
             out[k] = trimmed
         return pd.Series(out, name=shapes.name).reindex(shapes.index)
 

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -157,6 +157,28 @@ def test_segment_fast_tsp(df):
             assert isinstance(p, Polygon)
 
 
+@pytest.mark.skipif(not HAS_PYTHON_TSP, reason="python-tsp not installed")
+def test_python_tsp_clustered_points():
+    # Regression for GH-38: clustered border points can produce a
+    # self-intersecting polygon that causes GEOSException in _trim_overlaps.
+    n = 10
+    # Two phases, each with many border points clustered near a single spot
+    # plus one outlier so the convex hull is not just a point.
+    data = {
+        "c":         [0.0] * n + [0.05] + [1.0] * n + [0.95],
+        "T":         [500.0] * n + [600.0] + [500.0] * n + [600.0],
+        "mu":        [0.0] * (n + 1) + [0.0] * (n + 1),
+        "border":    [True] * (n + 1) + [True] * (n + 1),
+        "phase":     ["A"] * (n + 1) + ["B"] * (n + 1),
+        "phase_unit":[0] * (n + 1) + [0] * (n + 1),
+        "refined":   [True] * (n + 1) + [True] * (n + 1),
+        "phase_id":  ["A_0"] * (n + 1) + ["B_0"] * (n + 1),
+    }
+    df = pd.DataFrame(data)
+    result = PythonTsp().apply(df)
+    assert isinstance(result, pd.Series)
+
+
 def test_handle_poly_method():
     assert isinstance(handle_poly_method("concave"), Concave)
     assert isinstance(handle_poly_method("segments"), Segments)


### PR DESCRIPTION
Closes #38.

Two failure modes from clustered phase points:

1. `_make` (TSP methods) produces self-intersecting polygons when border points are co-located. Previously only warned; call `shapely.make_valid()` to repair before further processing.

2. Nearly-coincident phase boundaries cause GEOS robustness failures in `difference()`. Guard with `try/except shapely.errors.GEOSException`; also move MultiPolygon collapse inside the inner loop.

Generated with [Claude Code](https://claude.ai/code)