### PR TITLE
Mention-driven testplot workflow with Haiku-parsed args

### DIFF
--- a/.github/scripts/parse_testplot_mention.py
+++ b/.github/scripts/parse_testplot_mention.py
@@ -1,7 +1,8 @@
 """Translate an ``@testplot`` PR-comment mention into testplots.py CLI args.
 
-Reads the comment body from ``$COMMENT_BODY`` and pipes it through Claude
-Haiku, which must respond with a single JSON object of the form::
+Reads the comment body from ``$COMMENT_BODY`` and pipes it through the
+``claude`` CLI (Claude Code), which must respond with a single JSON
+object of the form::
 
     {"args": ["--only", "1d_T", "--poly-method", "fasttsp"], "note": "..."}
 
@@ -9,17 +10,17 @@ The ``args`` list is shell-splattered into ``python tests/integration/testplots.
 by the calling workflow. ``note`` is a short human-readable summary that gets
 echoed back in the PR comment.
 
-The script is invoked by ``.github/workflows/testplot-mention.yml``; it has
-no dependencies beyond the official ``anthropic`` SDK.
+Authenticated via ``$CLAUDE_CODE_OAUTH_TOKEN`` (same secret the existing
+.github/workflows/claude.yml uses). The script is invoked by
+``.github/workflows/testplot-mention.yml``.
 """
 from __future__ import annotations
 
 import json
 import os
 import re
+import subprocess
 import sys
-
-import anthropic
 
 PLOT_NAMES = ["1d_T", "1d_mu", "2d_basics", "2d_basics_mu", "2d_toy", "2d_toy_mu"]
 POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
@@ -56,7 +57,7 @@ Mapping conventions:
   - "tielines off" / "no tielines" -> --no-tielines
   - bare `@testplot` with no other directives -> no extra args (renders everything)
 
-Respond with a single JSON object and NOTHING else:
+Respond with a single JSON object and NOTHING else (no prose, no code fences):
 
   {{"args": ["--only", "1d_T"], "note": "1D T diagram"}}
 
@@ -80,7 +81,6 @@ def _validate(payload: dict) -> dict:
     args = payload.get("args", [])
     if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
         raise ValueError(f"args must be a list of strings, got {args!r}")
-    # Reject anything that doesn't look like a flag or one of our known plot keys / poly methods.
     allowed_values = set(PLOT_NAMES) | set(POLY_METHODS) | {"--only", "--poly-method", "--tielines", "--no-tielines"}
     for a in args:
         if a.startswith("--"):
@@ -95,20 +95,31 @@ def _validate(payload: dict) -> dict:
     return {"args": args, "note": note[:200]}
 
 
+def _call_claude(body: str) -> str:
+    result = subprocess.run(
+        [
+            "claude",
+            "--model", "claude-haiku-4-5-20251001",
+            "--append-system-prompt", SYSTEM,
+            "--output-format", "text",
+            "--permission-mode", "plan",
+            "-p", body,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return result.stdout
+
+
 def main() -> None:
     body = os.environ.get("COMMENT_BODY", "").strip()
     if not body:
         print(json.dumps({"args": [], "note": "empty mention; rendering all plots"}))
         return
 
-    client = anthropic.Anthropic()
-    resp = client.messages.create(
-        model="claude-haiku-4-5-20251001",
-        max_tokens=400,
-        system=SYSTEM,
-        messages=[{"role": "user", "content": body}],
-    )
-    text = "".join(block.text for block in resp.content if getattr(block, "type", None) == "text")
+    text = _call_claude(body)
     payload = _validate(_extract_json(text))
     json.dump(payload, sys.stdout)
 

--- a/.github/scripts/parse_testplot_mention.py
+++ b/.github/scripts/parse_testplot_mention.py
@@ -1,0 +1,117 @@
+"""Translate an ``@testplot`` PR-comment mention into testplots.py CLI args.
+
+Reads the comment body from ``$COMMENT_BODY`` and pipes it through Claude
+Haiku, which must respond with a single JSON object of the form::
+
+    {"args": ["--only", "1d_T", "--poly-method", "fasttsp"], "note": "..."}
+
+The ``args`` list is shell-splattered into ``python tests/integration/testplots.py``
+by the calling workflow. ``note`` is a short human-readable summary that gets
+echoed back in the PR comment.
+
+The script is invoked by ``.github/workflows/testplot-mention.yml``; it has
+no dependencies beyond the official ``anthropic`` SDK.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+import anthropic
+
+PLOT_NAMES = ["1d_T", "1d_mu", "2d_basics", "2d_basics_mu", "2d_toy", "2d_toy_mu"]
+POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
+
+SYSTEM = f"""You translate informal `@testplot` mentions in GitHub PR comments
+into arguments for `tests/integration/testplots.py`.
+
+The script renders reference phase diagrams. Its relevant flags are:
+
+  --only {{{','.join(PLOT_NAMES)}}} ...
+        restrict to a subset of plots. Plot keys:
+          1d_T         : 1D temperature diagram (pure-A fcc/hcp/liquid line phases)
+          1d_mu        : 1D chemical-potential diagram (hcp vs fcc isothermal)
+          2d_basics    : 2D c-T diagram (ideal-solution hcp/fcc/liquid)
+          2d_basics_mu : 2D T-mu diagram (same phases as 2d_basics)
+          2d_toy       : 2D c-T diagram (regular-solution liquid + intermediate solid)
+          2d_toy_mu    : 2D T-mu diagram (same phases as 2d_toy)
+
+  --poly-method {{{','.join(POLY_METHODS)}}}
+        polygon-construction method for 2D plots (default: library default).
+
+  --tielines / --no-tielines
+        draw tielines on 2D c-T diagrams (default: on; only affects 2d_basics / 2d_toy).
+
+Mapping conventions:
+  - "1d T" / "1D temperature" -> --only 1d_T
+  - "1d mu" / "1D chemical potential" -> --only 1d_mu
+  - "1d" alone -> --only 1d_T 1d_mu
+  - "2d" alone -> all four 2D plots
+  - "2d basics" -> 2d_basics 2d_basics_mu ; "2d basics c" -> 2d_basics
+  - "2d toy" -> 2d_toy 2d_toy_mu ; "2d toy mu" -> 2d_toy_mu
+  - "fasttsp" / "fast tsp" -> --poly-method fasttsp
+  - "segment fasttsp" / "segment-fasttsp" -> --poly-method segment-fasttsp
+  - "tielines off" / "no tielines" -> --no-tielines
+  - bare `@testplot` with no other directives -> no extra args (renders everything)
+
+Respond with a single JSON object and NOTHING else:
+
+  {{"args": ["--only", "1d_T"], "note": "1D T diagram"}}
+
+`args` is a flat list of strings to be passed to argparse. `note` is a short
+human-readable summary (under 80 chars). Do not include `--out`; the workflow
+sets that. If the request is ambiguous, pick the closest reasonable mapping
+rather than refusing.
+"""
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_json(text: str) -> dict:
+    match = _JSON_RE.search(text)
+    if not match:
+        raise ValueError(f"no JSON object in model output: {text!r}")
+    return json.loads(match.group(0))
+
+
+def _validate(payload: dict) -> dict:
+    args = payload.get("args", [])
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        raise ValueError(f"args must be a list of strings, got {args!r}")
+    # Reject anything that doesn't look like a flag or one of our known plot keys / poly methods.
+    allowed_values = set(PLOT_NAMES) | set(POLY_METHODS) | {"--only", "--poly-method", "--tielines", "--no-tielines"}
+    for a in args:
+        if a.startswith("--"):
+            if a not in allowed_values:
+                raise ValueError(f"disallowed flag in args: {a!r}")
+        else:
+            if a not in allowed_values:
+                raise ValueError(f"disallowed value in args: {a!r}")
+    note = payload.get("note", "")
+    if not isinstance(note, str):
+        raise ValueError(f"note must be a string, got {note!r}")
+    return {"args": args, "note": note[:200]}
+
+
+def main() -> None:
+    body = os.environ.get("COMMENT_BODY", "").strip()
+    if not body:
+        print(json.dumps({"args": [], "note": "empty mention; rendering all plots"}))
+        return
+
+    client = anthropic.Anthropic()
+    resp = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=400,
+        system=SYSTEM,
+        messages=[{"role": "user", "content": body}],
+    )
+    text = "".join(block.text for block in resp.content if getattr(block, "type", None) == "text")
+    payload = _validate(_extract_json(text))
+    json.dump(payload, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/parse_testplot_mention.py
+++ b/.github/scripts/parse_testplot_mention.py
@@ -28,9 +28,15 @@ POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "seg
 SYSTEM = f"""You translate informal `@testplot` mentions in GitHub PR comments
 into arguments for `tests/integration/testplots.py`.
 
-The script renders reference phase diagrams. Its relevant flags are:
+The script renders reference phase diagrams. All multi-valued flags
+cross-product, so `--poly-method a b --tielines on off` against four 2D
+plots renders 4 x 2 x 2 = 16 figures. Be generous: if the user says
+"everything" or names a plural ("methods", "tielines on and off"), pass
+every matching value rather than picking one.
 
-  --only {{{','.join(PLOT_NAMES)}}} ...
+Flags:
+
+  --only {{{','.join(PLOT_NAMES)}}} [...]
         restrict to a subset of plots. Plot keys:
           1d_T         : 1D temperature diagram (pure-A fcc/hcp/liquid line phases)
           1d_mu        : 1D chemical-potential diagram (hcp vs fcc isothermal)
@@ -39,11 +45,13 @@ The script renders reference phase diagrams. Its relevant flags are:
           2d_toy       : 2D c-T diagram (regular-solution liquid + intermediate solid)
           2d_toy_mu    : 2D T-mu diagram (same phases as 2d_toy)
 
-  --poly-method {{{','.join(POLY_METHODS)}}}
-        polygon-construction method for 2D plots (default: library default).
+  --poly-method {{{','.join(POLY_METHODS)}}} [...]
+        one or more polygon-construction methods, cross-producted over the
+        2D plots. Omit entirely to use the library default.
 
-  --tielines / --no-tielines
-        draw tielines on 2D c-T diagrams (default: on; only affects 2d_basics / 2d_toy).
+  --tielines {{on,off}} [...]
+        one or more tieline modes, cross-producted over 2D c-T plots
+        (only affects 2d_basics / 2d_toy). Default: on.
 
 Mapping conventions:
   - "1d T" / "1D temperature" -> --only 1d_T
@@ -53,9 +61,12 @@ Mapping conventions:
   - "2d basics" -> 2d_basics 2d_basics_mu ; "2d basics c" -> 2d_basics
   - "2d toy" -> 2d_toy 2d_toy_mu ; "2d toy mu" -> 2d_toy_mu
   - "fasttsp" / "fast tsp" -> --poly-method fasttsp
-  - "segment fasttsp" / "segment-fasttsp" -> --poly-method segment-fasttsp
-  - "tielines off" / "no tielines" -> --no-tielines
-  - bare `@testplot` with no other directives -> no extra args (renders everything)
+  - "all tsp methods" / "tsp methods" -> --poly-method tsp fasttsp segment-tsp segment-fasttsp
+  - "segment methods" / "segment tsp methods" -> --poly-method segment-tsp segment-fasttsp
+  - "all poly methods" / "every poly-method" -> --poly-method concave segments fasttsp tsp segment-fasttsp segment-tsp
+  - "tielines off" / "no tielines" -> --tielines off
+  - "with and without tielines" / "both tieline modes" -> --tielines on off
+  - "everything" / "all plots" / bare `@testplot` -> no extra args (renders every plot once)
 
 Respond with a single JSON object and NOTHING else (no prose, no code fences):
 
@@ -81,7 +92,12 @@ def _validate(payload: dict) -> dict:
     args = payload.get("args", [])
     if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
         raise ValueError(f"args must be a list of strings, got {args!r}")
-    allowed_values = set(PLOT_NAMES) | set(POLY_METHODS) | {"--only", "--poly-method", "--tielines", "--no-tielines"}
+    allowed_values = (
+        set(PLOT_NAMES)
+        | set(POLY_METHODS)
+        | {"on", "off"}
+        | {"--only", "--poly-method", "--tielines"}
+    )
     for a in args:
         if a.startswith("--"):
             if a not in allowed_values:

--- a/.github/workflows/testplot-mention.yml
+++ b/.github/workflows/testplot-mention.yml
@@ -1,0 +1,167 @@
+name: testplot-mention
+
+# Render reference phase diagrams in response to an `@testplot` mention in
+# a PR comment. The comment body is piped through Claude Haiku to turn
+# informal directives like "@testplot 2d fasttsp" into CLI flags for
+# tests/integration/testplots.py.
+#
+# Plots are published to the same content-addressed `testplots` gallery
+# branch used by .github/workflows/testplot.yml so a single PR can
+# accumulate diagrams from both the label-driven and mention-driven flows.
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  GALLERY_BRANCH: testplots
+
+jobs:
+  render:
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@testplot')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: React to the mention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve PR head
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('ref', pr.data.head.ref);
+
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          path: src
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: src/pyproject.toml
+
+      - name: Install
+        working-directory: src
+        run: |
+          pip install -e .[fast-tsp,python-tsp]
+          pip install 'anthropic>=0.40'
+
+      - name: Parse mention via Haiku
+        id: parse
+        working-directory: src
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          python .github/scripts/parse_testplot_mention.py > "${GITHUB_WORKSPACE}/_parsed.json"
+          cat "${GITHUB_WORKSPACE}/_parsed.json"
+          {
+            echo "note<<EOF"
+            jq -r '.note' "${GITHUB_WORKSPACE}/_parsed.json"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render phase diagrams
+        working-directory: src
+        run: |
+          set -euxo pipefail
+          mapfile -t ARGS < <(jq -r '.args[]' "${GITHUB_WORKSPACE}/_parsed.json")
+          python tests/integration/testplots.py --out "${GITHUB_WORKSPACE}/_plots" "${ARGS[@]}"
+
+      - name: Publish plots to ${{ env.GALLERY_BRANCH }} branch
+        id: publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git clone --depth=1 "$REPO_URL" gallery
+          cd gallery
+          git config user.email "actions@github.com"
+          git config user.name "github-actions[bot]"
+          if git ls-remote --exit-code --heads origin "$GALLERY_BRANCH" >/dev/null; then
+            git fetch --depth=1 origin "$GALLERY_BRANCH":"$GALLERY_BRANCH"
+            git checkout "$GALLERY_BRANCH"
+          else
+            git checkout --orphan "$GALLERY_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+            printf '# Test plot gallery\n\nContent-addressed PNGs published by .github/workflows/testplot*.yml.\n' > README.md
+            git add README.md
+            git commit -m "init $GALLERY_BRANCH branch"
+          fi
+          mkdir -p "$PR"
+          : > "${GITHUB_WORKSPACE}/_plot_paths.txt"
+          for f in "${GITHUB_WORKSPACE}"/_plots/*.png; do
+            name=$(basename "$f" .png)
+            sha=$(sha256sum "$f" | cut -c1-16)
+            rel="${PR}/${sha}-${name}.png"
+            cp "$f" "$rel"
+            echo "$rel" >> "${GITHUB_WORKSPACE}/_plot_paths.txt"
+          done
+          git add "$PR"
+          if git diff --cached --quiet; then
+            echo "all plots already published; nothing to commit"
+          else
+            git commit -m "testplots @ ${GITHUB_SHA} (mention)"
+            git push origin "$GALLERY_BRANCH"
+          fi
+
+      - name: Post comment with images
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+          GALLERY_BRANCH: ${{ env.GALLERY_BRANCH }}
+          NOTE: ${{ steps.parse.outputs.note }}
+          TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
+        with:
+          script: |
+            const fs = require('fs');
+            const paths = fs.readFileSync('_plot_paths.txt', 'utf8')
+              .split('\n').filter(Boolean).sort();
+            const short = process.env.HEAD_SHA.slice(0, 7);
+            const base = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/${process.env.GALLERY_BRANCH}`;
+            const lines = [
+              `### Test plots for \`${short}\` ([mention](${process.env.TRIGGER_COMMENT_URL}))`,
+              '',
+              `_${process.env.NOTE || 'rendered via @testplot mention'}_`,
+              '',
+            ];
+            for (const rel of paths) {
+              const file = rel.split('/').pop();
+              const name = file.replace(/^[0-9a-f]+-/, '').replace(/\.png$/, '');
+              lines.push(`#### ${name}`);
+              lines.push('');
+              lines.push(`<img alt="${name}" src="${base}/${rel}" width="600">`);
+              lines.push('');
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: lines.join('\n'),
+            });

--- a/.github/workflows/testplot-mention.yml
+++ b/.github/workflows/testplot-mention.yml
@@ -65,15 +65,20 @@ jobs:
 
       - name: Install
         working-directory: src
-        run: |
-          pip install -e .[fast-tsp,python-tsp]
-          pip install 'anthropic>=0.40'
+        run: pip install -e .[fast-tsp,python-tsp]
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
 
       - name: Parse mention via Haiku
         id: parse
         working-directory: src
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -6,7 +6,8 @@ notebooks and saves a single phase-diagram PNG into the output directory
 
 The script is intentionally not a pytest test: the "correctness" of a
 landau plot is hard to formalise so we instead post the rendered figures
-on PRs labeled ``testplot`` and review them by eye.
+on PRs labeled ``testplot`` (or mentioned with ``@testplot``) and review
+them by eye.
 """
 from __future__ import annotations
 
@@ -24,16 +25,18 @@ import landau.interpolate as ldi
 import landau.phases as ldp
 import landau.plot as lpl
 
+POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
 
-def _save(fig, out_dir: Path, name: str) -> Path:
+
+def _save(fig, out_dir: Path, name: str, suffix: str = "") -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / f"{name}.png"
+    path = out_dir / f"{name}{suffix}.png"
     fig.savefig(path, dpi=120, bbox_inches="tight")
     plt.close(fig)
     return path
 
 
-def plot_1d_T(out_dir: Path) -> Path:
+def plot_1d_T(out_dir: Path, **_) -> Path:
     """1D T phase diagram from notebooks/Basics.ipynb (three pure-A phases)."""
     fcca = ldp.LinePhase("fcc", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
     hcpa = ldp.LinePhase("hcp", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
@@ -48,7 +51,7 @@ def plot_1d_T(out_dir: Path) -> Path:
     return _save(fig, out_dir, "1d_T_phase_diagram")
 
 
-def plot_1d_mu(out_dir: Path) -> Path:
+def plot_1d_mu(out_dir: Path, **_) -> Path:
     """1D mu phase diagram from notebooks/Basics.ipynb (hcp vs fcc isothermal)."""
     fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
     fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.00, line_entropy=1.1 * ldp.kB)
@@ -65,7 +68,7 @@ def plot_1d_mu(out_dir: Path) -> Path:
     return _save(fig, out_dir, "1d_mu_phase_diagram")
 
 
-def plot_2d_basics(out_dir: Path) -> Path:
+def plot_2d_basics(out_dir: Path, poly_method: str | None = None, tielines: bool = True, **_) -> Path:
     """2D c-T phase diagram (hcp / fcc / liquid ideal solutions) from Basics.ipynb."""
     fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
     fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.00, line_entropy=1.1 * ldp.kB)
@@ -81,12 +84,12 @@ def plot_2d_basics(out_dir: Path) -> Path:
     df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts, mu=100)
 
     fig, ax = plt.subplots(figsize=(6, 5))
-    lpl.plot_phase_diagram(df, ax=ax, tielines=True)
-    ax.set_title("2D c-T diagram (hcp / fcc / liquid ideal solutions)")
-    return _save(fig, out_dir, "2d_basics_phase_diagram")
+    lpl.plot_phase_diagram(df, ax=ax, tielines=tielines, poly_method=poly_method)
+    ax.set_title(f"2D c-T diagram (hcp / fcc / liquid ideal solutions){_poly_suffix(poly_method)}")
+    return _save(fig, out_dir, "2d_basics_phase_diagram", _file_suffix(poly_method))
 
 
-def plot_2d_basics_mu(out_dir: Path) -> Path:
+def plot_2d_basics_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
     """2D T-mu phase diagram (hcp / fcc / liquid ideal solutions) from Basics.ipynb."""
     fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
     fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.00, line_entropy=1.1 * ldp.kB)
@@ -103,12 +106,12 @@ def plot_2d_basics_mu(out_dir: Path) -> Path:
     df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts, mu=mus)
 
     fig, ax = plt.subplots(figsize=(6, 5))
-    lpl.plot_mu_phase_diagram(df, ax=ax)
-    ax.set_title(r"2D T-$\mu$ diagram (hcp / fcc / liquid ideal solutions)")
-    return _save(fig, out_dir, "2d_basics_mu_phase_diagram")
+    lpl.plot_mu_phase_diagram(df, ax=ax, poly_method=poly_method)
+    ax.set_title(rf"2D T-$\mu$ diagram (hcp / fcc / liquid ideal solutions){_poly_suffix(poly_method)}")
+    return _save(fig, out_dir, "2d_basics_mu_phase_diagram", _file_suffix(poly_method))
 
 
-def plot_2d_toy(out_dir: Path) -> Path:
+def plot_2d_toy(out_dir: Path, poly_method: str | None = None, tielines: bool = True, **_) -> Path:
     """2D c-T diagram with a regular-solution liquid + intermediate solid, from Toy.ipynb."""
     l1 = ldp.TemperatureDependentLinePhase(
         "l0", fixed_concentration=0, temperatures=[1, 750, 1000],
@@ -142,12 +145,12 @@ def plot_2d_toy(out_dir: Path) -> Path:
     df = ldc.calc_phase_diagram([rliq, sol, s3], np.linspace(500, 1000, 40), mu, refine=True)
 
     fig, ax = plt.subplots(figsize=(6, 5))
-    lpl.plot_phase_diagram(df, ax=ax, tielines=True)
-    ax.set_title("2D c-T diagram (regular-solution liquid + intermediate solid)")
-    return _save(fig, out_dir, "2d_toy_phase_diagram")
+    lpl.plot_phase_diagram(df, ax=ax, tielines=tielines, poly_method=poly_method)
+    ax.set_title(f"2D c-T diagram (regular-solution liquid + intermediate solid){_poly_suffix(poly_method)}")
+    return _save(fig, out_dir, "2d_toy_phase_diagram", _file_suffix(poly_method))
 
 
-def plot_2d_toy_mu(out_dir: Path) -> Path:
+def plot_2d_toy_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
     """2D T-mu diagram with a regular-solution liquid + intermediate solid, from Toy.ipynb."""
     l1 = ldp.TemperatureDependentLinePhase(
         "l0", fixed_concentration=0, temperatures=[1, 750, 1000],
@@ -181,9 +184,17 @@ def plot_2d_toy_mu(out_dir: Path) -> Path:
     df = ldc.calc_phase_diagram([rliq, sol, s3], np.linspace(500, 1000, 40), mu, refine=True)
 
     fig, ax = plt.subplots(figsize=(6, 5))
-    lpl.plot_mu_phase_diagram(df, ax=ax)
-    ax.set_title(r"2D T-$\mu$ diagram (regular-solution liquid + intermediate solid)")
-    return _save(fig, out_dir, "2d_toy_mu_phase_diagram")
+    lpl.plot_mu_phase_diagram(df, ax=ax, poly_method=poly_method)
+    ax.set_title(rf"2D T-$\mu$ diagram (regular-solution liquid + intermediate solid){_poly_suffix(poly_method)}")
+    return _save(fig, out_dir, "2d_toy_mu_phase_diagram", _file_suffix(poly_method))
+
+
+def _poly_suffix(poly_method: str | None) -> str:
+    return f" [{poly_method}]" if poly_method else ""
+
+
+def _file_suffix(poly_method: str | None) -> str:
+    return f"_{poly_method}" if poly_method else ""
 
 
 PLOTS = {
@@ -210,11 +221,24 @@ def main() -> None:
         nargs="*",
         help="restrict to a subset of plots",
     )
+    parser.add_argument(
+        "--poly-method",
+        choices=POLY_METHODS,
+        default=None,
+        help="polygon-construction method passed to 2D plot_phase_diagram / plot_mu_phase_diagram",
+    )
+    parser.add_argument(
+        "--tielines",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="draw tielines on 2D c-T diagrams (default: on)",
+    )
     args = parser.parse_args()
 
     names = args.only or list(PLOTS)
+    kwargs = {"poly_method": args.poly_method, "tielines": args.tielines}
     for name in names:
-        path = PLOTS[name](args.out)
+        path = PLOTS[name](args.out, **kwargs)
         print(f"wrote {path}")
 
 

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -12,6 +12,7 @@ them by eye.
 from __future__ import annotations
 
 import argparse
+import itertools
 from pathlib import Path
 
 import matplotlib
@@ -26,6 +27,7 @@ import landau.phases as ldp
 import landau.plot as lpl
 
 POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
+TIELINE_VALUES = ["on", "off"]
 
 
 def _save(fig, out_dir: Path, name: str, suffix: str = "") -> Path:
@@ -34,6 +36,24 @@ def _save(fig, out_dir: Path, name: str, suffix: str = "") -> Path:
     fig.savefig(path, dpi=120, bbox_inches="tight")
     plt.close(fig)
     return path
+
+
+def _title_suffix(poly_method: str | None = None, tielines: bool = True) -> str:
+    parts = []
+    if poly_method:
+        parts.append(poly_method)
+    if not tielines:
+        parts.append("no tielines")
+    return f" [{', '.join(parts)}]" if parts else ""
+
+
+def _file_suffix(poly_method: str | None = None, tielines: bool = True) -> str:
+    parts = []
+    if poly_method:
+        parts.append(poly_method)
+    if not tielines:
+        parts.append("notielines")
+    return "_" + "_".join(parts) if parts else ""
 
 
 def plot_1d_T(out_dir: Path, **_) -> Path:
@@ -85,8 +105,8 @@ def plot_2d_basics(out_dir: Path, poly_method: str | None = None, tielines: bool
 
     fig, ax = plt.subplots(figsize=(6, 5))
     lpl.plot_phase_diagram(df, ax=ax, tielines=tielines, poly_method=poly_method)
-    ax.set_title(f"2D c-T diagram (hcp / fcc / liquid ideal solutions){_poly_suffix(poly_method)}")
-    return _save(fig, out_dir, "2d_basics_phase_diagram", _file_suffix(poly_method))
+    ax.set_title(f"2D c-T diagram (hcp / fcc / liquid ideal solutions){_title_suffix(poly_method, tielines)}")
+    return _save(fig, out_dir, "2d_basics_phase_diagram", _file_suffix(poly_method, tielines))
 
 
 def plot_2d_basics_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
@@ -107,7 +127,7 @@ def plot_2d_basics_mu(out_dir: Path, poly_method: str | None = None, **_) -> Pat
 
     fig, ax = plt.subplots(figsize=(6, 5))
     lpl.plot_mu_phase_diagram(df, ax=ax, poly_method=poly_method)
-    ax.set_title(rf"2D T-$\mu$ diagram (hcp / fcc / liquid ideal solutions){_poly_suffix(poly_method)}")
+    ax.set_title(rf"2D T-$\mu$ diagram (hcp / fcc / liquid ideal solutions){_title_suffix(poly_method)}")
     return _save(fig, out_dir, "2d_basics_mu_phase_diagram", _file_suffix(poly_method))
 
 
@@ -146,8 +166,8 @@ def plot_2d_toy(out_dir: Path, poly_method: str | None = None, tielines: bool = 
 
     fig, ax = plt.subplots(figsize=(6, 5))
     lpl.plot_phase_diagram(df, ax=ax, tielines=tielines, poly_method=poly_method)
-    ax.set_title(f"2D c-T diagram (regular-solution liquid + intermediate solid){_poly_suffix(poly_method)}")
-    return _save(fig, out_dir, "2d_toy_phase_diagram", _file_suffix(poly_method))
+    ax.set_title(f"2D c-T diagram (regular-solution liquid + intermediate solid){_title_suffix(poly_method, tielines)}")
+    return _save(fig, out_dir, "2d_toy_phase_diagram", _file_suffix(poly_method, tielines))
 
 
 def plot_2d_toy_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
@@ -185,25 +205,20 @@ def plot_2d_toy_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
 
     fig, ax = plt.subplots(figsize=(6, 5))
     lpl.plot_mu_phase_diagram(df, ax=ax, poly_method=poly_method)
-    ax.set_title(rf"2D T-$\mu$ diagram (regular-solution liquid + intermediate solid){_poly_suffix(poly_method)}")
+    ax.set_title(rf"2D T-$\mu$ diagram (regular-solution liquid + intermediate solid){_title_suffix(poly_method)}")
     return _save(fig, out_dir, "2d_toy_mu_phase_diagram", _file_suffix(poly_method))
 
 
-def _poly_suffix(poly_method: str | None) -> str:
-    return f" [{poly_method}]" if poly_method else ""
-
-
-def _file_suffix(poly_method: str | None) -> str:
-    return f"_{poly_method}" if poly_method else ""
-
-
+# Each plot maps to (function, kwargs it actually consumes). 1D plots ignore
+# poly_method and tielines, so cross-product iteration over them dedupes
+# automatically instead of re-rendering identical files.
 PLOTS = {
-    "1d_T": plot_1d_T,
-    "1d_mu": plot_1d_mu,
-    "2d_basics": plot_2d_basics,
-    "2d_basics_mu": plot_2d_basics_mu,
-    "2d_toy": plot_2d_toy,
-    "2d_toy_mu": plot_2d_toy_mu,
+    "1d_T":         (plot_1d_T,         ()),
+    "1d_mu":        (plot_1d_mu,        ()),
+    "2d_basics":    (plot_2d_basics,    ("poly_method", "tielines")),
+    "2d_basics_mu": (plot_2d_basics_mu, ("poly_method",)),
+    "2d_toy":       (plot_2d_toy,       ("poly_method", "tielines")),
+    "2d_toy_mu":    (plot_2d_toy_mu,    ("poly_method",)),
 }
 
 
@@ -218,28 +233,37 @@ def main() -> None:
     parser.add_argument(
         "--only",
         choices=sorted(PLOTS),
-        nargs="*",
-        help="restrict to a subset of plots",
+        nargs="+",
+        help="restrict to a subset of plots (default: all)",
     )
     parser.add_argument(
         "--poly-method",
         choices=POLY_METHODS,
+        nargs="+",
         default=None,
-        help="polygon-construction method passed to 2D plot_phase_diagram / plot_mu_phase_diagram",
+        help="one or more polygon-construction methods to cross-product over the 2D plots "
+             "(default: library default, single rendering)",
     )
     parser.add_argument(
         "--tielines",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="draw tielines on 2D c-T diagrams (default: on)",
+        choices=TIELINE_VALUES,
+        nargs="+",
+        default=["on"],
+        help="tieline modes to cross-product over 2D c-T plots: 'on', 'off', or both (default: on)",
     )
     args = parser.parse_args()
 
     names = args.only or list(PLOTS)
-    kwargs = {"poly_method": args.poly_method, "tielines": args.tielines}
+    poly_methods = args.poly_method if args.poly_method else [None]
+    tielines = [v == "on" for v in args.tielines]
+    axes = {"poly_method": poly_methods, "tielines": tielines}
+
     for name in names:
-        path = PLOTS[name](args.out, **kwargs)
-        print(f"wrote {path}")
+        fn, uses = PLOTS[name]
+        for combo in itertools.product(*(axes[k] for k in uses)):
+            call_kwargs = dict(zip(uses, combo))
+            path = fn(args.out, **call_kwargs)
+            print(f"wrote {path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #103. Adds a second trigger for the testplot pipeline driven by `@testplot` mentions in PR comments, plus the script options needed to make those mentions meaningful.

## Changes

- `.github/workflows/testplot-mention.yml` — fires on PR comments containing `@testplot`. Reacts with `eyes`, resolves the PR head SHA, installs landau, calls the parser, renders, and reuses the existing `testplots` gallery branch + comment template.
- `.github/scripts/parse_testplot_mention.py` — pipes `$COMMENT_BODY` through `claude-haiku-4-5-20251001` and emits `{"args": [...], "note": "..."}`. The args list is validated against a fixed allow-list of plot keys and flags before the workflow shell-splats it, so a commenter can't smuggle in `--out /etc/passwd` or arbitrary plot names.
- `tests/integration/testplots.py` — new flags `--poly-method` (passes through to `plot_phase_diagram` / `plot_mu_phase_diagram` on the 2D plots) and `--tielines/--no-tielines`. 2D output filenames pick up a `_<poly-method>` suffix when one is set, so different methods coexist in the content-addressed gallery without overwriting each other. Default invocation is byte-identical to before, so the label-triggered workflow stays idempotent.

## Examples

- `@testplot 2d fasttsp` → `--only 2d_basics 2d_basics_mu 2d_toy 2d_toy_mu --poly-method fasttsp`
- `@testplot 1d T` → `--only 1d_T`
- `@testplot 2d toy mu segment-fasttsp` → `--only 2d_toy_mu --poly-method segment-fasttsp`
- bare `@testplot` → renders everything

## Requirements

- Repo secret `ANTHROPIC_API_KEY` must be set for the parse step. Without it the step errors out before any rendering.

## Test plan

- [x] `python tests/integration/testplots.py --help` shows the new flags
- [x] `python tests/integration/testplots.py --only 2d_basics --poly-method fasttsp` writes `2d_basics_phase_diagram_fasttsp.png`
- [x] `python tests/integration/testplots.py --only 2d_basics` still writes `2d_basics_phase_diagram.png` (no suffix), preserving idempotency against the `testplots` gallery branch
- [x] Parser validator rejects `--out`, unknown plot keys, and unknown poly methods
- [ ] Add `ANTHROPIC_API_KEY` to repo secrets and exercise the workflow with `@testplot 2d fasttsp` on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_011TptP76r9xb5eAXL1mgErD)_