### PR TITLE
Sandbox the @testplot mention workflow and document the trade-off

### DIFF
--- a/.github/workflows/testplot-mention.yml
+++ b/.github/workflows/testplot-mention.yml
@@ -8,6 +8,21 @@ name: testplot-mention
 # Plots are published to the same content-addressed `testplots` gallery
 # branch used by .github/workflows/testplot.yml so a single PR can
 # accumulate diagrams from both the label-driven and mention-driven flows.
+#
+# Job split to keep the PR's untrusted code away from repo write secrets:
+#   parse    — checks out `main` (trusted), runs the Haiku parser with
+#              CLAUDE_CODE_OAUTH_TOKEN, emits the parsed args as outputs.
+#   render   — checks out the PR head (untrusted), installs and runs the
+#              PR's testplots.py with no secrets in scope and only
+#              contents: read on the auto-token. Uploads the PNGs as an
+#              artifact.
+#   publish  — runs no PR code; downloads the artifact, pushes it to the
+#              gallery branch, and posts the inline-image PR comment.
+#
+# Trade-off: the parser's allow-list of plot keys is frozen to whatever
+# is on `main`. A PR that adds a new plot to tests/integration/testplots.py
+# can't be exercised via @testplot until the parser allow-list on `main`
+# also knows the new key.
 
 on:
   issue_comment:
@@ -17,15 +32,18 @@ env:
   GALLERY_BRANCH: testplots
 
 jobs:
-  render:
+  parse:
     if: >-
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@testplot')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
       issues: write
+      pull-requests: write
+    outputs:
+      sha: ${{ steps.pr.outputs.sha }}
+      args_json: ${{ steps.parse.outputs.args_json }}
+      note: ${{ steps.parse.outputs.note }}
     steps:
       - name: React to the mention
         uses: actions/github-script@v7
@@ -49,23 +67,15 @@ jobs:
               pull_number: context.issue.number,
             });
             core.setOutput('sha', pr.data.head.sha);
-            core.setOutput('ref', pr.data.head.ref);
 
-      - name: Checkout PR head
+      - name: Checkout main (trusted parser)
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.pr.outputs.sha }}
-          path: src
+          ref: main
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: src/pyproject.toml
-
-      - name: Install
-        working-directory: src
-        run: pip install -e .[fast-tsp,python-tsp]
 
       - uses: actions/setup-node@v4
         with:
@@ -76,32 +86,78 @@ jobs:
 
       - name: Parse mention via Haiku
         id: parse
-        working-directory: src
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          python .github/scripts/parse_testplot_mention.py > "${GITHUB_WORKSPACE}/_parsed.json"
-          cat "${GITHUB_WORKSPACE}/_parsed.json"
+          python .github/scripts/parse_testplot_mention.py > parsed.json
+          cat parsed.json
           {
+            echo "args_json=$(jq -c .args parsed.json)"
             echo "note<<EOF"
-            jq -r '.note' "${GITHUB_WORKSPACE}/_parsed.json"
+            jq -r '.note' parsed.json
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
+  render:
+    needs: parse
+    runs-on: ubuntu-latest
+    # Untrusted: PR code runs here. No secrets are referenced in any
+    # step env, and the auto-issued GITHUB_TOKEN gets only contents:read.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head (untrusted)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.parse.outputs.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: pip install -e .[fast-tsp,python-tsp]
+
       - name: Render phase diagrams
-        working-directory: src
+        env:
+          ARGS_JSON: ${{ needs.parse.outputs.args_json }}
         run: |
           set -euxo pipefail
-          mapfile -t ARGS < <(jq -r '.args[]' "${GITHUB_WORKSPACE}/_parsed.json")
-          python tests/integration/testplots.py --out "${GITHUB_WORKSPACE}/_plots" "${ARGS[@]}"
+          mapfile -t ARGS < <(echo "$ARGS_JSON" | jq -r '.[]')
+          mkdir -p _plots
+          python tests/integration/testplots.py --out _plots "${ARGS[@]}"
+
+      - name: Upload rendered PNGs
+        uses: actions/upload-artifact@v4
+        with:
+          name: testplot-renders
+          path: _plots
+          retention-days: 7
+
+  publish:
+    needs: [parse, render]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download rendered PNGs
+        uses: actions/download-artifact@v4
+        with:
+          name: testplot-renders
+          path: _plots
 
       - name: Publish plots to ${{ env.GALLERY_BRANCH }} branch
-        id: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ needs.parse.outputs.sha }}
         run: |
           set -euxo pipefail
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -132,16 +188,16 @@ jobs:
           if git diff --cached --quiet; then
             echo "all plots already published; nothing to commit"
           else
-            git commit -m "testplots @ ${GITHUB_SHA} (mention)"
+            git commit -m "testplots @ ${HEAD_SHA} (mention)"
             git push origin "$GALLERY_BRANCH"
           fi
 
       - name: Post comment with images
         uses: actions/github-script@v7
         env:
-          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+          HEAD_SHA: ${{ needs.parse.outputs.sha }}
           GALLERY_BRANCH: ${{ env.GALLERY_BRANCH }}
-          NOTE: ${{ steps.parse.outputs.note }}
+          NOTE: ${{ needs.parse.outputs.note }}
           TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
         with:
           script: |

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -9,21 +9,19 @@ landau plot is hard to formalise so we instead post the rendered figures
 on PRs labeled ``testplot`` (or mentioned with ``@testplot``) and review
 them by eye.
 
-Known issue (security / UX trade-off):
+Known issue (UX trade-off):
 
-The ``@testplot`` mention workflow checks out the PR head and runs both
-this script *and* ``.github/scripts/parse_testplot_mention.py`` with the
-repo's ``CLAUDE_CODE_OAUTH_TOKEN`` and a write-scoped ``GITHUB_TOKEN`` in
-scope. That is the classic "pwn request" pattern — an outside contributor
-can put anything in those files and have it run with secrets.
+The ``@testplot`` mention workflow is split into three jobs so PR code
+never runs in the same context as the Haiku OAuth token or a write-scoped
+``GITHUB_TOKEN``: ``parse`` checks out ``main`` (trusted parser, has the
+Claude secret), ``render`` checks out the PR head (untrusted code, no
+secrets, ``contents: read``), and ``publish`` runs no PR code at all.
 
-The natural fix is to run the parser from a trusted ``main`` checkout and
-render PR code in a no-secrets sandbox job. The downside is that the
-parser's allow-list of plot keys is then frozen to ``main``: any PR that
-adds a new plot here can't be exercised via ``@testplot`` until it lands.
-We're leaving the more permissive setup in place for now since the repo
-only takes maintainer-pushed branches; revisit before opening to outside
-contributors.
+The cost of that split is that the parser's allow-list of plot keys is
+frozen to ``main``. A PR that adds a new plot here can't be exercised
+via ``@testplot`` until the parser allow-list on ``main`` is updated to
+know the new key. The workaround is to land a small parser-only PR
+first, then the plot PR.
 """
 from __future__ import annotations
 

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -8,6 +8,22 @@ The script is intentionally not a pytest test: the "correctness" of a
 landau plot is hard to formalise so we instead post the rendered figures
 on PRs labeled ``testplot`` (or mentioned with ``@testplot``) and review
 them by eye.
+
+Known issue (security / UX trade-off):
+
+The ``@testplot`` mention workflow checks out the PR head and runs both
+this script *and* ``.github/scripts/parse_testplot_mention.py`` with the
+repo's ``CLAUDE_CODE_OAUTH_TOKEN`` and a write-scoped ``GITHUB_TOKEN`` in
+scope. That is the classic "pwn request" pattern — an outside contributor
+can put anything in those files and have it run with secrets.
+
+The natural fix is to run the parser from a trusted ``main`` checkout and
+render PR code in a no-secrets sandbox job. The downside is that the
+parser's allow-list of plot keys is then frozen to ``main``: any PR that
+adds a new plot here can't be exercised via ``@testplot`` until it lands.
+We're leaving the more permissive setup in place for now since the repo
+only takes maintainer-pushed branches; revisit before opening to outside
+contributors.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Splits the `@testplot` mention workflow into three jobs so PR-controlled code never runs in the same context as repo write secrets, and updates the docstring in `tests/integration/testplots.py` to record the resulting trade-off.

## Workflow split

- `parse` — checks out `main`, installs the Claude Code CLI, runs `.github/scripts/parse_testplot_mention.py` with `CLAUDE_CODE_OAUTH_TOKEN` and the comment body. Emits `sha`, `args_json`, and `note` as job outputs.
- `render` — checks out the PR head with `persist-credentials: false`, declares `permissions: contents: read`, and runs `pip install -e .[fast-tsp,python-tsp]` + `python tests/integration/testplots.py` against the PR's code. No secrets are referenced in any step env. Uploads `_plots/` as an artifact.
- `publish` — downloads the artifact, clones the repo with `GITHUB_TOKEN`, pushes the PNGs to the `testplots` gallery branch, and posts the inline-image comment. Runs no PR code.

## Trade-off (documented in `testplots.py`)

Parser allow-list of plot keys is frozen to `main`. A PR that adds a new plot to `testplots.py` can't be exercised via `@testplot` until a parser-only PR lands the new key on `main` first.

## Test plan

- [x] yaml parses; `jq -c` round-trip of `args_json` works for empty and populated arg lists
- [x] `permissions: contents: read` on the `render` job; no `secrets.*` references in any of its step envs
- [ ] Land and exercise `@testplot 2d fasttsp` on a follow-up PR; confirm the artifact handoff between `render` and `publish` and the published comment
