### PR TITLE
Diff @testplot output against main when the mention asks for it

### DIFF
--- a/.github/scripts/parse_testplot_mention.py
+++ b/.github/scripts/parse_testplot_mention.py
@@ -4,11 +4,14 @@ Reads the comment body from ``$COMMENT_BODY`` and pipes it through the
 ``claude`` CLI (Claude Code), which must respond with a single JSON
 object of the form::
 
-    {"args": ["--only", "1d_T", "--poly-method", "fasttsp"], "note": "..."}
+    {"args": ["--only", "1d_T", "--poly-method", "fasttsp"],
+     "note": "...", "diff": false}
 
 The ``args`` list is shell-splattered into ``python tests/integration/testplots.py``
 by the calling workflow. ``note`` is a short human-readable summary that gets
-echoed back in the PR comment.
+echoed back in the PR comment. ``diff`` is a boolean: when true the workflow
+also renders the same args against ``main`` and posts a side-by-side
+comparison.
 
 Authenticated via ``$CLAUDE_CODE_OAUTH_TOKEN`` (same secret the existing
 .github/workflows/claude.yml uses). The script is invoked by
@@ -68,9 +71,15 @@ Mapping conventions:
   - "with and without tielines" / "both tieline modes" -> --tielines on off
   - "everything" / "all plots" / bare `@testplot` -> no extra args (renders every plot once)
 
+Diff mode:
+  Set `"diff": true` when the user wants a side-by-side comparison against
+  `main`. Triggers: "diff", "diff main", "vs main", "compare with main",
+  "before/after", "side by side", "regression". Otherwise omit the field
+  or set it to false.
+
 Respond with a single JSON object and NOTHING else (no prose, no code fences):
 
-  {{"args": ["--only", "1d_T"], "note": "1D T diagram"}}
+  {{"args": ["--only", "1d_T"], "note": "1D T diagram", "diff": false}}
 
 `args` is a flat list of strings to be passed to argparse. `note` is a short
 human-readable summary (under 80 chars). Do not include `--out`; the workflow
@@ -108,7 +117,10 @@ def _validate(payload: dict) -> dict:
     note = payload.get("note", "")
     if not isinstance(note, str):
         raise ValueError(f"note must be a string, got {note!r}")
-    return {"args": args, "note": note[:200]}
+    diff = payload.get("diff", False)
+    if not isinstance(diff, bool):
+        raise ValueError(f"diff must be a bool, got {diff!r}")
+    return {"args": args, "note": note[:200], "diff": diff}
 
 
 def _call_claude(body: str) -> str:
@@ -132,7 +144,7 @@ def _call_claude(body: str) -> str:
 def main() -> None:
     body = os.environ.get("COMMENT_BODY", "").strip()
     if not body:
-        print(json.dumps({"args": [], "note": "empty mention; rendering all plots"}))
+        print(json.dumps({"args": [], "note": "empty mention; rendering all plots", "diff": False}))
         return
 
     text = _call_claude(body)

--- a/.github/workflows/testplot-mention.yml
+++ b/.github/workflows/testplot-mention.yml
@@ -10,14 +10,20 @@ name: testplot-mention
 # accumulate diagrams from both the label-driven and mention-driven flows.
 #
 # Job split to keep the PR's untrusted code away from repo write secrets:
-#   parse    — checks out `main` (trusted), runs the Haiku parser with
-#              CLAUDE_CODE_OAUTH_TOKEN, emits the parsed args as outputs.
-#   render   — checks out the PR head (untrusted), installs and runs the
-#              PR's testplots.py with no secrets in scope and only
-#              contents: read on the auto-token. Uploads the PNGs as an
-#              artifact.
-#   publish  — runs no PR code; downloads the artifact, pushes it to the
-#              gallery branch, and posts the inline-image PR comment.
+#   parse        — checks out `main` (trusted), runs the Haiku parser with
+#                  CLAUDE_CODE_OAUTH_TOKEN, emits the parsed args + a
+#                  `diff` flag as outputs.
+#   render-pr    — checks out the PR head (untrusted), installs and runs
+#                  the PR's testplots.py with no secrets in scope and only
+#                  contents: read on the auto-token. Uploads PNGs as
+#                  artifact `testplot-renders-pr`.
+#   render-main  — same as render-pr but checks out `main`. Only runs
+#                  when the parser sets diff=true; produces artifact
+#                  `testplot-renders-main` for side-by-side comparison.
+#   publish      — runs no PR code; downloads available artifacts, pushes
+#                  them to the gallery branch under <PR>/<target>/, and
+#                  posts the comment (side-by-side when both targets
+#                  rendered, single-image otherwise).
 #
 # Trade-off: the parser's allow-list of plot keys is frozen to whatever
 # is on `main`. A PR that adds a new plot to tests/integration/testplots.py
@@ -44,6 +50,7 @@ jobs:
       sha: ${{ steps.pr.outputs.sha }}
       args_json: ${{ steps.parse.outputs.args_json }}
       note: ${{ steps.parse.outputs.note }}
+      diff: ${{ steps.parse.outputs.diff }}
     steps:
       - name: React to the mention
         uses: actions/github-script@v7
@@ -95,16 +102,15 @@ jobs:
           cat parsed.json
           {
             echo "args_json=$(jq -c .args parsed.json)"
+            echo "diff=$(jq -r '.diff // false' parsed.json)"
             echo "note<<EOF"
             jq -r '.note' parsed.json
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
-  render:
+  render-pr:
     needs: parse
     runs-on: ubuntu-latest
-    # Untrusted: PR code runs here. No secrets are referenced in any
-    # step env, and the auto-issued GITHUB_TOKEN gets only contents:read.
     permissions:
       contents: read
     steps:
@@ -135,23 +141,63 @@ jobs:
       - name: Upload rendered PNGs
         uses: actions/upload-artifact@v4
         with:
-          name: testplot-renders
+          name: testplot-renders-pr
+          path: _plots
+          retention-days: 7
+
+  render-main:
+    needs: parse
+    if: needs.parse.outputs.diff == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout main baseline
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: pip install -e .[fast-tsp,python-tsp]
+
+      - name: Render phase diagrams
+        env:
+          ARGS_JSON: ${{ needs.parse.outputs.args_json }}
+        run: |
+          set -euxo pipefail
+          mapfile -t ARGS < <(echo "$ARGS_JSON" | jq -r '.[]')
+          mkdir -p _plots
+          python tests/integration/testplots.py --out _plots "${ARGS[@]}"
+
+      - name: Upload rendered PNGs
+        uses: actions/upload-artifact@v4
+        with:
+          name: testplot-renders-main
           path: _plots
           retention-days: 7
 
   publish:
-    needs: [parse, render]
+    needs: [parse, render-pr, render-main]
+    # render-main is skipped when diff=false; still publish in that case.
+    if: always() && needs['render-pr'].result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
       pull-requests: write
     steps:
-      - name: Download rendered PNGs
+      - name: Download rendered PNGs (all targets)
         uses: actions/download-artifact@v4
         with:
-          name: testplot-renders
-          path: _plots
+          pattern: testplot-renders-*
+          path: _renders
 
       - name: Publish plots to ${{ env.GALLERY_BRANCH }} branch
         env:
@@ -176,13 +222,19 @@ jobs:
             git commit -m "init $GALLERY_BRANCH branch"
           fi
           mkdir -p "$PR"
-          : > "${GITHUB_WORKSPACE}/_plot_paths.txt"
-          for f in "${GITHUB_WORKSPACE}"/_plots/*.png; do
-            name=$(basename "$f" .png)
-            sha=$(sha256sum "$f" | cut -c1-16)
-            rel="${PR}/${sha}-${name}.png"
-            cp "$f" "$rel"
-            echo "$rel" >> "${GITHUB_WORKSPACE}/_plot_paths.txt"
+          : > "${GITHUB_WORKSPACE}/_manifest.tsv"
+          for tdir in "${GITHUB_WORKSPACE}"/_renders/testplot-renders-*; do
+            [ -d "$tdir" ] || continue
+            target="${tdir##*/testplot-renders-}"
+            mkdir -p "${PR}/${target}"
+            for f in "$tdir"/*.png; do
+              [ -e "$f" ] || continue
+              name=$(basename "$f" .png)
+              sha=$(sha256sum "$f" | cut -c1-16)
+              rel="${PR}/${target}/${sha}-${name}.png"
+              cp "$f" "$rel"
+              printf '%s\t%s\t%s\n' "$target" "$name" "$rel" >> "${GITHUB_WORKSPACE}/_manifest.tsv"
+            done
           done
           git add "$PR"
           if git diff --cached --quiet; then
@@ -198,26 +250,42 @@ jobs:
           HEAD_SHA: ${{ needs.parse.outputs.sha }}
           GALLERY_BRANCH: ${{ env.GALLERY_BRANCH }}
           NOTE: ${{ needs.parse.outputs.note }}
+          DIFF: ${{ needs.parse.outputs.diff }}
           TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
         with:
           script: |
             const fs = require('fs');
-            const paths = fs.readFileSync('_plot_paths.txt', 'utf8')
-              .split('\n').filter(Boolean).sort();
+            const rows = fs.readFileSync('_manifest.tsv', 'utf8')
+              .split('\n').filter(Boolean)
+              .map(l => l.split('\t'));
+            // group by plot name; each entry maps target ('pr'/'main') -> gallery path
+            const byName = {};
+            for (const [target, name, rel] of rows) {
+              (byName[name] ??= {})[target] = rel;
+            }
             const short = process.env.HEAD_SHA.slice(0, 7);
             const base = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/${process.env.GALLERY_BRANCH}`;
+            const isDiff = process.env.DIFF === 'true';
             const lines = [
-              `### Test plots for \`${short}\` ([mention](${process.env.TRIGGER_COMMENT_URL}))`,
+              `### Test plots for \`${short}\` ([mention](${process.env.TRIGGER_COMMENT_URL}))${isDiff ? ' — vs `main`' : ''}`,
               '',
               `_${process.env.NOTE || 'rendered via @testplot mention'}_`,
               '',
             ];
-            for (const rel of paths) {
-              const file = rel.split('/').pop();
-              const name = file.replace(/^[0-9a-f]+-/, '').replace(/\.png$/, '');
+            for (const name of Object.keys(byName).sort()) {
+              const entries = byName[name];
               lines.push(`#### ${name}`);
               lines.push('');
-              lines.push(`<img alt="${name}" src="${base}/${rel}" width="600">`);
+              if (entries.pr && entries.main) {
+                lines.push('<table><tr><th>main</th><th>PR</th></tr><tr>');
+                lines.push(`<td><img alt="main:${name}" src="${base}/${entries.main}" width="450"></td>`);
+                lines.push(`<td><img alt="pr:${name}" src="${base}/${entries.pr}" width="450"></td>`);
+                lines.push('</tr></table>');
+              } else {
+                const [target, rel] = Object.entries(entries)[0];
+                const tag = target === 'pr' ? '' : ` (${target})`;
+                lines.push(`<img alt="${name}${tag}" src="${base}/${rel}" width="600">`);
+              }
               lines.push('');
             }
             await github.rest.issues.createComment({


### PR DESCRIPTION
First of two follow-ups from the planning discussion. Adds optional diff-vs-main rendering to the `@testplot` mention flow.

## Trigger

The parser system prompt learns "diff", "vs main", "compare with main", "side by side", "before/after", "regression". When any of those appears, Haiku adds `"diff": true` to its JSON output; otherwise it's `false`/absent.

Examples:
- `@testplot 2d fasttsp vs main` → render 2D plots with fasttsp on PR head *and* main, side-by-side
- `@testplot diff` → all six plots side-by-side
- `@testplot 2d toy` → unchanged single-target behavior

## Workflow

The single `render` job splits in two:
- `render-pr` always runs (PR head, untrusted, `contents: read`, no secrets)
- `render-main` runs only when `needs.parse.outputs.diff == 'true'` (main, same sandbox shape)

Each uploads a distinct artifact (`testplot-renders-pr`, `testplot-renders-main`). `publish` uses `if: always() && needs['render-pr'].result == 'success'` so a failed/skipped `render-main` doesn't block PR-only output, and downloads via `pattern: testplot-renders-*` to pick up whatever's available.

## Comment format

Gallery paths gain a target subdir: `<PR>/<target>/<sha16>-<name>.png`. The comment-build step groups by plot name and emits a `<table>` row with two columns when both targets rendered, falling back to a single `<img>` when only one did.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` — YAML still parses
- [x] Validator round-trip: `_validate({"args": ["--only", "2d_basics"], "note": "x", "diff": True})` accepts; non-bool diff is rejected
- [ ] Trigger `@testplot 2d toy vs main` on a follow-up PR; confirm the side-by-side comment renders
- [ ] Trigger `@testplot 2d toy` (no diff) on the same PR; confirm single-image fallback still works


---
_Generated by [Claude Code](https://claude.ai/code/session_011TptP76r9xb5eAXL1mgErD)_