### PR TITLE
Diff-aware plot selection on the `testplot` label

### DIFF
--- a/.github/scripts/select_testplot_args_from_diff.py
+++ b/.github/scripts/select_testplot_args_from_diff.py
@@ -1,0 +1,143 @@
+"""Pick testplots.py args for a PR based on which files it changed.
+
+Reads ``$CHANGED_FILES`` (newline-separated repo-relative paths) and pipes
+it through the ``claude`` CLI to choose which plots and poly methods are
+worth rendering. Output is the same JSON shape consumed by
+.github/workflows/testplot.yml's render step::
+
+    {"args": ["--only", "2d_basics", "--poly-method", "fasttsp"],
+     "note": "...", "diff": false}
+
+The validator is intentionally identical to parse_testplot_mention.py's
+allow-list: same plot keys, same poly methods, same tieline values. If
+the model emits anything else the script errors out instead of letting
+arbitrary tokens reach argparse.
+
+Authenticated via ``$CLAUDE_CODE_OAUTH_TOKEN``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+PLOT_NAMES = ["1d_T", "1d_mu", "2d_basics", "2d_basics_mu", "2d_toy", "2d_toy_mu"]
+POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
+
+SYSTEM = f"""You pick which phase-diagram tests to render for a PR.
+
+The script tests/integration/testplots.py renders these plots:
+  1d_T         : 1D temperature diagram (pure-A line phases)
+  1d_mu        : 1D chemical-potential diagram (ideal solutions)
+  2d_basics    : 2D c-T diagram (ideal-solution hcp/fcc/liquid)
+  2d_basics_mu : 2D T-mu diagram (same phases as 2d_basics)
+  2d_toy       : 2D c-T diagram (regular-solution liquid + intermediate solid)
+  2d_toy_mu    : 2D T-mu diagram (same phases as 2d_toy)
+
+Flags you can emit:
+  --only <plot> [...]                     subset of plots (omit = all 6)
+  --poly-method <method> [...]            cross-product over the 2D plots;
+                                          choices: {','.join(POLY_METHODS)}
+  --tielines on|off [...]                 tieline modes on 2D c-T plots
+
+Heuristics from changed file paths:
+  - landau/poly.py touched
+      → render all four 2D plots
+      → --poly-method fasttsp tsp segment-fasttsp segment-tsp
+        (skip "concave" / "segments" unless the change explicitly affects them)
+  - landau/plot.py touched
+      → all six plots (no extra flags)
+  - landau/phases.py or landau/calculate.py touched
+      → all six plots (no extra flags)
+  - landau/interpolate/** touched
+      → --only 2d_toy 2d_toy_mu (toy uses interpolators; basics doesn't)
+  - tests/integration/testplots.py touched
+      → all six plots (the test itself changed)
+  - only docs/, *.md, *.cfg, pyproject.toml, .github/** touched
+      → minimal smoke test: --only 1d_T 2d_basics
+  - mix of the above
+      → take the union; prefer the broader set when a specific rule and an
+        "all plots" rule both apply
+
+Respond with a single JSON object and NOTHING else (no prose, no code fences):
+
+  {{"args": ["--only", "2d_basics", "2d_basics_mu", "2d_toy", "2d_toy_mu",
+            "--poly-method", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"],
+   "note": "poly.py touched: all 2D × tsp variants", "diff": false}}
+
+`args` is flat list of argparse tokens. `note` is a short one-line summary
+(under 100 chars) explaining what was selected and why. Do not include
+`--out`. `diff` should stay false in this script (the label-driven flow
+doesn't do side-by-side renders yet); always include the key.
+"""
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_json(text: str) -> dict:
+    match = _JSON_RE.search(text)
+    if not match:
+        raise ValueError(f"no JSON object in model output: {text!r}")
+    return json.loads(match.group(0))
+
+
+def _validate(payload: dict) -> dict:
+    args = payload.get("args", [])
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        raise ValueError(f"args must be a list of strings, got {args!r}")
+    allowed_values = (
+        set(PLOT_NAMES)
+        | set(POLY_METHODS)
+        | {"on", "off"}
+        | {"--only", "--poly-method", "--tielines"}
+    )
+    for a in args:
+        if a.startswith("--"):
+            if a not in allowed_values:
+                raise ValueError(f"disallowed flag in args: {a!r}")
+        else:
+            if a not in allowed_values:
+                raise ValueError(f"disallowed value in args: {a!r}")
+    note = payload.get("note", "")
+    if not isinstance(note, str):
+        raise ValueError(f"note must be a string, got {note!r}")
+    diff = payload.get("diff", False)
+    if not isinstance(diff, bool):
+        raise ValueError(f"diff must be a bool, got {diff!r}")
+    return {"args": args, "note": note[:200], "diff": diff}
+
+
+def _call_claude(changed_files: str) -> str:
+    user_msg = "Changed files in this PR:\n" + changed_files
+    result = subprocess.run(
+        [
+            "claude",
+            "--model", "claude-haiku-4-5-20251001",
+            "--append-system-prompt", SYSTEM,
+            "--output-format", "text",
+            "--permission-mode", "plan",
+            "-p", user_msg,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return result.stdout
+
+
+def main() -> None:
+    changed = os.environ.get("CHANGED_FILES", "").strip()
+    if not changed:
+        print(json.dumps({"args": [], "note": "no changed files reported; rendering all plots", "diff": False}))
+        return
+
+    text = _call_claude(changed)
+    payload = _validate(_extract_json(text))
+    json.dump(payload, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/testplot.yml
+++ b/.github/workflows/testplot.yml
@@ -1,15 +1,16 @@
 name: testplot
 
-# Render reference phase diagrams and post them on the PR so reviewers
-# can eyeball them. The "correctness" of a landau plot is hard to
-# formalise in a unit test, so we trigger this on demand by adding the
-# `testplot` label to a PR.
+# Render reference phase diagrams when a PR is labeled `testplot`. Instead
+# of always rendering all six diagrams, the workflow pipes the PR's list
+# of changed files through Claude Haiku to choose a subset that's worth
+# eyeballing for this particular change (e.g. landau/poly.py touched ->
+# all 2D plots with all TSP poly methods).
 #
-# The rendered PNGs are committed to a dedicated orphan `testplots`
-# branch under <PR_NUMBER>/<short-content-sha>-<name>.png and then
-# referenced from a PR comment via raw.githubusercontent.com so they
-# render inline. This keeps the PR branch's commit history clean and
-# is idempotent: re-rendering identical plots reuses existing paths.
+# Job split mirrors testplot-mention.yml: a trusted `select` job runs the
+# Haiku selector from a main checkout with the Claude OAuth token; the
+# `render` job runs the PR's testplots.py in a no-secrets sandbox; and
+# `publish` pushes the PNGs to the orphan `testplots` gallery branch and
+# posts the inline-image comment.
 
 on:
   pull_request:
@@ -19,40 +20,118 @@ env:
   GALLERY_BRANCH: testplots
 
 jobs:
-  render:
+  select:
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'testplot') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'testplot'))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      pull-requests: read
+    outputs:
+      args_json: ${{ steps.select.outputs.args_json }}
+      note: ${{ steps.select.outputs.note }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout main (trusted selector)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: List changed files
+        id: files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const paths = files.map(f => f.filename).join('\n');
+            core.setOutput('paths', paths);
+
+      - name: Select args via Haiku
+        id: select
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CHANGED_FILES: ${{ steps.files.outputs.paths }}
+        run: |
+          set -euo pipefail
+          python .github/scripts/select_testplot_args_from_diff.py > parsed.json
+          cat parsed.json
+          {
+            echo "args_json=$(jq -c .args parsed.json)"
+            echo "note<<EOF"
+            jq -r '.note' parsed.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+  render:
+    needs: select
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head (untrusted)
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: src
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: src/pyproject.toml
+          cache-dependency-path: pyproject.toml
 
       - name: Install
-        working-directory: src
-        run: pip install -e .[fast-tsp]
+        run: pip install -e .[fast-tsp,python-tsp]
 
       - name: Render phase diagrams
-        working-directory: src
-        run: python tests/integration/testplots.py --out "${GITHUB_WORKSPACE}/_plots"
+        env:
+          ARGS_JSON: ${{ needs.select.outputs.args_json }}
+        run: |
+          set -euxo pipefail
+          mapfile -t ARGS < <(echo "$ARGS_JSON" | jq -r '.[]')
+          mkdir -p _plots
+          python tests/integration/testplots.py --out _plots "${ARGS[@]}"
+
+      - name: Upload rendered PNGs
+        uses: actions/upload-artifact@v4
+        with:
+          name: testplot-renders
+          path: _plots
+          retention-days: 7
+
+  publish:
+    needs: [select, render]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Download rendered PNGs
+        uses: actions/download-artifact@v4
+        with:
+          name: testplot-renders
+          path: _plots
 
       - name: Publish plots to ${{ env.GALLERY_BRANCH }} branch
-        id: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euxo pipefail
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -66,7 +145,7 @@ jobs:
           else
             git checkout --orphan "$GALLERY_BRANCH"
             git rm -rf . >/dev/null 2>&1 || true
-            printf '# Test plot gallery\n\nContent-addressed PNGs published by .github/workflows/testplot.yml.\n' > README.md
+            printf '# Test plot gallery\n\nContent-addressed PNGs published by .github/workflows/testplot*.yml.\n' > README.md
             git add README.md
             git commit -m "init $GALLERY_BRANCH branch"
           fi
@@ -83,7 +162,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "all plots already published; nothing to commit"
           else
-            git commit -m "testplots @ ${GITHUB_SHA}"
+            git commit -m "testplots @ ${HEAD_SHA}"
             git push origin "$GALLERY_BRANCH"
           fi
 
@@ -92,6 +171,7 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GALLERY_BRANCH: ${{ env.GALLERY_BRANCH }}
+          NOTE: ${{ needs.select.outputs.note }}
         with:
           script: |
             const fs = require('fs');
@@ -102,12 +182,11 @@ jobs:
             const lines = [
               `### Test plots for \`${short}\``,
               '',
-              `Rendered by \`tests/integration/testplots.py\`.`,
+              `_${process.env.NOTE || 'rendered by tests/integration/testplots.py'}_`,
               '',
             ];
             for (const rel of paths) {
               const file = rel.split('/').pop();
-              // file is <sha>-<name>.png; strip the sha prefix for the heading
               const name = file.replace(/^[0-9a-f]+-/, '').replace(/\.png$/, '');
               lines.push(`#### ${name}`);
               lines.push('');

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -11,17 +11,18 @@ them by eye.
 
 Known issue (UX trade-off):
 
-The ``@testplot`` mention workflow is split into three jobs so PR code
-never runs in the same context as the Haiku OAuth token or a write-scoped
-``GITHUB_TOKEN``: ``parse`` checks out ``main`` (trusted parser, has the
-Claude secret), ``render`` checks out the PR head (untrusted code, no
-secrets, ``contents: read``), and ``publish`` runs no PR code at all.
+Both the ``testplot`` label workflow and the ``@testplot`` mention
+workflow are split into three jobs so PR code never runs in the same
+context as the Haiku OAuth token or a write-scoped ``GITHUB_TOKEN``:
+``select`` / ``parse`` checks out ``main`` (trusted, has the Claude
+secret), ``render`` checks out the PR head (untrusted code, no secrets,
+``contents: read``), and ``publish`` runs no PR code at all.
 
-The cost of that split is that the parser's allow-list of plot keys is
+The cost of that split is that the Haiku allow-list of plot keys is
 frozen to ``main``. A PR that adds a new plot here can't be exercised
-via ``@testplot`` until the parser allow-list on ``main`` is updated to
-know the new key. The workaround is to land a small parser-only PR
-first, then the plot PR.
+via ``@testplot`` or the diff-aware label until the allow-lists on
+``main`` are updated to know the new key. The workaround is to land a
+small parser-only PR first, then the plot PR.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Second of two follow-ups from the planning discussion. Sibling to #150; independent of it. Makes the `testplot` label consult Haiku to pick a subset of plots based on what the PR changed, instead of always rendering all six.

## What's new

- `.github/scripts/select_testplot_args_from_diff.py` — reads `$CHANGED_FILES` (newline-separated repo paths), asks `claude-haiku-4-5-20251001` to map them to testplots.py args. System prompt encodes per-subsystem heuristics:
  - `landau/poly.py` → all 2D plots × the TSP poly methods
  - `landau/plot.py` / `phases.py` / `calculate.py` → all six plots
  - `landau/interpolate/**` → `2d_toy` + `2d_toy_mu` (toy uses interpolators; basics doesn't)
  - docs / config / `.github/**` only → smoke test (`1d_T` + `2d_basics`)
- Same validator allow-list shape as `parse_testplot_mention.py`: known plot keys, poly methods, on/off, three flag names. Anything else aborts before reaching argparse.

## Workflow shape

`testplot.yml` now mirrors `testplot-mention.yml`:
- `select` (main checkout) lists PR files via `pulls.listFiles`, runs the selector with `CLAUDE_CODE_OAUTH_TOKEN`. Emits `args_json` and `note`.
- `render` (PR head, `contents: read`, no secrets) runs `testplots.py` with the selected args, uploads artifact.
- `publish` (no PR code) pushes to the gallery branch and posts the comment, prefixing with the selector's one-line `note` so reviewers see why this subset was chosen.

## Trade-off

Same allow-list-frozen-to-main issue as the mention flow. Docstring in `testplots.py` is updated to say it applies to both workflows.

## Test plan

- [x] YAML loads (`yaml.safe_load`)
- [x] Validator round-trip and rejection of unknown flags
- [ ] Apply the `testplot` label to a follow-up PR touching only `landau/poly.py`; confirm the comment renders 2D × TSP methods with a relevant `note`
- [ ] Same on a PR touching only `docs/`; confirm the smoke-test subset

Future hook (not in this PR): when #150 lands, the selector can set `diff: true` for `poly.py`-touching PRs to get side-by-side automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_011TptP76r9xb5eAXL1mgErD)_