### PR TITLE
refactor(poly): extract _greedy_stitch from Segments._sort_segments

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -248,37 +248,8 @@ class Segments(AbstractPolyMethod):
                                           (s[x_col].mean() - com[x_col]) / norm[0])
         )
 
-        def start(s):
-            return s.iloc[0][[x_col, y_col]]
-
-        def end(s):
-            return s.iloc[-1][[x_col, y_col]]
-
-        def dist(p1, p2):
-            return np.linalg.norm((p2 - p1) / norm)
-
-        def flip(s):
-            s.reset_index(drop=True, inplace=True)
-            s.loc[:] = s.loc[::-1].reset_index(drop=True)
-            return s
-
-        head, *remaining = sorted(segments, key=lambda s: s[x_col].min())
-
-        def find_distance(head, segment):
-            head2tail = dist(end(head), start(segment))
-            tail2tail = dist(end(head), end(segment))
-            if tail2tail < head2tail:
-                flip(segment)
-                return tail2tail
-            else:
-                return head2tail
-
-        segments = [head]
-        while len(remaining) > 0:
-            head, *remaining = sorted(remaining, key=lambda s: find_distance(head, s))
-            segments.append(head)
-
-        return pd.concat(segments, ignore_index=True)
+        ordered = _greedy_stitch(segments, norm, x_col, y_col)
+        return pd.concat(ordered, ignore_index=True)
 
     def _make(self, pp: np.ndarray, border: np.ndarray, segment_label: np.ndarray) -> shapely.Geometry | None:
         """
@@ -305,6 +276,60 @@ class Segments(AbstractPolyMethod):
             return None
 
         return shapely.Polygon(coords)
+
+
+def _greedy_stitch(
+        segments: list[pd.DataFrame],
+        norm: np.ndarray,
+        x_col: str,
+        y_col: str,
+) -> list[pd.DataFrame]:
+    """Greedy nearest-neighbour ordering of pre-sorted border segments.
+
+    Starts from the segment with the smallest ``x_col`` value, then repeatedly
+    picks from the remaining segments the one whose closer endpoint is nearest
+    to the current head's tail. The picked segment is reversed in place when
+    its end is closer than its start. Distances are scaled by ``norm`` so that
+    ``x_col`` and ``y_col`` contribute on comparable scales.
+
+    Returns the segments in stitch order; each segment is the original
+    DataFrame, possibly with row order reversed. The caller concatenates.
+
+    Notes
+    -----
+    The min-``x_col`` head heuristic is documented to fail when a phase is
+    stable at the upper or lower edge of the diagram (where no proper
+    "segment" is computed); see :class:`Segments`.
+    """
+    if not segments:
+        return []
+
+    def endpoint(s, where):
+        return s.iloc[where][[x_col, y_col]]
+
+    def scaled_dist(p1, p2):
+        return np.linalg.norm((p2 - p1) / norm)
+
+    def flip(s):
+        s.reset_index(drop=True, inplace=True)
+        s.loc[:] = s.loc[::-1].reset_index(drop=True)
+        return s
+
+    def find_distance(head, segment):
+        head_tail = endpoint(head, -1)
+        head2tail = scaled_dist(head_tail, endpoint(segment, 0))
+        tail2tail = scaled_dist(head_tail, endpoint(segment, -1))
+        if tail2tail < head2tail:
+            flip(segment)
+            return tail2tail
+        return head2tail
+
+    head, *remaining = sorted(segments, key=lambda s: s[x_col].min())
+    ordered = [head]
+    while remaining:
+        head, *remaining = sorted(remaining, key=lambda s: find_distance(head, s))
+        ordered.append(head)
+    return ordered
 
 
 def _pca_sort_segment(pts: np.ndarray) -> np.ndarray:

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -1,6 +1,7 @@
+import numpy as np
 import pandas as pd
 from hypothesis import given, strategies as st, settings
-from landau.poly import Concave, Segments, handle_poly_method
+from landau.poly import Concave, Segments, _greedy_stitch, handle_poly_method
 import pytest
 from matplotlib.patches import Polygon
 
@@ -200,3 +201,95 @@ def test_handle_poly_method():
 
     with pytest.raises(TypeError):
         handle_poly_method(123)
+
+
+# --- _greedy_stitch tests ---
+
+
+def _segment(xs, ys):
+    return pd.DataFrame({"c": xs, "T": ys})
+
+
+@pytest.fixture
+def unit_norm():
+    return np.array([1.0, 1.0])
+
+
+def test_greedy_stitch_empty(unit_norm):
+    assert _greedy_stitch([], unit_norm, "c", "T") == []
+
+
+def test_greedy_stitch_single_segment_returns_unchanged(unit_norm):
+    seg = _segment([0.3, 0.4, 0.5], [10.0, 20.0, 30.0])
+    out = _greedy_stitch([seg], unit_norm, "c", "T")
+    assert len(out) == 1
+    pd.testing.assert_frame_equal(out[0], seg)
+
+
+def test_greedy_stitch_picks_min_x_as_head(unit_norm):
+    left = _segment([0.0, 0.1], [0.0, 0.0])
+    right = _segment([0.5, 0.6], [0.0, 0.0])
+    # right is passed first, but left has smaller min(x) and should lead
+    out = _greedy_stitch([right, left], unit_norm, "c", "T")
+    assert out[0] is left
+    assert out[1] is right
+
+
+def test_greedy_stitch_flips_segment_when_end_is_closer(unit_norm):
+    head = _segment([0.0, 0.1], [0.0, 0.0])  # head ends at (0.1, 0)
+    # Other goes from x=0.5 down to x=0.2. Its end (x=0.2) is closer to
+    # head's tail than its start (x=0.5) — should be flipped in place.
+    other = _segment([0.5, 0.4, 0.3, 0.2], [0.0, 0.0, 0.0, 0.0])
+    out = _greedy_stitch([head, other], unit_norm, "c", "T")
+    assert out[0] is head
+    assert out[1] is other
+    # other was flipped: now starts at the previously-final row
+    assert out[1].iloc[0]["c"] == pytest.approx(0.2)
+    assert out[1].iloc[-1]["c"] == pytest.approx(0.5)
+
+
+def test_greedy_stitch_no_flip_when_start_is_closer(unit_norm):
+    head = _segment([0.0, 0.1], [0.0, 0.0])
+    # Other starts at x=0.2 (close to head's tail) and ends at x=0.5 (far)
+    other = _segment([0.2, 0.3, 0.4, 0.5], [0.0, 0.0, 0.0, 0.0])
+    pre_flip = other.copy()
+    out = _greedy_stitch([head, other], unit_norm, "c", "T")
+    pd.testing.assert_frame_equal(out[1], pre_flip)
+
+
+def test_greedy_stitch_three_segments_orders_by_distance():
+    # head at x=[0,1], y=0; near segment touching head's tail; far segment
+    # further out. Expected order: head, near, far.
+    head = _segment([0.0, 1.0], [0.0, 0.0])
+    near = _segment([1.1, 2.0], [0.0, 0.0])
+    far = _segment([5.0, 6.0], [0.0, 0.0])
+    norm = np.array([1.0, 1.0])
+    out = _greedy_stitch([far, head, near], norm, "c", "T")
+    assert [s.iloc[0]["c"] for s in out] == pytest.approx([0.0, 1.1, 5.0])
+
+
+def test_greedy_stitch_norm_scales_axes():
+    # y dominates raw distance, but a large y-norm should make x dominate.
+    head = _segment([0.0, 0.1], [0.0, 0.0])  # head tail at (0.1, 0)
+    seg_a = _segment([0.2, 0.3], [100.0, 100.0])  # close in x, far in raw y
+    seg_b = _segment([5.0, 5.1], [0.5, 0.5])     # far in x, close in raw y
+    # With unit norm, seg_b wins (y matters more)
+    out_unit = _greedy_stitch(
+        [head, seg_a.copy(), seg_b.copy()], np.array([1.0, 1.0]), "c", "T"
+    )
+    assert out_unit[1].iloc[0]["c"] == pytest.approx(5.0)
+    # With y-norm large, y becomes irrelevant and seg_a (closer in x) wins
+    out_scaled = _greedy_stitch(
+        [head, seg_a.copy(), seg_b.copy()], np.array([1.0, 1000.0]), "c", "T"
+    )
+    assert out_scaled[1].iloc[0]["c"] == pytest.approx(0.2)
+
+
+def test_greedy_stitch_custom_columns(unit_norm):
+    # Sanity that the column names are honoured rather than hard-coded to c/T.
+    head = pd.DataFrame({"x": [0.0, 1.0], "y": [0.0, 0.0]})
+    other = pd.DataFrame({"x": [3.0, 2.0], "y": [0.0, 0.0]})  # ends at x=2, closer
+    out = _greedy_stitch([head, other], unit_norm, "x", "y")
+    assert out[0] is head
+    # other should have been flipped to start at x=2
+    assert out[1].iloc[0]["x"] == pytest.approx(2.0)


### PR DESCRIPTION
Pulls the min-x head + nearest-endpoint greedy ordering out of
`Segments._sort_segments` into a module-level `_greedy_stitch` helper.
`_sort_segments` keeps the per-segment PCA sort and the COM-angle
pre-sort and just delegates the final stitching loop.

Behaviour unchanged. The PCA-sorted segments fed in are the same objects
that come back out (possibly with row order reversed in place via the
existing `flip`), so `pd.concat` in `_sort_segments` sees the same
sequence as before.

The umbrella refactor issue #116 backlog flagged this exact extraction:
> `landau/poly.py:Segments._sort_segments` mixes PCA projection, segment
> ordering by COM angle, and a greedy stitching loop in one ~60-line
> static method with three nested closures. [...] a smaller intermediate
> step is to extract `_greedy_stitch(segments, norm)` into a free
> function.

## Tests

New unit tests under `tests/unit/test_poly.py` cover the helper in
isolation:

- empty input → empty output
- single segment → unchanged
- min-x head selection (input order shuffled)
- in-place flip when an endpoint is closer than the start
- no flip when the start is closer
- three-segment greedy ordering by tail-to-endpoint distance
- `norm` actually scales the two axes
- helper honours custom `x_col`/`y_col` rather than hard-coding `c`/`T`

Existing `Segments`/`SegmentPythonTsp`/`SegmentFastTsp` hypothesis
tests continue to pass.

Refs #116.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty9w5erdqXPFbDJkEPnZqz)_