### PR TITLE
test(calculate): cover _split_stable, _border_edges, reduce, cluster

### DIFF
--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -231,7 +231,8 @@ def test_guess_mu_range_degenerate_raises():
 # --- _split_stable tests ---
 
 
-def _stable_unstable_frame():
+@pytest.fixture
+def stable_unstable_frame():
     return pd.DataFrame(
         {
             "T": [300.0, 400.0, 500.0, 600.0],
@@ -243,23 +244,23 @@ def _stable_unstable_frame():
     )
 
 
-def test_split_stable_partitions_by_stable_flag():
-    df = _stable_unstable_frame()
+def test_split_stable_partitions_by_stable_flag(stable_unstable_frame):
+    df = stable_unstable_frame
     sdf, udf = _split_stable(df)
     assert sdf["stable"].all()
     assert not udf["stable"].any()
     assert len(sdf) + len(udf) == len(df)
 
 
-def test_split_stable_resets_index():
-    df = _stable_unstable_frame().iloc[[3, 2, 1, 0]]  # shuffle source index
+def test_split_stable_resets_index(stable_unstable_frame):
+    df = stable_unstable_frame.iloc[[3, 2, 1, 0]]  # shuffle source index
     sdf, udf = _split_stable(df)
     assert list(sdf.index) == list(range(len(sdf)))
     assert list(udf.index) == list(range(len(udf)))
 
 
-def test_split_stable_adds_border_and_refined_columns():
-    df = _stable_unstable_frame()
+def test_split_stable_adds_border_and_refined_columns(stable_unstable_frame):
+    df = stable_unstable_frame
     sdf, udf = _split_stable(df)
     # both halves get a border=False column
     assert (sdf["border"] == False).all()  # noqa: E712
@@ -269,8 +270,8 @@ def test_split_stable_adds_border_and_refined_columns():
     assert "refined" not in udf.columns
 
 
-def test_split_stable_does_not_mutate_input():
-    df = _stable_unstable_frame()
+def test_split_stable_does_not_mutate_input(stable_unstable_frame):
+    df = stable_unstable_frame
     before = df.copy()
     _split_stable(df)
     pd.testing.assert_frame_equal(df, before)
@@ -279,7 +280,8 @@ def test_split_stable_does_not_mutate_input():
 # --- _border_edges tests ---
 
 
-def _grid_frame():
+@pytest.fixture
+def grid_frame():
     """A small (T, mu) grid with two phases; mimics the post-_split_stable
     `sdf` that `refine_phase_diagram` feeds into `_border_edges`."""
     Ts = [300.0, 400.0, 500.0]
@@ -291,16 +293,16 @@ def _grid_frame():
     return pd.DataFrame(rows)
 
 
-def test_border_edges_marks_T_extremes_in_place():
-    df = _grid_frame()
+def test_border_edges_marks_T_extremes_in_place(grid_frame):
+    df = grid_frame
     _border_edges(df, min_c=0.0, max_c=1.0)
     assert df.loc[df["T"] == 300.0, "border"].all()
     assert df.loc[df["T"] == 500.0, "border"].all()
     assert not df.loc[df["T"] == 400.0, "border"].any()
 
 
-def test_border_edges_left_right_use_extreme_mu_rows():
-    df = _grid_frame()
+def test_border_edges_left_right_use_extreme_mu_rows(grid_frame):
+    df = grid_frame
     left, right = _border_edges(df, min_c=0.05, max_c=0.95)
     # one synthetic row per (phase, T) at each mu extreme — here one phase × 3 Ts
     assert len(left) == 3
@@ -315,8 +317,8 @@ def test_border_edges_left_right_use_extreme_mu_rows():
     assert (right["stable"] == True).all()  # noqa: E712
 
 
-def test_border_edges_preserves_T_and_phase_from_source():
-    df = _grid_frame()
+def test_border_edges_preserves_T_and_phase_from_source(grid_frame):
+    df = grid_frame
     left, right = _border_edges(df, min_c=0.0, max_c=1.0)
     # the source rows at the extreme mu values are at all three Ts, single phase A
     assert sorted(left["T"].tolist()) == [300.0, 400.0, 500.0]
@@ -329,12 +331,13 @@ def test_border_edges_preserves_T_and_phase_from_source():
 
 
 def test_reduce_joins_phase_names_sorted_by_c():
-    # rows deliberately out of c order to verify sort_values("c") happens first
+    # rows deliberately out of c order; transition string must reflect ascending-c sort
     dd = pd.DataFrame({"phase": ["liq", "fcc", "bcc"], "c": [0.7, 0.2, 0.5]})
+    phases_by_c = dd.sort_values("c")["phase"].tolist()
     out = reduce(dd)
-    assert out["transition"] == "fcc-bcc-liq"
-    assert out["c"] == [0.2, 0.5, 0.7]
-    assert out["phase"] == ["fcc", "bcc", "liq"]
+    assert out["transition"] == "-".join(phases_by_c)
+    assert out["c"] == sorted(dd["c"].tolist())
+    assert out["phase"] == phases_by_c
 
 
 def test_reduce_single_phase_no_dash():

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -4,10 +4,14 @@ import pandas as pd
 from hypothesis import given, strategies as st
 from landau.calculate import (
     find_one_point,
+    cluster,
     cluster_T_c,
     cluster_T_c_mu,
+    reduce,
+    _border_edges,
     _join_phase_unit,
     _split_phase_unit,
+    _split_stable,
     guess_mu_range,
 )
 from unittest.mock import MagicMock
@@ -222,3 +226,141 @@ def test_guess_mu_range_degenerate_raises():
     b = LinePhase("B", 0.5, 0.1, 0)
     with pytest.raises(ValueError):
         guess_mu_range([a, b], T=1000, samples=_GMR_SAMPLES)
+
+
+# --- _split_stable tests ---
+
+
+def _stable_unstable_frame():
+    return pd.DataFrame(
+        {
+            "T": [300.0, 400.0, 500.0, 600.0],
+            "mu": [0.0, 0.1, 0.2, 0.3],
+            "c":  [0.1, 0.2, 0.3, 0.4],
+            "phase": ["A", "B", "A", "B"],
+            "stable": [True, False, True, False],
+        }
+    )
+
+
+def test_split_stable_partitions_by_stable_flag():
+    df = _stable_unstable_frame()
+    sdf, udf = _split_stable(df)
+    assert sdf["stable"].all()
+    assert not udf["stable"].any()
+    assert len(sdf) + len(udf) == len(df)
+
+
+def test_split_stable_resets_index():
+    df = _stable_unstable_frame().iloc[[3, 2, 1, 0]]  # shuffle source index
+    sdf, udf = _split_stable(df)
+    assert list(sdf.index) == list(range(len(sdf)))
+    assert list(udf.index) == list(range(len(udf)))
+
+
+def test_split_stable_adds_border_and_refined_columns():
+    df = _stable_unstable_frame()
+    sdf, udf = _split_stable(df)
+    # both halves get a border=False column
+    assert (sdf["border"] == False).all()  # noqa: E712
+    assert (udf["border"] == False).all()  # noqa: E712
+    # only the stable half gets refined="no"
+    assert (sdf["refined"] == "no").all()
+    assert "refined" not in udf.columns
+
+
+def test_split_stable_does_not_mutate_input():
+    df = _stable_unstable_frame()
+    before = df.copy()
+    _split_stable(df)
+    pd.testing.assert_frame_equal(df, before)
+
+
+# --- _border_edges tests ---
+
+
+def _grid_frame():
+    """A small (T, mu) grid with two phases; mimics the post-_split_stable
+    `sdf` that `refine_phase_diagram` feeds into `_border_edges`."""
+    Ts = [300.0, 400.0, 500.0]
+    mus = [-0.5, 0.0, 0.5]
+    rows = []
+    for T in Ts:
+        for mu in mus:
+            rows.append({"T": T, "mu": mu, "c": 0.5, "phase": "A", "border": False})
+    return pd.DataFrame(rows)
+
+
+def test_border_edges_marks_T_extremes_in_place():
+    df = _grid_frame()
+    _border_edges(df, min_c=0.0, max_c=1.0)
+    assert df.loc[df["T"] == 300.0, "border"].all()
+    assert df.loc[df["T"] == 500.0, "border"].all()
+    assert not df.loc[df["T"] == 400.0, "border"].any()
+
+
+def test_border_edges_left_right_use_extreme_mu_rows():
+    df = _grid_frame()
+    left, right = _border_edges(df, min_c=0.05, max_c=0.95)
+    # one synthetic row per (phase, T) at each mu extreme — here one phase × 3 Ts
+    assert len(left) == 3
+    assert len(right) == 3
+    assert (left["mu"] == -np.inf).all()
+    assert (right["mu"] == +np.inf).all()
+    assert (left["c"] == 0.05).all()
+    assert (right["c"] == 0.95).all()
+    assert (left["border"] == True).all()  # noqa: E712
+    assert (right["border"] == True).all()  # noqa: E712
+    assert (left["stable"] == True).all()  # noqa: E712
+    assert (right["stable"] == True).all()  # noqa: E712
+
+
+def test_border_edges_preserves_T_and_phase_from_source():
+    df = _grid_frame()
+    left, right = _border_edges(df, min_c=0.0, max_c=1.0)
+    # the source rows at the extreme mu values are at all three Ts, single phase A
+    assert sorted(left["T"].tolist()) == [300.0, 400.0, 500.0]
+    assert sorted(right["T"].tolist()) == [300.0, 400.0, 500.0]
+    assert (left["phase"] == "A").all()
+    assert (right["phase"] == "A").all()
+
+
+# --- reduce tests ---
+
+
+def test_reduce_joins_phase_names_sorted_by_c():
+    # rows deliberately out of c order to verify sort_values("c") happens first
+    dd = pd.DataFrame({"phase": ["liq", "fcc", "bcc"], "c": [0.7, 0.2, 0.5]})
+    out = reduce(dd)
+    assert out["transition"] == "fcc-bcc-liq"
+    assert out["c"] == [0.2, 0.5, 0.7]
+    assert out["phase"] == ["fcc", "bcc", "liq"]
+
+
+def test_reduce_single_phase_no_dash():
+    dd = pd.DataFrame({"phase": ["fcc"], "c": [0.3]})
+    out = reduce(dd)
+    assert out["transition"] == "fcc"
+    assert out["c"] == [0.3]
+
+
+# --- cluster dispatcher tests ---
+
+
+def test_cluster_use_mu_true_dispatches_to_cluster_T_c_mu():
+    # mu=+inf gets its own label only in the cluster_T_c_mu branch
+    dd = pd.DataFrame({"T": [300.0, 400.0], "c": [0.1, 0.2], "mu": [np.inf, 0.0]})
+    labels = cluster(dd, distance_threshold=0.5)
+    assert labels.loc[dd["mu"] == np.inf].nunique() == 1
+    assert labels.loc[dd["mu"] == np.inf].iloc[0] != labels.loc[dd["mu"] == 0.0].iloc[0]
+
+
+def test_cluster_use_mu_false_dispatches_to_cluster_T_c():
+    # When use_mu=False, the function must work on a frame without a mu column
+    dd = pd.DataFrame({
+        "T": np.linspace(300, 400, 10),
+        "c": np.linspace(0.0, 0.2, 10),
+    })
+    labels = cluster(dd, use_mu=False, distance_threshold=0.5)
+    assert labels.nunique() == 1
+    assert len(labels) == len(dd)


### PR DESCRIPTION
Refs #116.

## What

Four scaffolding helpers in `landau/calculate.py` were exercised only end-to-end through `refine_phase_diagram` / `get_transitions`. Add direct unit tests in `tests/unit/test_calculate.py`:

- `_split_stable` — partitioning on the `stable` flag, index reset, the `border=False` / `refined="no"` column injection asymmetry, and input non-mutation.
- `_border_edges` — in-place T-extreme `border=True` marking; synthetic `mu=±inf` rows carry the right `c`, `border`, `stable` values and preserve `phase`/`T` from the extreme-`mu` source rows.
- `reduce` — `-`-joined `transition` string respects the `c`-sort order; single-row frames round-trip without an extra dash.
- `cluster` — dispatches to `cluster_T_c_mu` for `use_mu=True` and to `cluster_T_c` for `use_mu=False`.

11 new tests; 229 unit+regression tests pass.

## Why

These helpers are small but central: `_split_stable` and `_border_edges` set up every refined 2-D diagram, and `cluster` / `reduce` underpin transition extraction. A direct test net here makes the upcoming refactors flagged in the #116 backlog (e.g. dropping the unused `eps` kwarg on the cluster functions, the `pd.Series(..., index=pdf.index)` rewrite of the `fex.T` workaround) safe to do without leaning on end-to-end fixtures.


---
_Generated by [Claude Code](https://claude.ai/code/session_019sj95bwe8oDmwQ9BDRHmZi)_