### PR TITLE
fix: clamp col_wrap to number of temperatures in plot_excess_free_energy

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -507,6 +507,7 @@ def plot_excess_free_energy(
         df["border"] = False
 
     temperatures = sorted(df["T"].unique())
+    col_wrap = min(col_wrap, len(temperatures))
 
     # Line phases have a fixed concentration — detect by zero range across all rows.
     phase_names = list(df["phase"].unique())

--- a/tests/unit/plot/test_excess_free_energy.py
+++ b/tests/unit/plot/test_excess_free_energy.py
@@ -128,6 +128,14 @@ def test_single_temperature_convex_hull_true():
     plt.close(g.fig)
 
 
+def test_single_temperature_figure_not_wide():
+    """Figure width for one temperature must not span more than one column."""
+    # default height=3.0, aspect=1.3 → one column ≈ 3.9 in; col_wrap=3 would give 11.7 in.
+    g = plot_excess_free_energy(_minimal_df([1000]))
+    assert g.fig.get_figwidth() < 2 * 3.0 * 1.3
+    plt.close(g.fig)
+
+
 def test_all_line_phases_no_crash():
     """When all phases are line phases, plot_excess_free_energy must not crash."""
     from landau.calculate import calc_phase_diagram


### PR DESCRIPTION
Seaborn allocates figure width as `col_wrap * height * aspect`, so a single temperature with the default `col_wrap=3` produced a figure 3× too wide.

Clamp `col_wrap` to `len(temperatures)` before passing to seaborn.

Closes #183

Generated with [Claude Code](https://claude.ai/code)