### PR TITLE
feat(plot): add reference_phase to 1D plotting functions

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -334,6 +334,16 @@ def _assign_segment_ids(df: pd.DataFrame, scan_col: str) -> pd.Series:
     ).reindex(df.index)
 
 
+def _subtract_reference_phase(df, scan_col, reference_phase):
+    """Subtract reference phase's phi from all phases along scan_col."""
+    if reference_phase not in df["phase"].values:
+        raise ValueError(f"reference_phase {reference_phase!r} not found in data")
+    ref = df.loc[df["phase"] == reference_phase, [scan_col, "phi"]].rename(columns={"phi": "_ref_phi"})
+    df = df.merge(ref, on=scan_col, how="left")
+    df["phi"] = df["phi"] - df["_ref_phi"]
+    return df.drop(columns=["_ref_phi"])
+
+
 def plot_1d_mu_phase_diagram(
         df,
         ax=None,
@@ -370,12 +380,7 @@ def plot_1d_mu_phase_diagram(
     df = df.sort_values("mu").copy()
 
     if reference_phase is not None:
-        if reference_phase not in df["phase"].values:
-            raise ValueError(f"reference_phase {reference_phase!r} not found in data")
-        ref = df.loc[df["phase"] == reference_phase, ["mu", "phi"]].rename(columns={"phi": "_ref_phi"})
-        df = df.merge(ref, on="mu", how="left")
-        df["phi"] = df["phi"] - df["_ref_phi"]
-        df = df.drop(columns=["_ref_phi"])
+        df = _subtract_reference_phase(df, "mu", reference_phase)
 
     df["_seg_id"] = _assign_segment_ids(df, scan_col="mu")
     sns.lineplot(
@@ -404,7 +409,7 @@ def plot_1d_mu_phase_diagram(
     ax.set_xlabel("Chemical Potential Difference [eV]")
     ylabel = "Semi-grandcanonical Potential [eV/atom]"
     if reference_phase is not None:
-        ylabel = f"Semi-grandcanonical Potential relative to {reference_phase} [eV/atom]"
+        ylabel = f"Semi-grandcanonical Potential\nrelative to {reference_phase} [eV/atom]"
     ax.set_ylabel(ylabel)
 
     return ax
@@ -446,12 +451,7 @@ def plot_1d_T_phase_diagram(
     df = df.copy()
 
     if reference_phase is not None:
-        if reference_phase not in df["phase"].values:
-            raise ValueError(f"reference_phase {reference_phase!r} not found in data")
-        ref = df.loc[df["phase"] == reference_phase, ["T", "phi"]].rename(columns={"phi": "_ref_phi"})
-        df = df.merge(ref, on="T", how="left")
-        df["phi"] = df["phi"] - df["_ref_phi"]
-        df = df.drop(columns=["_ref_phi"])
+        df = _subtract_reference_phase(df, "T", reference_phase)
 
     df["_seg_id"] = _assign_segment_ids(df, scan_col="T")
 
@@ -481,7 +481,7 @@ def plot_1d_T_phase_diagram(
     ax.set_xlabel("Temperature [K]")
     ylabel = "Semi-grandcanonical potential [eV/atom]"
     if reference_phase is not None:
-        ylabel = f"Semi-grandcanonical potential relative to {reference_phase} [eV/atom]"
+        ylabel = f"Semi-grandcanonical potential\nrelative to {reference_phase} [eV/atom]"
     ax.set_ylabel(ylabel)
 
     return ax

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -338,13 +338,14 @@ def plot_1d_mu_phase_diagram(
         df,
         ax=None,
         show=True,
-        mark_transitions=True):
+        mark_transitions=True,
+        reference_phase=None):
     """
-    Plot a one dimensional isothermal phase diagram of the semi-grandcanonical 
+    Plot a one dimensional isothermal phase diagram of the semi-grandcanonical
     potential as function of the chemical potential difference.
 
     Args:
-        df (pandas.DataFrame): 
+        df (pandas.DataFrame):
             Input data containing columns for chemical potential difference ('mu'),
             semi-grandcanonical potential ('phi'), phase name ('phase'), stability
             ('stable'), and optionally a 'border' column indicating phase transition.
@@ -352,9 +353,12 @@ def plot_1d_mu_phase_diagram(
             Existing matplotlib Axes to plot on. If None, a new figure and axes are created.
         mark_transitions (bool, optional):
             If True, all transition temperatures are marked on the plot. Defaults to True.
+        reference_phase (str, optional):
+            If given, subtract this phase's potential from all other phases before
+            plotting so that the reference phase lies at zero throughout.
 
     Returns:
-        matplotlib.axes.Axes: 
+        matplotlib.axes.Axes:
             The Axes object with the phase diagram plot.
     """
 
@@ -364,6 +368,15 @@ def plot_1d_mu_phase_diagram(
         fig, ax = plt.subplots()
 
     df = df.sort_values("mu").copy()
+
+    if reference_phase is not None:
+        if reference_phase not in df["phase"].values:
+            raise ValueError(f"reference_phase {reference_phase!r} not found in data")
+        ref = df.loc[df["phase"] == reference_phase, ["mu", "phi"]].rename(columns={"phi": "_ref_phi"})
+        df = df.merge(ref, on="mu", how="left")
+        df["phi"] = df["phi"] - df["_ref_phi"]
+        df = df.drop(columns=["_ref_phi"])
+
     df["_seg_id"] = _assign_segment_ids(df, scan_col="mu")
     sns.lineplot(
         data=df,
@@ -389,21 +402,25 @@ def plot_1d_mu_phase_diagram(
             ax.text(mt - .05 * dfm, ft - dfa * .1, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
                     rotation='vertical', ha='center', va='top')
     ax.set_xlabel("Chemical Potential Difference [eV]")
-    ax.set_ylabel("Semi-grandcanonical Potential [eV/atom]")
+    ylabel = "Semi-grandcanonical Potential [eV/atom]"
+    if reference_phase is not None:
+        ylabel = f"Semi-grandcanonical Potential relative to {reference_phase} [eV/atom]"
+    ax.set_ylabel(ylabel)
 
     return ax
 
 def plot_1d_T_phase_diagram(
-        df, 
-        ax=None, 
+        df,
+        ax=None,
         mark_transitions=True,
-        show=True
+        show=True,
+        reference_phase=None,
         ):
     """
     Plots a one-dimensional equipotential phase diagram as a function of temperature.
 
     Args:
-        df (pandas.DataFrame): 
+        df (pandas.DataFrame):
             Input data containing columns for temperature ('T'), semi-grandcanonical
             potential ('phi'), phase name ('phase'), and optionally a 'border' column
             indicating phase transition.
@@ -411,9 +428,12 @@ def plot_1d_T_phase_diagram(
             Existing matplotlib Axes to plot on. If None, a new figure and axes are created.
         mark_transitions (bool, optional):
             If True, all transition temperatures are marked on the plot. Defaults to True.
+        reference_phase (str, optional):
+            If given, subtract this phase's potential from all other phases before
+            plotting so that the reference phase lies at zero throughout.
 
     Returns:
-        matplotlib.axes.Axes: 
+        matplotlib.axes.Axes:
             The Axes object with the phase diagram plot.
     """
 
@@ -424,6 +444,15 @@ def plot_1d_T_phase_diagram(
         fig, ax = plt.subplots()
 
     df = df.copy()
+
+    if reference_phase is not None:
+        if reference_phase not in df["phase"].values:
+            raise ValueError(f"reference_phase {reference_phase!r} not found in data")
+        ref = df.loc[df["phase"] == reference_phase, ["T", "phi"]].rename(columns={"phi": "_ref_phi"})
+        df = df.merge(ref, on="T", how="left")
+        df["phi"] = df["phi"] - df["_ref_phi"]
+        df = df.drop(columns=["_ref_phi"])
+
     df["_seg_id"] = _assign_segment_ids(df, scan_col="T")
 
     sns.lineplot(
@@ -450,7 +479,10 @@ def plot_1d_T_phase_diagram(
             ax.text(Tt + .05 * dft, ft + dfa * .1, rf"$T = {Tt:.0f}\,\mathrm{{K}}$", rotation='vertical', ha='center')
 
     ax.set_xlabel("Temperature [K]")
-    ax.set_ylabel("Semi-grandcanonical potential [eV/atom]")
+    ylabel = "Semi-grandcanonical potential [eV/atom]"
+    if reference_phase is not None:
+        ylabel = f"Semi-grandcanonical potential relative to {reference_phase} [eV/atom]"
+    ax.set_ylabel(ylabel)
 
     return ax
 

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -338,10 +338,11 @@ def _subtract_reference_phase(df, scan_col, reference_phase):
     """Subtract reference phase's phi from all phases along scan_col."""
     if reference_phase not in df["phase"].values:
         raise ValueError(f"reference_phase {reference_phase!r} not found in data")
-    ref = df.loc[df["phase"] == reference_phase, [scan_col, "phi"]].rename(columns={"phi": "_ref_phi"})
-    df = df.merge(ref, on=scan_col, how="left")
-    df["phi"] = df["phi"] - df["_ref_phi"]
-    return df.drop(columns=["_ref_phi"])
+    ref = df.loc[df["phase"] == reference_phase, [scan_col, "phi"]].sort_values(scan_col)
+    # np.interp handles border points where the reference phase has no exact row
+    # (refinement adds rows only for the two transitioning phases, not all phases).
+    df["phi"] = df["phi"] - np.interp(df[scan_col], ref[scan_col], ref["phi"])
+    return df
 
 
 def plot_1d_mu_phase_diagram(

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -134,6 +134,51 @@ def plot_1d_mu_three_stable(out_dir: Path, **_) -> Path:
     return _save(fig, out_dir, "1d_mu_three_stable_phase_diagram")
 
 
+def plot_1d_T_reference_phase(out_dir: Path, **_) -> Path:
+    """1D T diagram: bcc/fcc/liquid with reference_phase='bcc', showing relative semi-grand potential."""
+    T_s = np.array([100.0, 400.0, 700.0, 1000.0])
+    bcc = ldp.TemperatureDependentLinePhase(
+        "bcc", fixed_concentration=0, temperatures=T_s,
+        free_energies=-3.00 - 2e-4 * T_s - 1e-7 * T_s**2,
+    )
+    fcc = ldp.TemperatureDependentLinePhase(
+        "fcc", fixed_concentration=0, temperatures=T_s,
+        free_energies=-2.97 - 2.857e-4 * T_s - 2e-7 * T_s**2,
+    )
+    liquid = ldp.TemperatureDependentLinePhase(
+        "liquid", fixed_concentration=0, temperatures=T_s,
+        free_energies=-2.75 - 3.5e-4 * T_s - 5e-7 * T_s**2,
+    )
+
+    Ts = np.linspace(100, 1000, 50)
+    df = ldc.calc_phase_diagram([bcc, fcc, liquid], Ts, mu=0.0, refine=True, keep_unstable=True)
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    lpl.plot_1d_T_phase_diagram(df, ax=ax, reference_phase="bcc")
+    ax.set_title("1D T phase diagram with reference_phase='bcc'")
+    return _save(fig, out_dir, "1d_T_reference_phase_diagram")
+
+
+def plot_1d_mu_reference_phase(out_dir: Path, **_) -> Path:
+    """1D mu diagram: hcp/fcc/liquid with reference_phase='hcp', showing relative semi-grand potential."""
+    fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.02, line_entropy=1.0 * ldp.kB)
+    fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.02, line_entropy=1.1 * ldp.kB)
+    hcpa = ldp.LinePhase("hcpA", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
+    hcpb = ldp.LinePhase("hcpB", fixed_concentration=1, line_energy=-1.95, line_entropy=1.1 * ldp.kB)
+    lqda = ldp.LinePhase("liquidA", fixed_concentration=0, line_energy=-2.724, line_entropy=1.5 * ldp.kB)
+    lqdb = ldp.LinePhase("liquidB", fixed_concentration=1, line_energy=-2.050, line_entropy=1.2 * ldp.kB)
+    fcc = ldp.IdealSolution("fcc", fcca, fccb)
+    hcp = ldp.IdealSolution("hcp", hcpa, hcpb)
+    lqd = ldp.IdealSolution("liquid", lqda, lqdb)
+
+    df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts=1000.0, mu=100, keep_unstable=True)
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    lpl.plot_1d_mu_phase_diagram(df, ax=ax, reference_phase="hcp")
+    ax.set_title(r"1D $\mu$ phase diagram with reference_phase='hcp'")
+    return _save(fig, out_dir, "1d_mu_reference_phase_diagram")
+
+
 def plot_2d_basics(out_dir: Path, poly_method: str | None = None, tielines: bool = True, **_) -> Path:
     """2D c-T phase diagram (hcp / fcc / liquid ideal solutions) from Basics.ipynb."""
     fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.00, line_entropy=1.0 * ldp.kB)
@@ -290,13 +335,15 @@ def plot_2d_toy_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
 # poly_method and tielines, so cross-product iteration over them dedupes
 # automatically instead of re-rendering identical files.
 PLOTS = {
-    "1d_T_three_stable":   (plot_1d_T_three_stable,   ()),
-    "1d_mu_three_stable":  (plot_1d_mu_three_stable,  ()),
-    "2d_basics":           (plot_2d_basics,            ("poly_method", "tielines")),
-    "2d_basics_mu":        (plot_2d_basics_mu,         ("poly_method",)),
-    "2d_toy":              (plot_2d_toy,               ("poly_method", "tielines")),
-    "2d_toy_mu":           (plot_2d_toy_mu,            ("poly_method",)),
-    "excess_free_energy":  (plot_excess_free_energy,   ()),
+    "1d_T_three_stable":      (plot_1d_T_three_stable,      ()),
+    "1d_T_reference_phase":   (plot_1d_T_reference_phase,   ()),
+    "1d_mu_three_stable":     (plot_1d_mu_three_stable,     ()),
+    "1d_mu_reference_phase":  (plot_1d_mu_reference_phase,  ()),
+    "2d_basics":              (plot_2d_basics,               ("poly_method", "tielines")),
+    "2d_basics_mu":           (plot_2d_basics_mu,            ("poly_method",)),
+    "2d_toy":                 (plot_2d_toy,                  ("poly_method", "tielines")),
+    "2d_toy_mu":              (plot_2d_toy_mu,               ("poly_method",)),
+    "excess_free_energy":     (plot_excess_free_energy,      ()),
 }
 
 

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -72,13 +72,8 @@ def _file_suffix(poly_method: str | None = None, tielines: bool = True) -> str:
     return "_" + "_".join(parts) if parts else ""
 
 
-def plot_1d_T_three_stable(out_dir: Path, **_) -> Path:
-    """1D T diagram: three stable phases with concave-down free energies.
-
-    fcc is the intermediate phase, stable roughly 350–760 K; it is unstable
-    in two disjoint T ranges at low and high T, exposing the segment-splitting
-    fix in plot_1d_T_phase_diagram.
-    """
+def _calc_1d_T_bcc_fcc_liquid():
+    """bcc/fcc/liquid TemperatureDependentLinePhase scan shared by the 1D T testplots."""
     T_s = np.array([100.0, 400.0, 700.0, 1000.0])
     # G(T) = a - b*T - c*T^2 (c > 0: concave-down, strictly decreasing).
     # bcc: shallow slope, stable at low T.
@@ -96,10 +91,32 @@ def plot_1d_T_three_stable(out_dir: Path, **_) -> Path:
         "liquid", fixed_concentration=0, temperatures=T_s,
         free_energies=-2.75 - 3.5e-4 * T_s - 5e-7 * T_s**2,
     )
-
     Ts = np.linspace(100, 1000, 50)
-    df = ldc.calc_phase_diagram([bcc, fcc, liquid], Ts, mu=0.0, refine=True, keep_unstable=True)
+    return ldc.calc_phase_diagram([bcc, fcc, liquid], Ts, mu=0.0, refine=True, keep_unstable=True)
 
+
+def _calc_1d_mu_hcp_fcc_liquid():
+    """hcp/fcc/liquid IdealSolution mu scan shared by the 1D mu testplots."""
+    fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.02, line_entropy=1.0 * ldp.kB)
+    fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.02, line_entropy=1.1 * ldp.kB)
+    hcpa = ldp.LinePhase("hcpA", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
+    hcpb = ldp.LinePhase("hcpB", fixed_concentration=1, line_energy=-1.95, line_entropy=1.1 * ldp.kB)
+    lqda = ldp.LinePhase("liquidA", fixed_concentration=0, line_energy=-2.724, line_entropy=1.5 * ldp.kB)
+    lqdb = ldp.LinePhase("liquidB", fixed_concentration=1, line_energy=-2.050, line_entropy=1.2 * ldp.kB)
+    fcc = ldp.IdealSolution("fcc", fcca, fccb)
+    hcp = ldp.IdealSolution("hcp", hcpa, hcpb)
+    lqd = ldp.IdealSolution("liquid", lqda, lqdb)
+    return ldc.calc_phase_diagram([hcp, fcc, lqd], Ts=1000.0, mu=100, keep_unstable=True)
+
+
+def plot_1d_T_three_stable(out_dir: Path, **_) -> Path:
+    """1D T diagram: three stable phases with concave-down free energies.
+
+    fcc is the intermediate phase, stable roughly 350–760 K; it is unstable
+    in two disjoint T ranges at low and high T, exposing the segment-splitting
+    fix in plot_1d_T_phase_diagram.
+    """
+    df = _calc_1d_T_bcc_fcc_liquid()
     fig, ax = plt.subplots(figsize=(6, 4))
     lpl.plot_1d_T_phase_diagram(df, ax=ax)
     ax.set_title("1D T phase diagram (curved G: bcc / fcc / liquid)")
@@ -116,18 +133,7 @@ def plot_1d_mu_three_stable(out_dir: Path, **_) -> Path:
     fcc is unstable in two disjoint µ ranges (below and above its stable
     window), exposing the segment-splitting fix in plot_1d_mu_phase_diagram.
     """
-    fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.02, line_entropy=1.0 * ldp.kB)
-    fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.02, line_entropy=1.1 * ldp.kB)
-    hcpa = ldp.LinePhase("hcpA", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
-    hcpb = ldp.LinePhase("hcpB", fixed_concentration=1, line_energy=-1.95, line_entropy=1.1 * ldp.kB)
-    lqda = ldp.LinePhase("liquidA", fixed_concentration=0, line_energy=-2.724, line_entropy=1.5 * ldp.kB)
-    lqdb = ldp.LinePhase("liquidB", fixed_concentration=1, line_energy=-2.050, line_entropy=1.2 * ldp.kB)
-    fcc = ldp.IdealSolution("fcc", fcca, fccb)
-    hcp = ldp.IdealSolution("hcp", hcpa, hcpb)
-    lqd = ldp.IdealSolution("liquid", lqda, lqdb)
-
-    df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts=1000.0, mu=100, keep_unstable=True)
-
+    df = _calc_1d_mu_hcp_fcc_liquid()
     fig, ax = plt.subplots(figsize=(6, 4))
     lpl.plot_1d_mu_phase_diagram(df, ax=ax)
     ax.set_title(r"1D $\mu$ phase diagram (hcp / fcc / liquid, T=1000K)")
@@ -135,47 +141,20 @@ def plot_1d_mu_three_stable(out_dir: Path, **_) -> Path:
 
 
 def plot_1d_T_reference_phase(out_dir: Path, **_) -> Path:
-    """1D T diagram: bcc/fcc/liquid with reference_phase='bcc', showing relative semi-grand potential."""
-    T_s = np.array([100.0, 400.0, 700.0, 1000.0])
-    bcc = ldp.TemperatureDependentLinePhase(
-        "bcc", fixed_concentration=0, temperatures=T_s,
-        free_energies=-3.00 - 2e-4 * T_s - 1e-7 * T_s**2,
-    )
-    fcc = ldp.TemperatureDependentLinePhase(
-        "fcc", fixed_concentration=0, temperatures=T_s,
-        free_energies=-2.97 - 2.857e-4 * T_s - 2e-7 * T_s**2,
-    )
-    liquid = ldp.TemperatureDependentLinePhase(
-        "liquid", fixed_concentration=0, temperatures=T_s,
-        free_energies=-2.75 - 3.5e-4 * T_s - 5e-7 * T_s**2,
-    )
-
-    Ts = np.linspace(100, 1000, 50)
-    df = ldc.calc_phase_diagram([bcc, fcc, liquid], Ts, mu=0.0, refine=True, keep_unstable=True)
-
+    """1D T diagram: bcc/fcc/liquid with reference_phase='fcc', showing relative semi-grand potential."""
+    df = _calc_1d_T_bcc_fcc_liquid()
     fig, ax = plt.subplots(figsize=(6, 4))
-    lpl.plot_1d_T_phase_diagram(df, ax=ax, reference_phase="bcc")
-    ax.set_title("1D T phase diagram with reference_phase='bcc'")
+    lpl.plot_1d_T_phase_diagram(df, ax=ax, reference_phase="fcc")
+    ax.set_title("1D T phase diagram with reference_phase='fcc'")
     return _save(fig, out_dir, "1d_T_reference_phase_diagram")
 
 
 def plot_1d_mu_reference_phase(out_dir: Path, **_) -> Path:
-    """1D mu diagram: hcp/fcc/liquid with reference_phase='hcp', showing relative semi-grand potential."""
-    fcca = ldp.LinePhase("fccA", fixed_concentration=0, line_energy=-3.02, line_entropy=1.0 * ldp.kB)
-    fccb = ldp.LinePhase("fccB", fixed_concentration=1, line_energy=-2.02, line_entropy=1.1 * ldp.kB)
-    hcpa = ldp.LinePhase("hcpA", fixed_concentration=0, line_energy=-2.975, line_entropy=1.8 * ldp.kB)
-    hcpb = ldp.LinePhase("hcpB", fixed_concentration=1, line_energy=-1.95, line_entropy=1.1 * ldp.kB)
-    lqda = ldp.LinePhase("liquidA", fixed_concentration=0, line_energy=-2.724, line_entropy=1.5 * ldp.kB)
-    lqdb = ldp.LinePhase("liquidB", fixed_concentration=1, line_energy=-2.050, line_entropy=1.2 * ldp.kB)
-    fcc = ldp.IdealSolution("fcc", fcca, fccb)
-    hcp = ldp.IdealSolution("hcp", hcpa, hcpb)
-    lqd = ldp.IdealSolution("liquid", lqda, lqdb)
-
-    df = ldc.calc_phase_diagram([hcp, fcc, lqd], Ts=1000.0, mu=100, keep_unstable=True)
-
+    """1D mu diagram: hcp/fcc/liquid with reference_phase='fcc', showing relative semi-grand potential."""
+    df = _calc_1d_mu_hcp_fcc_liquid()
     fig, ax = plt.subplots(figsize=(6, 4))
-    lpl.plot_1d_mu_phase_diagram(df, ax=ax, reference_phase="hcp")
-    ax.set_title(r"1D $\mu$ phase diagram with reference_phase='hcp'")
+    lpl.plot_1d_mu_phase_diagram(df, ax=ax, reference_phase="fcc")
+    ax.set_title(r"1D $\mu$ phase diagram with reference_phase='fcc'")
     return _save(fig, out_dir, "1d_mu_reference_phase_diagram")
 
 

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -329,3 +329,98 @@ def test_plot_1d_T_middle_phase_three_lines(fixture, request):
         assert counts.get("liquid") == 2
     finally:
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# reference_phase subtraction
+# ---------------------------------------------------------------------------
+
+
+def _ydata_for_phase(ax, phase_name):
+    """Return a flat array of all y-values plotted for *phase_name* on *ax*."""
+    legend = ax.get_legend()
+    white = to_rgba("w")
+    gray2 = to_rgba(".2")
+    color_to_phase = {}
+    for handle, text in zip(legend.legend_handles, legend.texts):
+        try:
+            c = to_rgba(handle.get_color())
+        except (AttributeError, ValueError):
+            continue
+        if c == white or c == gray2:
+            continue
+        color_to_phase[c] = text.get_text()
+    ydata = []
+    for line in ax.lines:
+        yd = line.get_ydata()
+        if len(yd) == 0:
+            continue
+        try:
+            c = to_rgba(line.get_color())
+        except ValueError:
+            continue
+        if color_to_phase.get(c) == phase_name:
+            ydata.extend(yd)
+    return np.asarray(ydata)
+
+
+def test_plot_1d_mu_reference_phase_is_zero(df_mu_three_stable):
+    """After subtracting the reference phase, its own phi is zero at every mu."""
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_mu_phase_diagram(df_mu_three_stable, ax=ax, reference_phase="hcp")
+        yd = _ydata_for_phase(ax, "hcp")
+        assert len(yd) > 0
+        np.testing.assert_allclose(yd, 0.0, atol=1e-12)
+    finally:
+        plt.close(fig)
+
+
+def test_plot_1d_mu_reference_phase_differences_preserved(df_mu_three_stable):
+    """phi(fcc) - phi(ref) in the plot matches fcc_phi - hcp_phi from the raw data."""
+    df = df_mu_three_stable
+    ref = "hcp"
+    # Compute expected fcc - hcp difference at each mu point, sort for order-independence.
+    pivot = df.pivot_table(index="mu", columns="phase", values="phi")
+    expected = np.sort((pivot["fcc"] - pivot[ref]).dropna().values)
+
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_mu_phase_diagram(df, ax=ax, reference_phase=ref)
+        # fcc y-values across all segments, sorted for order-independence.
+        yd_fcc = np.sort(_ydata_for_phase(ax, "fcc"))
+        np.testing.assert_allclose(yd_fcc, expected, atol=1e-10)
+    finally:
+        plt.close(fig)
+
+
+def test_plot_1d_mu_reference_phase_invalid_raises(df_mu_three_stable):
+    """A reference_phase not present in the data raises ValueError."""
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(ValueError, match="reference_phase"):
+            plot_1d_mu_phase_diagram(df_mu_three_stable, ax=ax, reference_phase="nonexistent")
+    finally:
+        plt.close(fig)
+
+
+def test_plot_1d_T_reference_phase_is_zero(df_T_three_stable):
+    """After subtracting the reference phase, its own phi is zero at every T."""
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="bcc")
+        yd = _ydata_for_phase(ax, "bcc")
+        assert len(yd) > 0
+        np.testing.assert_allclose(yd, 0.0, atol=1e-12)
+    finally:
+        plt.close(fig)
+
+
+def test_plot_1d_T_reference_phase_invalid_raises(df_T_three_stable):
+    """A reference_phase not present in the data raises ValueError."""
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(ValueError, match="reference_phase"):
+            plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="nonexistent")
+    finally:
+        plt.close(fig)

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -380,16 +380,23 @@ def test_plot_1d_mu_reference_phase_differences_preserved(df_mu_three_stable):
     """phi(fcc) - phi(ref) in the plot matches fcc_phi - hcp_phi from the raw data."""
     df = df_mu_three_stable
     ref = "hcp"
-    # Compute expected fcc - hcp difference at each mu point, sort for order-independence.
-    pivot = df.pivot_table(index="mu", columns="phase", values="phi")
+    # Differences at mu values where BOTH fcc and hcp have exact rows.  At
+    # border-only mu values (where the reference is absent from the refined data),
+    # _subtract_reference_phase interpolates; those extra values are not tested here.
+    shared_mu = set(df.loc[df["phase"] == ref, "mu"]) & set(df.loc[df["phase"] == "fcc", "mu"])
+    pivot = df[df["mu"].isin(shared_mu)].pivot_table(index="mu", columns="phase", values="phi")
     expected = np.sort((pivot["fcc"] - pivot[ref]).dropna().values)
 
     fig, ax = plt.subplots()
     try:
         plot_1d_mu_phase_diagram(df, ax=ax, reference_phase=ref)
-        # fcc y-values across all segments, sorted for order-independence.
-        yd_fcc = np.sort(_ydata_for_phase(ax, "fcc"))
-        np.testing.assert_allclose(yd_fcc, expected, atol=1e-10)
+        yd_fcc = _ydata_for_phase(ax, "fcc")
+        yd_valid = np.sort(yd_fcc[~np.isnan(yd_fcc)])
+        assert len(yd_valid) >= len(expected)
+        for v in expected:
+            assert np.any(np.isclose(yd_valid, v, atol=1e-10)), (
+                f"Expected fcc-hcp difference {v:.8f} not found in plotted fcc values"
+            )
     finally:
         plt.close(fig)
 
@@ -422,5 +429,62 @@ def test_plot_1d_T_reference_phase_invalid_raises(df_T_three_stable):
     try:
         with pytest.raises(ValueError, match="reference_phase"):
             plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="nonexistent")
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Transition-marker introspection
+# ---------------------------------------------------------------------------
+
+
+def _transition_marker_y_positions(ax):
+    """Return the y-positions of all black scatter markers (transition dots) on *ax*.
+
+    Transition markers are added via ``ax.scatter(..., c='k')``, producing a
+    PathCollection with black facecolor.  Other artists (seaborn line plots) do
+    not create black PathCollections, so this isolates the marker set.
+    """
+    ys = []
+    for coll in ax.collections:
+        try:
+            fc = coll.get_facecolor()
+        except AttributeError:
+            continue
+        if fc is None or len(fc) == 0:
+            continue
+        color = np.asarray(fc[0])
+        if len(color) >= 3 and np.allclose(color[:3], [0.0, 0.0, 0.0], atol=0.01):
+            offsets = np.asarray(coll.get_offsets())
+            if len(offsets) > 0:
+                ys.extend(offsets[:, 1])
+    return np.asarray(ys)
+
+
+def test_plot_1d_T_reference_phase_all_transitions_marked(df_T_three_stable):
+    """All transition markers are present and have finite y when reference_phase is set.
+
+    Before the np.interp fix, border points where the reference phase had no
+    exact row got phi=NaN from the merge, making every marker after the first
+    invisible (ax.scatter with y=NaN renders nothing).
+    """
+    fig0, ax0 = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax0)
+        n_expected = len(_transition_marker_y_positions(ax0))
+    finally:
+        plt.close(fig0)
+
+    assert n_expected >= 2, "fixture must have at least 2 transition markers"
+
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="bcc")
+        ys = _transition_marker_y_positions(ax)
+        assert len(ys) == n_expected, (
+            f"Expected {n_expected} transition markers with reference_phase='bcc', "
+            f"got {len(ys)}. Likely NaN phi at a border point where bcc has no row."
+        )
+        assert np.all(np.isfinite(ys)), f"Some transition markers have non-finite y: {ys}"
     finally:
         plt.close(fig)


### PR DESCRIPTION
Add `reference_phase=None` parameter to `plot_1d_mu_phase_diagram` and `plot_1d_T_phase_diagram`.

When provided, each phase's semigrand potential has the reference phase's potential subtracted at every scan point, placing the reference at y=0. The y-axis label is updated to reflect the relative scale.

Closes #187

Generated with [Claude Code](https://claude.ai/code)