### PR TITLE
fix(plot): show legend when only line phases are stable

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -659,14 +659,17 @@ def plot_excess_free_energy(
             existing_handles = list(g._legend.legend_handles)
             existing_labels = [t.get_text() for t in g._legend.texts]
             g._legend.remove()
-            g.figure.legend(
-                existing_handles + lp_handles,
-                existing_labels + [h.get_label() for h in lp_handles],
-                title="phase",
-                bbox_to_anchor=(1.02, 0.5),
-                loc="center left",
-                borderaxespad=0,
-            )
+        else:
+            existing_handles = []
+            existing_labels = []
+        g.figure.legend(
+            existing_handles + lp_handles,
+            existing_labels + [h.get_label() for h in lp_handles],
+            title="phase",
+            bbox_to_anchor=(1.02, 0.5),
+            loc="center left",
+            borderaxespad=0,
+        )
 
     g.refline(y=0)
     g.set_titles("T = {col_name:.0f} K")

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -271,6 +271,21 @@ def plot_excess_free_energy(out_dir: Path, **_) -> Path:
     return _save(g.fig, out_dir, "excess_free_energy")
 
 
+def plot_excess_free_energy_line_phases(out_dir: Path, **_) -> Path:
+    """Excess free energy with only line phases — legend fix for #182."""
+    import pandas as pd
+    e0 = ldp.LinePhase("A",  fixed_concentration=0,   line_energy=-2.0, line_entropy=1.0 * ldp.kB)
+    e1 = ldp.LinePhase("B",  fixed_concentration=1,   line_energy=-3.0, line_entropy=1.5 * ldp.kB)
+    inter = ldp.LinePhase("AB", fixed_concentration=0.5, line_energy=-2.8, line_entropy=1.3 * ldp.kB)
+    df = pd.concat(
+        [ldc.calc_phase_diagram([e0, e1, inter], Ts=T, mu=50, keep_unstable=True)
+         for T in [500, 1000, 1500]],
+        ignore_index=True,
+    )
+    g = lpl.plot_excess_free_energy(df, convex_hull=True, height=4, aspect=1.1)
+    return _save(g.fig, out_dir, "excess_free_energy_line_phases")
+
+
 def plot_2d_toy_mu(out_dir: Path, poly_method: str | None = None, **_) -> Path:
     """2D T-mu diagram with a regular-solution liquid + intermediate solid, from Toy.ipynb."""
     l1 = ldp.TemperatureDependentLinePhase(
@@ -322,7 +337,8 @@ PLOTS = {
     "2d_basics_mu":           (plot_2d_basics_mu,            ("poly_method",)),
     "2d_toy":                 (plot_2d_toy,                  ("poly_method", "tielines")),
     "2d_toy_mu":              (plot_2d_toy_mu,               ("poly_method",)),
-    "excess_free_energy":     (plot_excess_free_energy,      ()),
+    "excess_free_energy":             (plot_excess_free_energy,             ()),
+    "excess_free_energy_line_phases": (plot_excess_free_energy_line_phases, ()),
 }
 
 

--- a/tests/unit/plot/test_excess_free_energy.py
+++ b/tests/unit/plot/test_excess_free_energy.py
@@ -147,3 +147,19 @@ def test_all_line_phases_no_crash():
     g = plot_excess_free_energy(df, convex_hull=True)
     assert g.axes.size == 1
     plt.close(g.fig)
+
+
+def test_all_line_phases_legend_present():
+    """When only line phases are stable the figure legend must list all phase names."""
+    from landau.calculate import calc_phase_diagram
+
+    e0 = LinePhase("A", fixed_concentration=0, line_energy=-2.0, line_entropy=1.0 * kB)
+    e1 = LinePhase("B", fixed_concentration=1, line_energy=-3.0, line_entropy=1.5 * kB)
+    inter = LinePhase("AB", fixed_concentration=0.5, line_energy=-2.8, line_entropy=1.3 * kB)
+    df = calc_phase_diagram([e0, e1, inter], Ts=1000, mu=50, keep_unstable=True)
+    g = plot_excess_free_energy(df, convex_hull=True)
+    legend = g.figure.legends
+    assert legend, "figure legend is missing when only line phases are stable"
+    legend_labels = {t.get_text() for t in legend[0].texts}
+    assert {"A", "B", "AB"} <= legend_labels
+    plt.close(g.fig)


### PR DESCRIPTION
When `g._legend` is `None` (no solution-phase hue legend from seaborn), the line-phase handles in `plot_excess_free_energy` were silently dropped. Fall through to empty `existing_handles`/`existing_labels` so the figure legend is always created when line phases are present.

Closes #182.

Generated with [Claude Code](https://claude.ai/code)