### PR TITLE
test(poly): unit tests for _pca_sort_segment, _segments_from_labels, _segment_tsp_polygon

### DIFF
--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -434,30 +434,31 @@ def test_segment_tsp_polygon_all_zero_distances():
     assert result is not None
 
 
-# Property: a segment is appended to the polygon in the direction set by the
-# parity of the tour node through which it is first entered. Segment k owns
-# nodes 2k (its start endpoint) and 2k+1 (its end endpoint); entering via the
-# even node walks the segment in stored order, via the odd node reverses it.
-# Both tests below stitch the same two segments and read the polygon back as
-# one chunk per segment, asserting each chunk against `seg` or `seg[::-1]`.
+class TestSegmentTspPolygonTraversalDirection:
+    """A segment is appended to the polygon in the direction set by the parity
+    of the tour node through which it is first entered. Segment k owns nodes 2k
+    (its start endpoint) and 2k+1 (its end endpoint); entering via the even node
+    walks the segment in stored order, via the odd node reverses it. Both tests
+    stitch the same two segments and read the polygon back as one chunk per
+    segment, asserting each chunk against ``seg`` or ``seg[::-1]``.
+    """
 
-def test_segment_tsp_polygon_even_entry_node_keeps_segment_order():
-    seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
-    seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
-    # Tour enters seg0 via node 0 (even) and seg1 via node 2 (even).
-    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [0, 1, 2, 3])
-    assert isinstance(result, shapely.Polygon)
-    coords = np.array(result.exterior.coords)[:-1]  # drop closing vertex
-    np.testing.assert_allclose(coords[:2], seg0)
-    np.testing.assert_allclose(coords[2:], seg1)
+    def test_even_entry_node_keeps_segment_order(self):
+        seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
+        seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
+        # Tour enters seg0 via node 0 (even) and seg1 via node 2 (even).
+        result = _segment_tsp_polygon([seg0, seg1], lambda dm: [0, 1, 2, 3])
+        assert isinstance(result, shapely.Polygon)
+        coords = np.array(result.exterior.coords)[:-1]  # drop closing vertex
+        np.testing.assert_allclose(coords[:2], seg0)
+        np.testing.assert_allclose(coords[2:], seg1)
 
-
-def test_segment_tsp_polygon_odd_entry_node_reverses_segment():
-    seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
-    seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
-    # Tour enters seg0 via node 1 (odd) and seg1 via node 3 (odd).
-    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [1, 0, 3, 2])
-    assert isinstance(result, shapely.Polygon)
-    coords = np.array(result.exterior.coords)[:-1]
-    np.testing.assert_allclose(coords[:2], seg0[::-1])
-    np.testing.assert_allclose(coords[2:], seg1[::-1])
+    def test_odd_entry_node_reverses_segment(self):
+        seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
+        seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
+        # Tour enters seg0 via node 1 (odd) and seg1 via node 3 (odd).
+        result = _segment_tsp_polygon([seg0, seg1], lambda dm: [1, 0, 3, 2])
+        assert isinstance(result, shapely.Polygon)
+        coords = np.array(result.exterior.coords)[:-1]
+        np.testing.assert_allclose(coords[:2], seg0[::-1])
+        np.testing.assert_allclose(coords[2:], seg1[::-1])

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -13,7 +13,7 @@ from landau.poly import (
 )
 import pytest
 from matplotlib.patches import Polygon
-from sklearn.decomposition import PCA as SkPCA
+from sklearn.decomposition import PCA
 
 # Check if optional dependencies are available
 try:
@@ -325,7 +325,7 @@ def test_greedy_stitch_custom_columns(unit_norm):
 def test_pca_sort_segment_empty():
     pts = np.zeros((0, 2))
     result = _pca_sort_segment(pts)
-    assert result.shape == (0, 2)
+    assert result.shape == pts.shape
 
 
 def test_pca_sort_segment_single_point():
@@ -348,7 +348,7 @@ def test_pca_sort_segment_diagonal_matches_argsort():
     # Assert the returned order equals pts[argsort(PCA projection)].
     pts = np.array([[3.0, 3.0], [1.0, 1.0], [2.0, 2.0]])
     result = _pca_sort_segment(pts)
-    pca = SkPCA(n_components=1)
+    pca = PCA(n_components=1)
     proj = pca.fit_transform(pts).ravel()
     expected = pts[np.argsort(proj)]
     np.testing.assert_array_equal(result, expected)
@@ -434,23 +434,30 @@ def test_segment_tsp_polygon_all_zero_distances():
     assert result is not None
 
 
-def test_segment_tsp_polygon_forward_traversal():
-    # Even-numbered tour nodes → segment traversed in its stored order.
+# Property: a segment is appended to the polygon in the direction set by the
+# parity of the tour node through which it is first entered. Segment k owns
+# nodes 2k (its start endpoint) and 2k+1 (its end endpoint); entering via the
+# even node walks the segment in stored order, via the odd node reverses it.
+# Both tests below stitch the same two segments and read the polygon back as
+# one chunk per segment, asserting each chunk against `seg` or `seg[::-1]`.
+
+def test_segment_tsp_polygon_even_entry_node_keeps_segment_order():
     seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
     seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
-    # Tour [0,1,2,3]: node 0 (even) → seg0 forward; node 2 (even) → seg1 forward.
+    # Tour enters seg0 via node 0 (even) and seg1 via node 2 (even).
     result = _segment_tsp_polygon([seg0, seg1], lambda dm: [0, 1, 2, 3])
     assert isinstance(result, shapely.Polygon)
     coords = np.array(result.exterior.coords)[:-1]  # drop closing vertex
-    np.testing.assert_allclose(coords, [[0, 0], [1, 0], [1, 1], [0, 1]])
+    np.testing.assert_allclose(coords[:2], seg0)
+    np.testing.assert_allclose(coords[2:], seg1)
 
 
-def test_segment_tsp_polygon_backward_traversal():
-    # Odd-numbered tour nodes → segment traversed in reverse.
+def test_segment_tsp_polygon_odd_entry_node_reverses_segment():
     seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
     seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
-    # Tour [1,0,3,2]: node 1 (odd) → seg0 backward; node 3 (odd) → seg1 backward.
+    # Tour enters seg0 via node 1 (odd) and seg1 via node 3 (odd).
     result = _segment_tsp_polygon([seg0, seg1], lambda dm: [1, 0, 3, 2])
     assert isinstance(result, shapely.Polygon)
     coords = np.array(result.exterior.coords)[:-1]
-    np.testing.assert_allclose(coords, [[1, 0], [0, 0], [0, 1], [1, 1]])
+    np.testing.assert_allclose(coords[:2], seg0[::-1])
+    np.testing.assert_allclose(coords[2:], seg1[::-1])

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -1,9 +1,19 @@
 import numpy as np
 import pandas as pd
+import shapely
 from hypothesis import given, strategies as st, settings
-from landau.poly import Concave, Segments, _greedy_stitch, handle_poly_method
+from landau.poly import (
+    Concave,
+    Segments,
+    _greedy_stitch,
+    _pca_sort_segment,
+    _segment_tsp_polygon,
+    _segments_from_labels,
+    handle_poly_method,
+)
 import pytest
 from matplotlib.patches import Polygon
+from sklearn.decomposition import PCA as SkPCA
 
 # Check if optional dependencies are available
 try:
@@ -307,3 +317,140 @@ def test_greedy_stitch_custom_columns(unit_norm):
     assert out[0] is head
     # other should have been flipped to start at x=2
     assert out[1].iloc[0]["x"] == pytest.approx(2.0)
+
+
+# --- _pca_sort_segment tests ---
+
+
+def test_pca_sort_segment_empty():
+    pts = np.zeros((0, 2))
+    result = _pca_sort_segment(pts)
+    assert result.shape == (0, 2)
+
+
+def test_pca_sort_segment_single_point():
+    pts = np.array([[3.0, 4.0]])
+    result = _pca_sort_segment(pts)
+    np.testing.assert_array_equal(result, pts)
+
+
+def test_pca_sort_segment_collinear_x():
+    # Collinear along x-axis in scrambled order; result must be monotone in x.
+    pts = np.array([[2.0, 0.0], [0.0, 0.0], [1.0, 0.0]])
+    result = _pca_sort_segment(pts)
+    assert set(map(tuple, result.tolist())) == {(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)}
+    xs = result[:, 0]
+    assert np.all(np.diff(xs) >= 0) or np.all(np.diff(xs) <= 0)
+
+
+def test_pca_sort_segment_diagonal_matches_argsort():
+    # Points on y=x diagonal. PCA principal axis is [1,1]/sqrt(2).
+    # Assert the returned order equals pts[argsort(PCA projection)].
+    pts = np.array([[3.0, 3.0], [1.0, 1.0], [2.0, 2.0]])
+    result = _pca_sort_segment(pts)
+    pca = SkPCA(n_components=1)
+    proj = pca.fit_transform(pts).ravel()
+    expected = pts[np.argsort(proj)]
+    np.testing.assert_array_equal(result, expected)
+
+
+# --- _segments_from_labels tests ---
+
+
+def test_segments_from_labels_empty():
+    pp = np.zeros((0, 2))
+    labels = np.array([], dtype=int)
+    result = _segments_from_labels(pp, labels)
+    assert result == []
+
+
+def test_segments_from_labels_single_label():
+    pts = np.array([[2.0, 0.0], [0.0, 0.0], [1.0, 0.0]])
+    labels = np.array([7, 7, 7])
+    result = _segments_from_labels(pts, labels)
+    assert len(result) == 1
+    assert set(map(tuple, result[0].tolist())) == {(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)}
+
+
+def test_segments_from_labels_two_labels():
+    pts = np.array([[1.0, 0.0], [0.0, 0.0], [3.0, 1.0], [2.0, 1.0]])
+    labels = np.array([0, 0, 1, 1])
+    result = _segments_from_labels(pts, labels)
+    assert len(result) == 2
+    assert set(map(tuple, result[0].tolist())) == {(0.0, 0.0), (1.0, 0.0)}
+    assert set(map(tuple, result[1].tolist())) == {(2.0, 1.0), (3.0, 1.0)}
+
+
+def test_segments_from_labels_each_group_pca_sorted():
+    # Two groups of 3 collinear points; each must come out monotone along its axis.
+    pts = np.array([
+        [2.0, 0.0], [0.0, 0.0], [1.0, 0.0],   # label 0, collinear along x
+        [0.0, 3.0], [0.0, 1.0], [0.0, 2.0],   # label 1, collinear along y
+    ])
+    labels = np.array([0, 0, 0, 1, 1, 1])
+    result = _segments_from_labels(pts, labels)
+    assert len(result) == 2
+    xs = result[0][:, 0]
+    ys = result[1][:, 1]
+    assert np.all(np.diff(xs) >= 0) or np.all(np.diff(xs) <= 0)
+    assert np.all(np.diff(ys) >= 0) or np.all(np.diff(ys) <= 0)
+
+
+# --- _segment_tsp_polygon tests ---
+
+
+def _identity_tour(dm):
+    return list(range(len(dm)))
+
+
+def test_segment_tsp_polygon_no_segments():
+    assert _segment_tsp_polygon([], _identity_tour) is None
+
+
+def test_segment_tsp_polygon_single_segment_two_points():
+    seg = np.array([[0.0, 0.0], [1.0, 0.0]])
+    assert _segment_tsp_polygon([seg], _identity_tour) is None
+
+
+def test_segment_tsp_polygon_single_segment_triangle():
+    seg = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
+    result = _segment_tsp_polygon([seg], _identity_tour)
+    assert isinstance(result, shapely.Polygon)
+    assert not result.is_empty
+
+
+def test_segment_tsp_polygon_all_zero_distances():
+    # All endpoints at the same location → pairwise distance matrix is all-zero
+    # → solve_tour must not be called; convex-hull fallback returned instead.
+    seg = np.array([[1.0, 1.0], [1.0, 1.0]])
+    called = []
+
+    def tracking_tour(dm):
+        called.append(dm)
+        return list(range(len(dm)))
+
+    result = _segment_tsp_polygon([seg, seg.copy()], tracking_tour)
+    assert not called
+    assert result is not None
+
+
+def test_segment_tsp_polygon_forward_traversal():
+    # Even-numbered tour nodes → segment traversed in its stored order.
+    seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
+    seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
+    # Tour [0,1,2,3]: node 0 (even) → seg0 forward; node 2 (even) → seg1 forward.
+    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [0, 1, 2, 3])
+    assert isinstance(result, shapely.Polygon)
+    coords = np.array(result.exterior.coords)[:-1]  # drop closing vertex
+    np.testing.assert_allclose(coords, [[0, 0], [1, 0], [1, 1], [0, 1]])
+
+
+def test_segment_tsp_polygon_backward_traversal():
+    # Odd-numbered tour nodes → segment traversed in reverse.
+    seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
+    seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
+    # Tour [1,0,3,2]: node 1 (odd) → seg0 backward; node 3 (odd) → seg1 backward.
+    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [1, 0, 3, 2])
+    assert isinstance(result, shapely.Polygon)
+    coords = np.array(result.exterior.coords)[:-1]
+    np.testing.assert_allclose(coords, [[1, 0], [0, 0], [0, 1], [1, 1]])


### PR DESCRIPTION
Closes #161.

Adds 14 direct unit tests for the three module-level helpers in `landau/poly.py` that were previously only exercised indirectly through the Hypothesis-driven `SegmentPythonTsp` / `SegmentFastTsp` tests.

## Coverage added

**`_pca_sort_segment`** (4 tests):
- empty array → shape `(0, 2)` returned unchanged
- single point → returned unchanged
- collinear-along-x: result contains all input points and x-values are monotone
- diagonal (y=x): result matches `pts[argsort(PCA projection)]` directly

**`_segments_from_labels`** (4 tests):
- empty `pp` / `labels` → `[]`
- single label: one segment, correct point membership
- two labels: two segments, correct group membership for each
- per-group PCA sort: each output segment is monotone along its principal axis

**`_segment_tsp_polygon`** (6 tests):
- 0 segments → `None`
- 1 segment, 2 points → `None`
- 1 segment, 3 points → `shapely.Polygon`
- all endpoints coincident → `solve_tour` not called, convex-hull fallback returned
- forward traversal (even tour nodes): polygon coords verified against expected
- backward traversal (odd tour nodes): polygon coords verified against expected

`solve_tour` is injected as a deterministic lambda in the multi-segment tests so the assertions are independent of any TSP solver.

## Test run

```
25 passed, 5 skipped in 5.27s
```
(5 skips: optional `python-tsp` / `fast-tsp` extras not installed in CI.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuzNLF2pWrrek8YYWpWu8a)_