### PR TITLE
ci: pin Claude action to Opus with high reasoning effort

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)'
+          claude_args: '--model opus --effort high --allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)'
 


### PR DESCRIPTION
`.github/workflows/claude.yml` set no `--model`, so the action used claude-code-action's default, which is Sonnet (per https://code.claude.com/docs/en/github-actions: "Claude Code GitHub Actions default to Sonnet").

Added `--model opus --effort high` to `claude_args`. On the Anthropic API the `opus` alias resolves to the latest Opus; `--effort high` sets reasoning effort explicitly (effort levels documented at https://code.claude.com/docs/en/model-config).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeDxUQCg5wjn6cggZn7hvh)_