### PR TITLE
Tune 1d phase-diagram side-label stack: ylim, adaptive width, overlap avoidance

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -826,17 +826,20 @@ def plot_1d_mu_phase_diagram(
     if 'border' not in df.columns:
         return ax
 
-    dfa = np.ptp(df['phi'].dropna())
     dfm = np.ptp(df['mu'].dropna())
 
     if mark_transitions:
+        # Label y in axes fraction (blended transform) so a zoomed ylim can't fling the
+        # text out of view; the marker dot stays in data coords and is simply clipped if
+        # the crossing lies outside the window.
         for mt, dd in df.query("mu.min()<mu<mu.max() and border").groupby("mu"):
             ft = dd['phi'].iloc[0]
             ax.axvline(mt, color='k', linestyle='dotted', alpha=.5)
             ax.scatter(mt, ft, marker='o', c='k', zorder=10)
 
-            ax.text(mt - .05 * dfm, ft - dfa * .1, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
-                    rotation='vertical', ha='center', va='top')
+            ax.text(mt - .05 * dfm, 0.02, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
+                    transform=ax.get_xaxis_transform(),
+                    rotation='vertical', ha='center', va='bottom')
     ax.set_xlabel("Chemical Potential Difference [eV]")
     ylabel = "Semi-grandcanonical Potential [eV/atom]"
     if reference_phase is not None:
@@ -915,16 +918,20 @@ def plot_1d_T_phase_diagram(
     if 'border' not in df.columns:
         return ax
 
-    dfa = np.ptp(df['phi'].dropna())
     dft = np.ptp(df['T'].dropna())
 
     if mark_transitions:
+        # Label y in axes fraction (blended transform) so a zoomed ylim can't fling the
+        # text out of view; the marker dot stays in data coords and is simply clipped if
+        # the crossing lies outside the window.
         for Tt, dd in df.query("T.min()<T<T.max() and border").groupby("T"):
             ft = dd['phi'].iloc[0]
             ax.axvline(Tt, color='k', linestyle='dotted', alpha=.5)
             ax.scatter(Tt, ft, marker='o', c='k', zorder=10)
 
-            ax.text(Tt + .05 * dft, ft + dfa * .1, rf"$T = {Tt:.0f}\,\mathrm{{K}}$", rotation='vertical', ha='center')
+            ax.text(Tt + .05 * dft, 0.02, rf"$T = {Tt:.0f}\,\mathrm{{K}}$",
+                    transform=ax.get_xaxis_transform(),
+                    rotation='vertical', ha='center', va='bottom')
 
     ax.set_xlabel("Temperature [K]")
     ylabel = "Semi-grandcanonical potential [eV/atom]"

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -663,8 +663,11 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True, yl
             right-end side labels.
         ylim: If given, applied via ``ax.set_ylim`` before the labels are placed,
             so the side labels are clamped to (and spread within) this window.
+            A scalar is treated as ``(None, ylim)`` — an upper bound only.
     """
     if ylim is not None:
+        if np.isscalar(ylim):
+            ylim = (None, ylim)
         ax.set_ylim(ylim)
 
     # Extract phase → color from the seaborn legend (used by both label sets).
@@ -762,10 +765,11 @@ def plot_1d_mu_phase_diagram(
         side_labels (bool, optional):
             If True, remove the default seaborn legend and label every phase at
             the right end of its line instead. Defaults to True.
-        ylim (tuple, optional):
-            If given, applied like :func:`matplotlib.pyplot.ylim`. It also bounds
-            the side-label stack: a label whose line end is above the window is
-            moved to a mirrored stack on the left.
+        ylim (tuple or float, optional):
+            If given, applied like :func:`matplotlib.pyplot.ylim`. A scalar is
+            treated as ``(None, ylim)`` (upper bound only). It also bounds the
+            side-label stack: a label whose line end is above the window is moved
+            to a mirrored stack on the left.
 
     Returns:
         matplotlib.axes.Axes:
@@ -847,10 +851,11 @@ def plot_1d_T_phase_diagram(
         side_labels (bool, optional):
             If True, remove the default seaborn legend and label every phase at
             the right end of its line instead. Defaults to True.
-        ylim (tuple, optional):
-            If given, applied like :func:`matplotlib.pyplot.ylim`. It also bounds
-            the side-label stack: a label whose line end is above the window is
-            moved to a mirrored stack on the left.
+        ylim (tuple or float, optional):
+            If given, applied like :func:`matplotlib.pyplot.ylim`. A scalar is
+            treated as ``(None, ylim)`` (upper bound only). It also bounds the
+            side-label stack: a label whose line end is above the window is moved
+            to a mirrored stack on the left.
 
     Returns:
         matplotlib.axes.Axes:

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -503,7 +503,144 @@ def _bold_math(label: str) -> str:
     return "$".join(parts)
 
 
-def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True):
+def _get_renderer(fig):
+    """Return a renderer for *fig*, drawing the canvas first so text can be measured.
+
+    ``Text.get_window_extent`` needs a renderer to report the rendered pixel size of a
+    label.  ``Figure.canvas.get_renderer`` exists on the Agg backend; other backends
+    expose it via the private ``Figure._get_renderer`` (matplotlib >= 3.6).
+    """
+    fig.canvas.draw()
+    if hasattr(fig.canvas, "get_renderer"):
+        return fig.canvas.get_renderer()
+    return fig._get_renderer()
+
+
+def _spread_labels(centers, heights, lo, hi, gap=0.0):
+    """Nudge label centers apart so their vertical extents never overlap.
+
+    Each label *i* occupies ``[center - heights[i]/2, center + heights[i]/2]``.  The
+    returned centers keep the input order's stacking, sit within ``[lo, hi]`` where the
+    stack fits, and move as little as possible from the requested ``centers``.  Works in
+    whatever 1-d coordinate the caller passes (display pixels are convenient because a
+    rendered text height is constant there regardless of the data scale).
+
+    Args:
+        centers: Desired center coordinate of each label.
+        heights: Full extent of each label in the same units as ``centers``.
+        lo, hi: Lower / upper bounds the stack should stay within.
+        gap: Extra clearance to keep between adjacent labels.
+
+    Returns:
+        List of adjusted centers, one per input label, in the input order.
+    """
+    n = len(centers)
+    if n == 0:
+        return []
+    order = sorted(range(n), key=lambda i: centers[i])
+    adj = list(centers)
+    # Upward pass: push each label up just enough to clear the one below it.
+    prev_top = lo
+    for i in order:
+        half = heights[i] / 2
+        c = max(centers[i], prev_top + half)
+        adj[i] = c
+        prev_top = c + half + gap
+    # Downward pass: pull labels down to respect the top bound while staying separated.
+    next_bot = hi
+    for i in reversed(order):
+        half = heights[i] / 2
+        c = min(adj[i], next_bot - half)
+        adj[i] = c
+        next_bot = c - half - gap
+    return adj
+
+
+def _place_side_labels(ax, df, scan_col, phase_colors):
+    """Label every phase at the end of its line, reserving room adaptively.
+
+    A phase is labelled at its right-hand line end by default.  The horizontal space
+    reserved for the stack is derived from the widest *rendered* label (measured in
+    pixels), not from any string-length heuristic, so the axis is widened by exactly as
+    much as the labels need.  Within a stack the labels are spread vertically so they do
+    not overlap, clamped to the current y-limits.
+
+    If the current y-limit would clip a label off the top (its right-end value lies above
+    the visible window), that phase is instead labelled at its left-hand line end on a
+    mirrored left-hand stack, which is reserved and laid out by the same rules.
+    """
+    fig = ax.figure
+    x_min, x_max = df[scan_col].min(), df[scan_col].max()
+    span0 = x_max - x_min
+
+    # Settle autoscaled limits (and obtain a renderer) before deciding which side each
+    # label belongs to or measuring any text.
+    renderer = _get_renderer(fig)
+    lo_d, hi_d = sorted(ax.get_ylim())
+    axbb = ax.get_window_extent(renderer)
+
+    # Split phases: those visible at the right end label on the right; those whose
+    # right end is above the window label at their left end instead.
+    right, left = [], []
+    for phase, group in df.groupby("phase"):
+        g = group.sort_values(scan_col)
+        right_y = g["phi"].iloc[-1]
+        if right_y > hi_d:
+            left.append((phase, g["phi"].iloc[0]))
+        else:
+            right.append((phase, right_y))
+
+    def make_texts(entries, ha):
+        return [
+            ax.text(
+                x_min, y, phase, transform=ax.transData,
+                ha=ha, va="center", fontsize="small",
+                color=phase_colors.get(phase, "black"), clip_on=True,
+            )
+            for phase, y in entries
+        ]
+
+    right_texts = make_texts(right, "left")
+    left_texts = make_texts(left, "right")
+
+    def measure(texts):
+        if not texts:
+            return 0.0, []
+        ext = [t.get_window_extent(renderer) for t in texts]
+        return max(e.width for e in ext) / axbb.width, [e.height for e in ext]
+
+    gap_frac, margin_frac = 0.02, 0.01
+    f_right, h_right = measure(right_texts)
+    f_left, h_left = measure(left_texts)
+    reserve_r = (gap_frac + f_right + margin_frac) if right_texts else 0.0
+    reserve_l = (gap_frac + f_left + margin_frac) if left_texts else 0.0
+
+    # Widen the axis so the line data occupies the middle (1 - reserve_l - reserve_r) of
+    # it and each stack sits in its reserved strip.
+    denom = max(1.0 - reserve_l - reserve_r, 0.2)
+    total_span = span0 / denom
+    x0 = x_min - reserve_l * total_span
+    ax.set_xlim(x0, x0 + total_span)
+
+    def place(texts, entries, heights, anchor_frac):
+        if not texts:
+            return
+        anchor_x = x0 + anchor_frac * total_span
+        target_px = [
+            ax.transData.transform((anchor_x, min(max(y, lo_d), hi_d)))[1]
+            for _, y in entries
+        ]
+        placed_px = _spread_labels(target_px, heights, axbb.y0, axbb.y1)
+        inv = ax.transData.inverted()
+        for t, py in zip(texts, placed_px):
+            y_d = inv.transform((axbb.x0, py))[1]
+            t.set_position((anchor_x, y_d))
+
+    place(right_texts, right, h_right, 1.0 - margin_frac - f_right)
+    place(left_texts, left, h_left, f_left + margin_frac)
+
+
+def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True, ylim=None):
     """Annotate a 1d phase diagram with inline phase labels.
 
     top_labels
@@ -524,7 +661,12 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True):
         top_labels: If True, add the top-spine ticks and stable-phase labels.
         side_labels: If True, remove the default seaborn legend and add the
             right-end side labels.
+        ylim: If given, applied via ``ax.set_ylim`` before the labels are placed,
+            so the side labels are clamped to (and spread within) this window.
     """
+    if ylim is not None:
+        ax.set_ylim(ylim)
+
     # Extract phase → color from the seaborn legend (used by both label sets).
     phase_colors = {}
     legend = ax.get_legend()
@@ -586,20 +728,7 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True):
             )
 
     if side_labels and not df["stable"].all():
-        # Right-end phase annotations placed just past each line's end but kept
-        # inside the axis by widening the right limit to make room for them.
-        x_min, x_max = df[scan_col].min(), df[scan_col].max()
-        span = x_max - x_min
-        ax.set_xlim(right=x_max + 0.13 * span)
-        for phase, group in df.groupby("phase"):
-            rightmost = group.sort_values(scan_col).iloc[-1]
-            ax.text(
-                rightmost[scan_col] + 0.02 * span, rightmost["phi"], phase,
-                transform=ax.transData,
-                ha="left", va="center", fontsize="small",
-                color=phase_colors.get(phase, "black"),
-                clip_on=True,
-            )
+        _place_side_labels(ax, df, scan_col, phase_colors)
 
 
 def plot_1d_mu_phase_diagram(
@@ -609,7 +738,8 @@ def plot_1d_mu_phase_diagram(
         mark_transitions=True,
         reference_phase=None,
         top_labels=True,
-        side_labels=True):
+        side_labels=True,
+        ylim=None):
     """
     Plot a one dimensional isothermal phase diagram of the semi-grandcanonical
     potential as function of the chemical potential difference.
@@ -632,6 +762,10 @@ def plot_1d_mu_phase_diagram(
         side_labels (bool, optional):
             If True, remove the default seaborn legend and label every phase at
             the right end of its line instead. Defaults to True.
+        ylim (tuple, optional):
+            If given, applied like :func:`matplotlib.pyplot.ylim`. It also bounds
+            the side-label stack: a label whose line end is above the window is
+            moved to a mirrored stack on the left.
 
     Returns:
         matplotlib.axes.Axes:
@@ -658,7 +792,7 @@ def plot_1d_mu_phase_diagram(
         ax=ax,
     )
 
-    _add_1d_phase_legend(ax, df, scan_col="mu", top_labels=top_labels, side_labels=side_labels)
+    _add_1d_phase_legend(ax, df, scan_col="mu", top_labels=top_labels, side_labels=side_labels, ylim=ylim)
 
     if 'border' not in df.columns:
         return ax
@@ -690,6 +824,7 @@ def plot_1d_T_phase_diagram(
         reference_phase=None,
         top_labels=True,
         side_labels=True,
+        ylim=None,
         ):
     """
     Plots a one-dimensional equipotential phase diagram as a function of temperature.
@@ -712,6 +847,10 @@ def plot_1d_T_phase_diagram(
         side_labels (bool, optional):
             If True, remove the default seaborn legend and label every phase at
             the right end of its line instead. Defaults to True.
+        ylim (tuple, optional):
+            If given, applied like :func:`matplotlib.pyplot.ylim`. It also bounds
+            the side-label stack: a label whose line end is above the window is
+            moved to a mirrored stack on the left.
 
     Returns:
         matplotlib.axes.Axes:
@@ -740,7 +879,7 @@ def plot_1d_T_phase_diagram(
         ax=ax,
     )
 
-    _add_1d_phase_legend(ax, df, scan_col="T", top_labels=top_labels, side_labels=side_labels)
+    _add_1d_phase_legend(ax, df, scan_col="T", top_labels=top_labels, side_labels=side_labels, ylim=ylim)
 
     if 'border' not in df.columns:
         return ax

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -556,6 +556,24 @@ def _spread_labels(centers, heights, lo, hi, gap=0.0):
     return adj
 
 
+def _phase_visible_in_band(phi, lo, hi):
+    """Whether a line with potentials ``phi`` (in scan order) shows inside ``[lo, hi]``.
+
+    Visible if any sampled point falls within the band, or if two consecutive points
+    straddle it (the connecting segment crosses the whole window).  Used to drop the
+    label of a phase whose line an applied ``ylim`` pushes entirely out of view.
+    """
+    phi = np.asarray(phi, dtype=float)
+    phi = phi[np.isfinite(phi)]
+    if phi.size == 0:
+        return False
+    if np.any((phi >= lo) & (phi <= hi)):
+        return True
+    below, above = phi < lo, phi > hi
+    crosses = (below[:-1] & above[1:]) | (above[:-1] & below[1:])
+    return bool(np.any(crosses))
+
+
 def _place_side_labels(ax, df, scan_col, phase_colors):
     """Label every phase at the end of its line, reserving room adaptively.
 
@@ -567,7 +585,8 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
 
     If the current y-limit would clip a label off the top (its right-end value lies above
     the visible window), that phase is instead labelled at its left-hand line end on a
-    mirrored left-hand stack, which is reserved and laid out by the same rules.
+    mirrored left-hand stack, which is reserved and laid out by the same rules.  A phase
+    whose line the y-limit pushes entirely out of view is not labelled at all.
     """
     fig = ax.figure
     x_min, x_max = df[scan_col].min(), df[scan_col].max()
@@ -580,10 +599,14 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
     axbb = ax.get_window_extent(renderer)
 
     # Split phases: those visible at the right end label on the right; those whose
-    # right end is above the window label at their left end instead.
+    # right end is above the window label at their left end instead.  A phase whose
+    # whole line is pushed out of view by the y-limit gets no label at all.
     right, left = [], []
     for phase, group in df.groupby("phase"):
         g = group.sort_values(scan_col)
+        phi = g["phi"].to_numpy()
+        if not _phase_visible_in_band(phi, lo_d, hi_d):
+            continue
         right_y = g["phi"].iloc[-1]
         if right_y > hi_d:
             left.append((phase, g["phi"].iloc[0]))
@@ -769,7 +792,8 @@ def plot_1d_mu_phase_diagram(
             If given, applied like :func:`matplotlib.pyplot.ylim`. A scalar is
             treated as ``(None, ylim)`` (upper bound only). It also bounds the
             side-label stack: a label whose line end is above the window is moved
-            to a mirrored stack on the left.
+            to a mirrored stack on the left, and a phase whose line is pushed
+            entirely out of view is not labelled.
 
     Returns:
         matplotlib.axes.Axes:
@@ -855,7 +879,8 @@ def plot_1d_T_phase_diagram(
             If given, applied like :func:`matplotlib.pyplot.ylim`. A scalar is
             treated as ``(None, ylim)`` (upper bound only). It also bounds the
             side-label stack: a label whose line end is above the window is moved
-            to a mirrored stack on the left.
+            to a mirrored stack on the left, and a phase whose line is pushed
+            entirely out of view is not labelled.
 
     Returns:
         matplotlib.axes.Axes:

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -649,10 +649,11 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
         if not texts:
             return
         anchor_x = x0 + anchor_frac * total_span
-        target_px = [
-            ax.transData.transform((anchor_x, min(max(y, lo_d), hi_d)))[1]
-            for _, y in entries
-        ]
+        # Spread the true (unclamped) line-terminal pixels: _spread_labels bounds the
+        # result to the axes box itself, so the labels stay in the window while keeping
+        # the terminals' vertical order.  Pre-clamping would tie targets that fall
+        # outside the window and collapse that order.
+        target_px = [ax.transData.transform((anchor_x, y))[1] for _, y in entries]
         placed_px = _spread_labels(target_px, heights, axbb.y0, axbb.y1)
         inv = ax.transData.inverted()
         for t, py in zip(texts, placed_px):

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -574,7 +574,7 @@ def _phase_visible_in_band(phi, lo, hi):
     return bool(np.any(crosses))
 
 
-def _place_side_labels(ax, df, scan_col, phase_colors):
+def _place_side_labels(ax, df, scan_col, phase_colors, top_texts=()):
     """Label every phase at the end of its line, reserving room adaptively.
 
     A phase is labelled at its right-hand line end by default.  The horizontal space
@@ -587,6 +587,9 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
     the visible window), that phase is instead labelled at its left-hand line end on a
     mirrored left-hand stack, which is reserved and laid out by the same rules.  A phase
     whose line the y-limit pushes entirely out of view is not labelled at all.
+
+    ``top_texts`` are the bold top stable-phase labels; both stacks are capped just below
+    their rendered bottom so they never intrude into that band.
     """
     fig = ax.figure
     x_min, x_max = df[scan_col].min(), df[scan_col].max()
@@ -597,6 +600,12 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
     renderer = _get_renderer(fig)
     lo_d, hi_d = sorted(ax.get_ylim())
     axbb = ax.get_window_extent(renderer)
+
+    # Ceiling for both stacks: just below the bold top-label band so they don't collide.
+    hi_px = axbb.y1
+    if len(top_texts):
+        top_bottom = min(t.get_window_extent(renderer).y0 for t in top_texts)
+        hi_px = max(min(hi_px, top_bottom - 0.01 * axbb.height), axbb.y0)
 
     # Split phases: those visible at the right end label on the right; those whose
     # right end is above the window label at their left end instead.  A phase whose
@@ -654,7 +663,7 @@ def _place_side_labels(ax, df, scan_col, phase_colors):
         # the terminals' vertical order.  Pre-clamping would tie targets that fall
         # outside the window and collapse that order.
         target_px = [ax.transData.transform((anchor_x, y))[1] for _, y in entries]
-        placed_px = _spread_labels(target_px, heights, axbb.y0, axbb.y1)
+        placed_px = _spread_labels(target_px, heights, axbb.y0, hi_px)
         inv = ax.transData.inverted()
         for t, py in zip(texts, placed_px):
             y_d = inv.transform((axbb.x0, py))[1]
@@ -715,6 +724,7 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True, yl
     # Store so tests (or user code) can still access the color map.
     ax._landau_phase_colors = phase_colors
 
+    top_texts = []
     if top_labels and "border" in df.columns:
         # Interior transition positions only.
         x_min = df[scan_col].min()
@@ -747,15 +757,15 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True, yl
                 )
             phase = stable_phases[0]
             # White outline keeps the bold label legible on top of tielines.
-            _text_with_outline(
+            top_texts.append(_text_with_outline(
                 ax, mid, 0.97, _bold_math(phase),
                 transform=xform,
                 ha="center", va="top", fontsize="small", fontweight="bold",
                 color=phase_colors.get(phase, "black"),
-            )
+            ))
 
     if side_labels and not df["stable"].all():
-        _place_side_labels(ax, df, scan_col, phase_colors)
+        _place_side_labels(ax, df, scan_col, phase_colors, top_texts)
 
 
 def plot_1d_mu_phase_diagram(

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -1072,6 +1072,27 @@ def test_longer_labels_reserve_more_space(df_T_three_stable):
 # ---------------------------------------------------------------------------
 
 
+def test_side_labels_keep_terminal_order_when_clamped():
+    """Spread labels keep their line-terminal vertical order, even clamped to the window.
+
+    'a' ends higher (-8) than 'b' (-10); both terminals fall below the window so both
+    are pulled to the bottom edge.  Pre-clamping tied them and fell back to alphabetical
+    order (b above a); the fix keeps the terminal order (a above b).
+    """
+    df = _synthetic_T_df({
+        "a": np.linspace(0.0, -8.0, 6),
+        "b": np.linspace(0.0, -10.0, 6),
+    })
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(-2.0, 2.0), top_labels=False)
+        ypos = {t.get_text(): t.get_position()[1] for t in _side_label_artists(ax)}
+        assert set(ypos) == {"a", "b"}
+        assert ypos["a"] > ypos["b"], f"terminal order not preserved: {ypos}"
+    finally:
+        plt.close(fig)
+
+
 def test_side_labels_do_not_overlap():
     """Side labels in a stack never overlap vertically once placed.
 

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -1128,6 +1128,27 @@ def test_side_labels_keep_terminal_order_when_clamped():
         plt.close(fig)
 
 
+def test_side_labels_stay_below_top_labels(df_T_three_stable):
+    """Both side stacks are capped below the bold top stable-phase labels.
+
+    With a ylim placing a right-end value near the top of the window, the side label
+    would otherwise rise into the top-label band; it must be pushed below it.
+    """
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="fcc", ylim=(-0.16, 0.16))
+        renderer = _renderer(fig)
+        top_boxes = [t.get_window_extent(renderer) for t in _top_label_artists(ax)]
+        side_boxes = [t.get_window_extent(renderer) for t in _side_label_artists(ax)]
+        assert top_boxes, "no top labels present"
+        assert side_boxes, "no side labels present"
+        top_bottom = min(b.y0 for b in top_boxes)
+        for b in side_boxes:
+            assert b.y1 <= top_bottom + 0.5, "side label intrudes into the top-label band"
+    finally:
+        plt.close(fig)
+
+
 def test_side_labels_do_not_overlap():
     """Side labels in a stack never overlap vertically once placed.
 

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -590,6 +590,41 @@ def test_plot_1d_T_reference_phase_all_transitions_marked(df_T_three_stable):
         plt.close(fig)
 
 
+def _transition_text_artists(ax):
+    """Return the rotated transition-marker text artists ($T=...$ / $\\Delta\\mu=...$)."""
+    return [t for t in ax.texts if abs(t.get_rotation() - 90.0) < 1e-6]
+
+
+@pytest.mark.parametrize(
+    "plot_func, fixture, ylim",
+    [
+        (plot_1d_T_phase_diagram, "df_T_three_stable", (-3.3, -3.1)),
+        (plot_1d_mu_phase_diagram, "df_mu_three_stable", (-3.3, -3.1)),
+    ],
+)
+def test_transition_labels_stay_inside_axis_under_ylim(plot_func, fixture, ylim, request):
+    """A zoomed ylim keeps the transition-marker text inside the axes.
+
+    The labels are positioned in axes-fraction y, so they no longer track the crossing
+    phi (which the zoom can place far outside the window).
+    """
+    df = request.getfixturevalue(fixture)
+    fig, ax = plt.subplots()
+    try:
+        plot_func(df, ax=ax, ylim=ylim)
+        renderer = _renderer(fig)
+        axbb = ax.get_window_extent(renderer)
+        labels = _transition_text_artists(ax)
+        assert labels, "no transition-marker labels found"
+        for t in labels:
+            bb = t.get_window_extent(renderer)
+            assert axbb.y0 - 0.5 <= bb.y0 and bb.y1 <= axbb.y1 + 0.5, (
+                f"{t.get_text()!r} y-box [{bb.y0}, {bb.y1}] outside axes [{axbb.y0}, {axbb.y1}]"
+            )
+    finally:
+        plt.close(fig)
+
+
 # ---------------------------------------------------------------------------
 # Custom phase legend (_add_1d_phase_legend)
 # ---------------------------------------------------------------------------

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -967,6 +967,25 @@ def test_ylim_sets_axis_limits(plot_func, fixture, request):
         plt.close(fig)
 
 
+def test_ylim_scalar_sets_upper_bound_only(df_T_three_stable):
+    """A scalar ylim sets only the top; the bottom stays at its autoscaled value."""
+    fig0, ax0 = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax0)
+        auto_bottom = ax0.get_ylim()[0]
+    finally:
+        plt.close(fig0)
+
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, ylim=0.2)
+        bottom, top = ax.get_ylim()
+        assert top == pytest.approx(0.2)
+        assert bottom == pytest.approx(auto_bottom)
+    finally:
+        plt.close(fig)
+
+
 def test_ylim_clamps_side_labels_within_window(df_T_three_stable):
     """Side labels stay within the ylim window (their y is clamped to it)."""
     ylim = (-0.05, 0.05)

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -29,6 +29,7 @@ from landau.plot import (
     _assign_segment_ids,
     _bold_math,
     _bridge_unstable_segments,
+    _phase_visible_in_band,
     _spread_labels,
     plot_1d_mu_phase_diagram,
     plot_1d_T_phase_diagram,
@@ -643,6 +644,23 @@ def _renderer(fig):
     return fig.canvas.get_renderer()
 
 
+def _synthetic_T_df(specs):
+    """Build a 1d T-scan frame with controlled per-phase phi curves.
+
+    ``specs`` maps a phase name to its phi values along the scan.  All rows are marked
+    unstable so the side-label stack is exercised; no 'border' column is added so the
+    plot function returns right after the legend (top labels and transition markers are
+    skipped, keeping the test focused on the side stack).
+    """
+    n = len(next(iter(specs.values())))
+    T = np.linspace(0.0, 1.0, n)
+    frames = [
+        pd.DataFrame({"T": T, "mu": 0.0, "phase": phase, "phi": np.asarray(phi, float), "stable": False})
+        for phase, phi in specs.items()
+    ]
+    return pd.concat(frames, ignore_index=True)
+
+
 def test_mu_phase_legend_removed(df_mu_three_stable):
     """The seaborn phase legend is replaced: no phase names appear in any legend."""
     fig, ax = plt.subplots()
@@ -986,14 +1004,15 @@ def test_ylim_scalar_sets_upper_bound_only(df_T_three_stable):
         plt.close(fig)
 
 
-def test_ylim_clamps_side_labels_within_window(df_T_three_stable):
+def test_ylim_clamps_side_labels_within_window():
     """Side labels stay within the ylim window (their y is clamped to it)."""
-    ylim = (-0.05, 0.05)
+    df = _synthetic_T_df({"rising": np.linspace(-1.0, 3.0, 6), "flat": np.zeros(6)})
+    ylim = (-2.0, 2.0)
     fig, ax = plt.subplots()
     try:
-        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, ylim=ylim)
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=ylim, top_labels=False)
         labels = _side_label_artists(ax)
-        assert labels, "no side labels drawn"
+        assert {t.get_text() for t in labels} == {"rising", "flat"}
         for t in labels:
             y = t.get_position()[1]
             assert ylim[0] - 1e-9 <= y <= ylim[1] + 1e-9, f"{t.get_text()!r} at y={y} outside {ylim}"
@@ -1053,12 +1072,20 @@ def test_longer_labels_reserve_more_space(df_T_three_stable):
 # ---------------------------------------------------------------------------
 
 
-def test_side_labels_do_not_overlap(df_T_three_stable):
-    """Side labels in a stack never overlap vertically once placed."""
-    ylim = (-0.05, 0.05)  # tight window forces the targets close together
+def test_side_labels_do_not_overlap():
+    """Side labels in a stack never overlap vertically once placed.
+
+    Three phases whose right ends nearly coincide would collide without spreading.
+    """
+    df = _synthetic_T_df({
+        "a": np.linspace(-0.8, 0.00, 6),
+        "b": np.linspace(-0.7, 0.03, 6),
+        "c": np.linspace(-0.9, -0.03, 6),
+    })
     fig, ax = plt.subplots()
     try:
-        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, ylim=ylim)
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(-1.0, 1.0), top_labels=False)
+        assert len(_side_label_artists(ax)) == 3
         renderer = _renderer(fig)
         # Each stack shares an x anchor; group by ha so the two columns are checked apart.
         for ha in ("left", "right"):
@@ -1077,41 +1104,50 @@ def test_side_labels_do_not_overlap(df_T_three_stable):
 # ---------------------------------------------------------------------------
 
 
-def test_ylim_moves_clipped_label_to_left_stack(df_T_three_stable):
-    """A phase whose right end is above the window is labelled on the left (ha='right')."""
-    df = df_T_three_stable
-    # Pick a ylim top that cuts off at least one phase's right-end value but not all.
-    right_ends = df.sort_values("T").groupby("phase", group_keys=False).apply(
-        lambda g: g["phi"].iloc[-1], include_groups=False
-    )
-    assert right_ends.nunique() > 1, "fixture needs phases with distinct right-end phi"
-    top = (right_ends.min() + right_ends.max()) / 2
-    expected_left = set(right_ends[right_ends > top].index)
-    expected_right = set(right_ends[right_ends <= top].index)
-    assert expected_left and expected_right, "ylim must split phases across both stacks"
+def test_ylim_moves_clipped_label_to_left_stack():
+    """A phase visible at its left end but clipped off the top labels on the left.
 
+    'rising' is visible at low T but exits the top of the window before its right end,
+    so it labels on the left (ha='right'); 'flat' stays in view and labels on the right.
+    """
+    df = _synthetic_T_df({"rising": np.linspace(-1.0, 3.0, 6), "flat": np.zeros(6)})
     fig, ax = plt.subplots()
     try:
-        plot_1d_T_phase_diagram(df, ax=ax, ylim=(df["phi"].min() - 0.05, top))
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(-2.0, 2.0), top_labels=False)
         left_labels = {t.get_text() for t in ax.texts if t.get_ha() == "right" and t.get_va() == "center"}
         right_labels = {t.get_text() for t in ax.texts if t.get_ha() == "left" and t.get_va() == "center"}
-        assert left_labels == expected_left
-        assert right_labels == expected_right
+        assert left_labels == {"rising"}
+        assert right_labels == {"flat"}
     finally:
         plt.close(fig)
 
 
-def test_left_stack_reserves_space_on_left(df_T_three_stable):
-    """When labels move to the left stack, the left x-limit is widened to fit them."""
-    df = df_T_three_stable
-    x_data_min = df["T"].min()
-    top = df["phi"].min() + 0.01  # very low top so most phases spill to the left
-
+def test_ylim_drops_fully_invisible_phase_labels():
+    """A phase whose whole line the y-limit pushes out of view gets no label."""
+    df = _synthetic_T_df({
+        "rising": np.linspace(-1.0, 3.0, 6),  # visible at left, clipped top -> left stack
+        "flat": np.zeros(6),                   # fully in view -> right stack
+        "above": np.full(6, 5.0),              # entirely above the window -> dropped
+        "below": np.full(6, -5.0),             # entirely below the window -> dropped
+    })
     fig, ax = plt.subplots()
     try:
-        plot_1d_T_phase_diagram(df, ax=ax, ylim=(df["phi"].min() - 0.05, top))
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(-2.0, 2.0), top_labels=False)
+        labelled = {t.get_text() for t in _side_label_artists(ax)}
+        assert labelled == {"rising", "flat"}
+    finally:
+        plt.close(fig)
+
+
+def test_left_stack_reserves_space_on_left():
+    """When labels move to the left stack, the left x-limit is widened to fit them."""
+    df = _synthetic_T_df({"rise1": np.linspace(-1.0, 3.0, 6), "rise2": np.linspace(-1.2, 4.0, 6)})
+    x_data_min = df["T"].min()
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(-2.0, 2.0), top_labels=False)
         left_stack = [t for t in ax.texts if t.get_ha() == "right" and t.get_va() == "center"]
-        assert left_stack, "expected a populated left stack"
+        assert {t.get_text() for t in left_stack} == {"rise1", "rise2"}
         # The left x-limit has been pushed below the leftmost data point to make room.
         assert ax.get_xlim()[0] < x_data_min
         # Every left label sits inside the axis.
@@ -1122,3 +1158,30 @@ def test_left_stack_reserves_space_on_left(df_T_three_stable):
             assert bb.x0 >= axbb.x0 - 0.5, f"{t.get_text()!r} clipped past the left spine"
     finally:
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# _phase_visible_in_band — line visibility within a y-window
+# ---------------------------------------------------------------------------
+
+
+def test_phase_visible_point_inside_band():
+    assert _phase_visible_in_band([5.0, 6.0, 7.0], 5.5, 6.5) is True
+
+
+def test_phase_visible_all_above_band():
+    assert _phase_visible_in_band([5.0, 6.0], 0.0, 1.0) is False
+
+
+def test_phase_visible_all_below_band():
+    assert _phase_visible_in_band([-5.0, -6.0], 0.0, 1.0) is False
+
+
+def test_phase_visible_segment_crosses_band():
+    # No sampled point lies inside, but the segment straddles the whole window.
+    assert _phase_visible_in_band([-5.0, 5.0], -1.0, 1.0) is True
+
+
+def test_phase_visible_empty_or_nan():
+    assert _phase_visible_in_band([np.nan, np.nan], 0.0, 1.0) is False
+    assert _phase_visible_in_band([], 0.0, 1.0) is False

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -29,6 +29,7 @@ from landau.plot import (
     _assign_segment_ids,
     _bold_math,
     _bridge_unstable_segments,
+    _spread_labels,
     plot_1d_mu_phase_diagram,
     plot_1d_T_phase_diagram,
 )
@@ -628,6 +629,20 @@ def _legend_texts(ax):
     return set() if legend is None else {t.get_text() for t in legend.texts}
 
 
+def _side_label_artists(ax):
+    """Return the Text artists for the right/left side-label stacks on *ax*.
+
+    Both stacks use va='center'; the right stack is ha='left', the left ha='right'.
+    The top-spine labels use va='top', so filtering on va='center' isolates them.
+    """
+    return [t for t in ax.texts if t.get_va() == "center" and t.get_ha() in ("left", "right")]
+
+
+def _renderer(fig):
+    fig.canvas.draw()
+    return fig.canvas.get_renderer()
+
+
 def test_mu_phase_legend_removed(df_mu_three_stable):
     """The seaborn phase legend is replaced: no phase names appear in any legend."""
     fig, ax = plt.subplots()
@@ -888,5 +903,203 @@ def test_T_no_right_annotations_stable_only(df_T_three_stable):
     try:
         plot_1d_T_phase_diagram(df, ax=ax)
         assert _right_annotations(ax) == []
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# _spread_labels — vertical overlap resolution
+# ---------------------------------------------------------------------------
+
+
+def test_spread_labels_separates_coincident_targets():
+    """Three labels requesting the same center come out non-overlapping in [lo, hi]."""
+    out = _spread_labels([5.0, 5.0, 5.0], [1.0, 1.0, 1.0], lo=0.0, hi=10.0)
+    out = sorted(out)
+    for a, b in zip(out, out[1:]):
+        assert b - a >= 1.0 - 1e-9, f"labels overlap: {out}"
+    assert out[0] >= 0.0 - 1e-9 and out[-1] <= 10.0 + 1e-9
+
+
+def test_spread_labels_leaves_separated_targets_untouched():
+    """Targets already clear of one another are returned unchanged."""
+    out = _spread_labels([1.0, 5.0, 9.0], [1.0, 1.0, 1.0], lo=0.0, hi=10.0)
+    np.testing.assert_allclose(out, [1.0, 5.0, 9.0])
+
+
+def test_spread_labels_preserves_input_order():
+    """The returned list is aligned with the input order, not the sorted order."""
+    out = _spread_labels([9.0, 1.0, 5.0], [1.0, 1.0, 1.0], lo=0.0, hi=10.0)
+    # largest target stays the largest output, smallest stays smallest
+    assert out[0] == max(out)
+    assert out[1] == min(out)
+
+
+def test_spread_labels_respects_top_bound():
+    """Targets piled near the top are pushed down to fit under hi."""
+    out = _spread_labels([9.5, 9.6, 9.7], [1.0, 1.0, 1.0], lo=0.0, hi=10.0)
+    assert max(out) <= 10.0 + 1e-9
+    out_sorted = sorted(out)
+    for a, b in zip(out_sorted, out_sorted[1:]):
+        assert b - a >= 1.0 - 1e-9
+
+
+# ---------------------------------------------------------------------------
+# ylim keyword
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plot_func, fixture",
+    [
+        (plot_1d_mu_phase_diagram, "df_mu_three_stable"),
+        (plot_1d_T_phase_diagram, "df_T_three_stable"),
+    ],
+)
+def test_ylim_sets_axis_limits(plot_func, fixture, request):
+    """The ylim kwarg sets the axes y-limits like the matplotlib builtin."""
+    df = request.getfixturevalue(fixture)
+    fig, ax = plt.subplots()
+    try:
+        plot_func(df, ax=ax, ylim=(-0.1, 0.2))
+        np.testing.assert_allclose(ax.get_ylim(), (-0.1, 0.2))
+    finally:
+        plt.close(fig)
+
+
+def test_ylim_clamps_side_labels_within_window(df_T_three_stable):
+    """Side labels stay within the ylim window (their y is clamped to it)."""
+    ylim = (-0.05, 0.05)
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, ylim=ylim)
+        labels = _side_label_artists(ax)
+        assert labels, "no side labels drawn"
+        for t in labels:
+            y = t.get_position()[1]
+            assert ylim[0] - 1e-9 <= y <= ylim[1] + 1e-9, f"{t.get_text()!r} at y={y} outside {ylim}"
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive width reservation (rendered text size, not string length)
+# ---------------------------------------------------------------------------
+
+
+def test_side_labels_fit_inside_axis(df_T_three_stable):
+    """Every side label's rendered box fits horizontally inside the axes."""
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax)
+        renderer = _renderer(fig)
+        axbb = ax.get_window_extent(renderer)
+        labels = _side_label_artists(ax)
+        assert labels, "no side labels drawn"
+        for t in labels:
+            bb = t.get_window_extent(renderer)
+            assert axbb.x0 - 0.5 <= bb.x0 and bb.x1 <= axbb.x1 + 0.5, (
+                f"{t.get_text()!r} box [{bb.x0}, {bb.x1}] not within axes [{axbb.x0}, {axbb.x1}]"
+            )
+    finally:
+        plt.close(fig)
+
+
+def test_longer_labels_reserve_more_space(df_T_three_stable):
+    """Wider rendered labels reserve more horizontal room than narrow ones.
+
+    The reservation is read off the rendered text size, so renaming the phases to long
+    strings widens the right x-limit beyond what the short names need — no string-length
+    heuristic, just the measured box.
+    """
+    short = df_T_three_stable
+    long = short.copy()
+    long["phase"] = long["phase"].map(lambda p: p + "_" + "x" * 30)
+
+    x_data_max = short["T"].max()
+
+    def reserved(df):
+        fig, ax = plt.subplots()
+        try:
+            plot_1d_T_phase_diagram(df, ax=ax)
+            return ax.get_xlim()[1] - x_data_max
+        finally:
+            plt.close(fig)
+
+    assert reserved(long) > reserved(short)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive vertical avoidance
+# ---------------------------------------------------------------------------
+
+
+def test_side_labels_do_not_overlap(df_T_three_stable):
+    """Side labels in a stack never overlap vertically once placed."""
+    ylim = (-0.05, 0.05)  # tight window forces the targets close together
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, ylim=ylim)
+        renderer = _renderer(fig)
+        # Each stack shares an x anchor; group by ha so the two columns are checked apart.
+        for ha in ("left", "right"):
+            boxes = sorted(
+                (t.get_window_extent(renderer) for t in _side_label_artists(ax) if t.get_ha() == ha),
+                key=lambda b: b.y0,
+            )
+            for lower, upper in zip(boxes, boxes[1:]):
+                assert upper.y0 >= lower.y1 - 0.5, "side labels overlap vertically"
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Left-hand stack for labels clipped off the top by ylim
+# ---------------------------------------------------------------------------
+
+
+def test_ylim_moves_clipped_label_to_left_stack(df_T_three_stable):
+    """A phase whose right end is above the window is labelled on the left (ha='right')."""
+    df = df_T_three_stable
+    # Pick a ylim top that cuts off at least one phase's right-end value but not all.
+    right_ends = df.sort_values("T").groupby("phase", group_keys=False).apply(
+        lambda g: g["phi"].iloc[-1], include_groups=False
+    )
+    assert right_ends.nunique() > 1, "fixture needs phases with distinct right-end phi"
+    top = (right_ends.min() + right_ends.max()) / 2
+    expected_left = set(right_ends[right_ends > top].index)
+    expected_right = set(right_ends[right_ends <= top].index)
+    assert expected_left and expected_right, "ylim must split phases across both stacks"
+
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(df["phi"].min() - 0.05, top))
+        left_labels = {t.get_text() for t in ax.texts if t.get_ha() == "right" and t.get_va() == "center"}
+        right_labels = {t.get_text() for t in ax.texts if t.get_ha() == "left" and t.get_va() == "center"}
+        assert left_labels == expected_left
+        assert right_labels == expected_right
+    finally:
+        plt.close(fig)
+
+
+def test_left_stack_reserves_space_on_left(df_T_three_stable):
+    """When labels move to the left stack, the left x-limit is widened to fit them."""
+    df = df_T_three_stable
+    x_data_min = df["T"].min()
+    top = df["phi"].min() + 0.01  # very low top so most phases spill to the left
+
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_T_phase_diagram(df, ax=ax, ylim=(df["phi"].min() - 0.05, top))
+        left_stack = [t for t in ax.texts if t.get_ha() == "right" and t.get_va() == "center"]
+        assert left_stack, "expected a populated left stack"
+        # The left x-limit has been pushed below the leftmost data point to make room.
+        assert ax.get_xlim()[0] < x_data_min
+        # Every left label sits inside the axis.
+        renderer = _renderer(fig)
+        axbb = ax.get_window_extent(renderer)
+        for t in left_stack:
+            bb = t.get_window_extent(renderer)
+            assert bb.x0 >= axbb.x0 - 0.5, f"{t.get_text()!r} clipped past the left spine"
     finally:
         plt.close(fig)


### PR DESCRIPTION
Tunes the 1d phase-diagram side-label legend (`plot_1d_mu_phase_diagram` / `plot_1d_T_phase_diagram`).

## Changes

1. **`ylim` keyword** on both functions. Applied via `ax.set_ylim` like the matplotlib builtin, and used to bound the side-label stack (label `y` is clamped to the window).

2. **Adaptive width reservation.** The room reserved for the right-hand label stack is now derived from the widest *rendered* label, measured in pixels via the figure renderer (`Text.get_window_extent`), not a string-length heuristic. The right x-limit is widened by exactly the fraction of the axes width the widest label occupies.

3. **Vertical overlap avoidance.** Labels in a stack are spread apart so their rendered boxes never overlap (`_spread_labels`, a pure two-pass placer resolved in display space and clamped to `[lo, hi]`).

4. **Left-hand stack for clipped labels.** When `ylim` would clip a label off the top — its line end sits above the window — that phase is labelled at its left line end on a mirrored left-hand stack, reserved and laid out by the same rules. With the default (autoscaled) `ylim` nothing is clipped, so all labels stay on the right and behaviour is unchanged.

## Tests

`tests/unit/plot/test_1d_plots.py`:
- `_spread_labels` unit tests: separation of coincident targets, untouched separated targets, input-order preservation, top-bound respect.
- `ylim` sets axes limits and clamps side labels within the window.
- side labels' rendered boxes fit inside the axes; longer phase names reserve strictly more space than short ones.
- side labels in a stack do not overlap vertically (checked from rendered boxes).
- a tight `ylim` moves clipped phases to the left (`ha='right'`) stack and widens the left x-limit to fit them.

Full file: 65 tests pass; `tests/unit/plot/` 112 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUP94FpY3n1dCisbGfjKHK)_