### PR TITLE
fix(plot): bold mathtext subscripts in 1d top-spine labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ These are project-specific preferences distilled from past PR/issue feedback. So
 - Module names: no underscores. `asewrapper`, not `ase_wrapper` (PR #68).
 - Promote single-file modules to subpackages once they grow (as was done for `interpolate/`).
 
+### Git workflow
+- Merge commits are disabled on GitHub; never bring a branch up to date with `git merge`. Rebase onto `origin/main` instead (`git reset` off any stray merge, then `git rebase origin/main`) and force-push, so history stays linear.
+
 ### Do not commit
 - `.hypothesis/`, `_version.py`, stray top-level scripts, duplicate exploratory files (PR #71, #94). Check for duplicates of what you are about to add before pushing.
 

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -434,6 +434,24 @@ def _subtract_reference_phase(df, scan_col, reference_phase):
     return df
 
 
+def _bold_math(label: str) -> str:
+    """Wrap mathtext segments of ``label`` in ``\\mathbf`` so subscripts render bold.
+
+    matplotlib's ``fontweight="bold"`` only affects the regular-text portions of a
+    string; content inside ``$...$`` keeps the regular math weight. Wrapping each
+    math segment in ``\\mathbf{...}`` bolds it to match while leaving arbitrary
+    LaTeX inside renderable. A malformed string (odd number of ``$``) is returned
+    unchanged.
+    """
+    parts = label.split("$")
+    if len(parts) % 2 == 0:  # unbalanced '$' -> leave untouched
+        return label
+    for i in range(1, len(parts), 2):
+        if parts[i]:
+            parts[i] = r"\mathbf{" + parts[i] + "}"
+    return "$".join(parts)
+
+
 def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True):
     """Annotate a 1d phase diagram with inline phase labels.
 
@@ -510,7 +528,7 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True):
             phase = stable_phases[0]
             # White outline keeps the bold label legible on top of tielines.
             _text_with_outline(
-                ax, mid, 0.97, phase,
+                ax, mid, 0.97, _bold_math(phase),
                 transform=xform,
                 ha="center", va="top", fontsize="small", fontweight="bold",
                 color=phase_colors.get(phase, "black"),

--- a/tests/integration/testplots.py
+++ b/tests/integration/testplots.py
@@ -109,6 +109,20 @@ def _calc_1d_mu_hcp_fcc_liquid():
     return ldc.calc_phase_diagram([hcp, fcc, lqd], Ts=1000.0, mu=100, keep_unstable=True)
 
 
+def _calc_1d_mu_intermetallic():
+    """A/B solid solution + AB2 line phase mu scan for the 1D intermetallic testplot.
+
+    The subscripted phase name (``AB$_2$``) exercises the bold-mathtext top-spine
+    label path: AB2 is the stable intermediate over a mu window, with the solid
+    solution stable on the A-rich and B-rich sides.
+    """
+    sa = ldp.LinePhase("A", fixed_concentration=0, line_energy=-2.0, line_entropy=1.0 * ldp.kB)
+    sb = ldp.LinePhase("B", fixed_concentration=1, line_energy=-3.0, line_entropy=1.5 * ldp.kB)
+    solid = ldp.IdealSolution("solid", sa, sb)
+    inter = ldp.LinePhase("AB$_2$", fixed_concentration=2 / 3, line_energy=-2.8, line_entropy=1.3 * ldp.kB)
+    return ldc.calc_phase_diagram([solid, inter], Ts=600.0, mu=200, keep_unstable=True)
+
+
 def plot_1d_T_three_stable(out_dir: Path, **_) -> Path:
     """1D T diagram: three stable phases with concave-down free energies.
 
@@ -156,6 +170,15 @@ def plot_1d_mu_reference_phase(out_dir: Path, **_) -> Path:
     lpl.plot_1d_mu_phase_diagram(df, ax=ax, reference_phase="fcc")
     ax.set_title(r"1D $\mu$ phase diagram with reference_phase='fcc'")
     return _save(fig, out_dir, "1d_mu_reference_phase_diagram")
+
+
+def plot_1d_mu_intermetallic(out_dir: Path, **_) -> Path:
+    """1D mu diagram with a subscripted phase name (AB$_2$), exercising bold mathtext labels."""
+    df = _calc_1d_mu_intermetallic()
+    fig, ax = plt.subplots(figsize=(6, 4))
+    lpl.plot_1d_mu_phase_diagram(df, ax=ax)
+    ax.set_title(r"1D $\mu$ phase diagram (solid / AB$_2$ intermetallic, T=600K)")
+    return _save(fig, out_dir, "1d_mu_intermetallic_phase_diagram")
 
 
 def plot_2d_basics(out_dir: Path, poly_method: str | None = None, tielines: bool = True, **_) -> Path:
@@ -333,6 +356,7 @@ PLOTS = {
     "1d_T_reference_phase":   (plot_1d_T_reference_phase,   ()),
     "1d_mu_three_stable":     (plot_1d_mu_three_stable,     ()),
     "1d_mu_reference_phase":  (plot_1d_mu_reference_phase,  ()),
+    "1d_mu_intermetallic":    (plot_1d_mu_intermetallic,    ()),
     "2d_basics":              (plot_2d_basics,               ("poly_method", "tielines")),
     "2d_basics_mu":           (plot_2d_basics_mu,            ("poly_method",)),
     "2d_toy":                 (plot_2d_toy,                  ("poly_method", "tielines")),

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -27,6 +27,7 @@ import landau.calculate as ldc
 import landau.phases as ldp
 from landau.plot import (
     _assign_segment_ids,
+    _bold_math,
     plot_1d_mu_phase_diagram,
     plot_1d_T_phase_diagram,
 )
@@ -683,6 +684,42 @@ def test_top_spine_labels_bold_with_white_outline(df_T_three_stable):
             assert to_rgba(effects[0]._gc["foreground"]) == to_rgba("white")
     finally:
         plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("Al", "Al"),                                       # no math: unchanged
+        ("liquid", "liquid"),
+        ("Ca (bcc)", "Ca (bcc)"),
+        ("Al$_4$Ca$_2$", r"Al$\mathbf{_4}$Ca$\mathbf{_2}$"),
+        ("Al$_{14}$Ca$_{13}$", r"Al$\mathbf{_{14}}$Ca$\mathbf{_{13}}$"),
+        (r"$\frac{1}{2}$AB", r"$\mathbf{\frac{1}{2}}$AB"),  # arbitrary LaTeX preserved
+        ("a$b$c$d", "a$b$c$d"),                             # unbalanced '$': untouched
+        ("X$$Y", "X$$Y"),                                   # empty math segment: untouched
+    ],
+)
+def test_bold_math_wraps_math_segments(label, expected):
+    assert _bold_math(label) == expected
+
+
+def _label_darkness(text):
+    """Rendered ink (summed darkness) of a bold Text artist drawn on a fresh figure."""
+    fig = plt.figure(figsize=(3, 1), dpi=200)
+    try:
+        fig.text(0.5, 0.5, text, fontsize=40, fontweight="bold", ha="center", va="center")
+        fig.canvas.draw()
+        buf = np.asarray(fig.canvas.buffer_rgba())
+        return int((255 - buf[..., 0]).sum())
+    finally:
+        plt.close(fig)
+
+
+def test_bold_math_subscripts_render_bolder():
+    """The \\mathbf wrap actually thickens the subscript; fontweight='bold' alone does not."""
+    plain = _label_darkness("X$_2$")
+    bolded = _label_darkness(_bold_math("X$_2$"))
+    assert bolded > plain * 1.05, f"bolded subscript not thicker: {bolded} vs {plain}"
 
 
 def test_mu_right_annotations_when_unstable(df_mu_three_stable):


### PR DESCRIPTION
The bold top-spine phase labels in `plot_1d_{mu,T}_phase_diagram` rendered formula subscripts in regular weight: matplotlib's `fontweight="bold"` only affects the regular-text portions of a string, not content inside `$...$`. So `Al$_4$Ca$_2$` drew thin `4`/`2` against bold `Al`/`Ca`.

`_bold_math(label)` (in `landau/plot.py`) splits on `$` and wraps each math segment in `\mathbf{...}`, applied at the top-label `ax.text` call. `\mathbf` thickens digit subscripts (`\boldsymbol` leaves digits unchanged, verified by rendered-ink measurement); arbitrary LaTeX inside a segment stays renderable since it is only wrapped in a font group. Strings with an unbalanced number of `$` are returned untouched.

Tests in `tests/unit/test_1d_plots.py`:
- `test_bold_math_wraps_math_segments` — parametrized transform cases (no-math passthrough, single/multi-digit subscripts, `\frac` preserved, unbalanced/empty-segment passthrough).
- `test_bold_math_subscripts_render_bolder` — renders `X$_2$` with and without the wrap and asserts the wrapped form has measurably more ink.

`pytest tests/unit/plot` (109 tests) passes. The two `ruff` warnings on `landau/plot.py` (unused `cluster`/`cluster_T_c` imports, line 12) pre-date this change.

https://claude.ai/code/session_016j81739rHqegChVWioPQXe

---
_Generated by [Claude Code](https://claude.ai/code/session_016j81739rHqegChVWioPQXe)_