### PR TITLE
Apply white-outline path effect to 1d transition marker labels

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -847,9 +847,9 @@ def plot_1d_mu_phase_diagram(
             ax.axvline(mt, color='k', linestyle='dotted', alpha=.5)
             ax.scatter(mt, ft, marker='o', c='k', zorder=10)
 
-            ax.text(mt - .05 * dfm, 0.02, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
-                    transform=ax.get_xaxis_transform(),
-                    rotation='vertical', ha='center', va='bottom')
+            _text_with_outline(ax, mt - .05 * dfm, 0.02, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
+                               transform=ax.get_xaxis_transform(),
+                               rotation='vertical', ha='center', va='bottom')
     ax.set_xlabel("Chemical Potential Difference [eV]")
     ylabel = "Semi-grandcanonical Potential [eV/atom]"
     if reference_phase is not None:
@@ -939,9 +939,9 @@ def plot_1d_T_phase_diagram(
             ax.axvline(Tt, color='k', linestyle='dotted', alpha=.5)
             ax.scatter(Tt, ft, marker='o', c='k', zorder=10)
 
-            ax.text(Tt + .05 * dft, 0.02, rf"$T = {Tt:.0f}\,\mathrm{{K}}$",
-                    transform=ax.get_xaxis_transform(),
-                    rotation='vertical', ha='center', va='bottom')
+            _text_with_outline(ax, Tt + .05 * dft, 0.02, rf"$T = {Tt:.0f}\,\mathrm{{K}}$",
+                               transform=ax.get_xaxis_transform(),
+                               rotation='vertical', ha='center', va='bottom')
 
     ax.set_xlabel("Temperature [K]")
     ylabel = "Semi-grandcanonical potential [eV/atom]"

--- a/landau/plot.py
+++ b/landau/plot.py
@@ -849,7 +849,7 @@ def plot_1d_mu_phase_diagram(
 
             _text_with_outline(ax, mt - .05 * dfm, 0.02, rf"$\Delta\mu = {mt:.03f}\,\mathrm{{eV}}$",
                                transform=ax.get_xaxis_transform(),
-                               rotation='vertical', ha='center', va='bottom')
+                               rotation='vertical', ha='center', va='bottom', zorder=100)
     ax.set_xlabel("Chemical Potential Difference [eV]")
     ylabel = "Semi-grandcanonical Potential [eV/atom]"
     if reference_phase is not None:
@@ -941,7 +941,7 @@ def plot_1d_T_phase_diagram(
 
             _text_with_outline(ax, Tt + .05 * dft, 0.02, rf"$T = {Tt:.0f}\,\mathrm{{K}}$",
                                transform=ax.get_xaxis_transform(),
-                               rotation='vertical', ha='center', va='bottom')
+                               rotation='vertical', ha='center', va='bottom', zorder=100)
 
     ax.set_xlabel("Temperature [K]")
     ylabel = "Semi-grandcanonical potential [eV/atom]"

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -644,6 +644,7 @@ def test_transition_labels_have_white_outline(plot_func, fixture, request):
             effects = t.get_path_effects()
             assert len(effects) == 1, f"{t.get_text()!r} has no path effect"
             assert to_rgba(effects[0]._gc["foreground"]) == to_rgba("white")
+            assert t.get_zorder() >= 100, f"{t.get_text()!r} zorder too low"
     finally:
         plt.close(fig)
 

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -625,6 +625,29 @@ def test_transition_labels_stay_inside_axis_under_ylim(plot_func, fixture, ylim,
         plt.close(fig)
 
 
+@pytest.mark.parametrize(
+    "plot_func, fixture",
+    [
+        (plot_1d_T_phase_diagram, "df_T_three_stable"),
+        (plot_1d_mu_phase_diagram, "df_mu_three_stable"),
+    ],
+)
+def test_transition_labels_have_white_outline(plot_func, fixture, request):
+    """Transition-marker labels are stroked with a white outline (legible over tielines)."""
+    df = request.getfixturevalue(fixture)
+    fig, ax = plt.subplots()
+    try:
+        plot_func(df, ax=ax)
+        labels = _transition_text_artists(ax)
+        assert labels, "no transition-marker labels found"
+        for t in labels:
+            effects = t.get_path_effects()
+            assert len(effects) == 1, f"{t.get_text()!r} has no path effect"
+            assert to_rgba(effects[0]._gc["foreground"]) == to_rgba("white")
+    finally:
+        plt.close(fig)
+
+
 # ---------------------------------------------------------------------------
 # Custom phase legend (_add_1d_phase_legend)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The `_text_with_outline` helper (white path-effect stroke for legibility over coloured fills/tielines) now also wraps the rotated transition-marker labels in `plot_1d_mu_phase_diagram` and `plot_1d_T_phase_diagram`, which previously used a bare `ax.text`.

Added `test_transition_labels_have_white_outline` in `tests/unit/plot/test_1d_plots.py`, asserting each marker label carries exactly one white-foreground path effect, parametrised over both 1d plot functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GeomdcZwCPpECc5MQ1pkX)_