### PR TITLE
Render 1d transition marker labels at 'small' font size

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -705,7 +705,7 @@ def _place_transition_labels(ax, positions, labels, *, side, **text_kw):
     texts = [
         _text_with_outline(
             ax, x, 0.02, s, transform=xform,
-            rotation="vertical", ha="center", va="bottom", zorder=100, **text_kw,
+            rotation="vertical", ha="center", va="bottom", fontsize="small", zorder=100, **text_kw,
         )
         for x, s in zip(positions, labels)
     ]

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -23,6 +23,7 @@ from collections import Counter
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from matplotlib.colors import to_rgba
+from matplotlib.font_manager import FontProperties
 
 import landau.calculate as ldc
 import landau.phases as ldp
@@ -647,6 +648,28 @@ def test_transition_labels_have_white_outline(plot_func, fixture, request):
             assert len(effects) == 1, f"{t.get_text()!r} has no path effect"
             assert to_rgba(effects[0]._gc["foreground"]) == to_rgba("white")
             assert t.get_zorder() >= 100, f"{t.get_text()!r} zorder too low"
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "plot_func, fixture",
+    [
+        (plot_1d_T_phase_diagram, "df_T_three_stable"),
+        (plot_1d_mu_phase_diagram, "df_mu_three_stable"),
+    ],
+)
+def test_transition_labels_use_small_fontsize(plot_func, fixture, request):
+    """Transition-marker labels render at the 'small' size, matching the side labels."""
+    df = request.getfixturevalue(fixture)
+    expected = FontProperties(size="small").get_size_in_points()
+    fig, ax = plt.subplots()
+    try:
+        plot_func(df, ax=ax)
+        labels = _transition_text_artists(ax)
+        assert labels, "no transition-marker labels found"
+        for t in labels:
+            assert t.get_fontsize() == pytest.approx(expected), t.get_text()
     finally:
         plt.close(fig)
 


### PR DESCRIPTION
The vertical transition-marker labels in `plot_1d_mu_phase_diagram` / `plot_1d_T_phase_diagram` rendered at the default font size, while the side stack labels use `fontsize="small"`. Set the marker labels to `"small"` so the two label sets match.

`_place_transition_labels` measures the rendered widths after the text artists are created, so the horizontal spacing adapts to the smaller size with no other change.

Test: `test_transition_labels_use_small_fontsize` asserts each marker label's resolved size equals `FontProperties(size="small")` on the `df_{mu,T}_three_stable` fixtures. Full `tests/unit/plot/test_1d_plots.py` passes (102).

https://claude.ai/code/session_012mhJP3cZo8wtPTp92gdx73

---
_Generated by [Claude Code](https://claude.ai/code/session_012mhJP3cZo8wtPTp92gdx73)_