### PR TITLE
refactor(phases): introduce _scalarize and dedupe 0-d collapse pattern

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -52,6 +52,18 @@ def c_from_dmu(dmu, T, e_defect):
     return 1 / (1 + np.exp(-(dmu - e_defect) / kB / T))
 
 
+def _scalarize(x):
+    """Collapse a 0-d numpy result to a Python scalar; pass everything else through.
+
+    Phase methods promise a Python scalar out when both ``T`` and ``dmu`` are
+    scalars in; broadcasting through ``np.asarray`` / ``np.vectorize`` otherwise
+    leaves them as 0-d arrays. This is the central place to undo that.
+    """
+    if isinstance(x, np.ndarray) and x.ndim == 0:
+        return x.item()
+    return x
+
+
 @dataclass(frozen=True)
 class Phase(ABC):
     """
@@ -101,8 +113,7 @@ class AbstractLinePhase(Phase):
         return self.line_free_energy(T)
 
     def concentration(self, T, dmu):
-        result = np.full(np.broadcast(T, dmu).shape, self.line_concentration)
-        return result.item() if result.ndim == 0 else result
+        return _scalarize(np.full(np.broadcast(T, dmu).shape, self.line_concentration))
 
     def semigrand_potential(self, T, dmu):
         f = self.line_free_energy(T)
@@ -235,9 +246,7 @@ class IdealSolution(Phase):
                     phi = f2 - dmu
                 else:
                     phi[I] = f2 - dmu[I]
-        if phi.shape == ():
-            phi = phi.item()
-        return phi
+        return _scalarize(phi)
 
     def concentration(self, T, dmu):
         p1 = self.phase1
@@ -368,10 +377,7 @@ class RegularSolution(Phase):
         if not isinstance(dmu, np.ndarray):
             if np.isnan(pi):
                 pi = np.inf
-            x = min(pi, pl, f0)
-            if isinstance(x, np.ndarray):
-                x = x.item()
-            return x
+            return _scalarize(min(pi, pl, f0))
         pl[pl > f0] = f0
         I = np.isnan(pi)
         pi[I] = pl[I]
@@ -498,11 +504,7 @@ class InterpolatingPhase(Phase):
         c = c.reshape(output_shape)
         phi = phi.reshape(output_shape)
 
-        if c.ndim == 0:
-            c = c.item()
-        if phi.ndim == 0:
-            phi = phi.item()
-        return phi, c
+        return _scalarize(phi), _scalarize(c)
 
     def semigrand_potential(self, T, dmu):
         return self._find_phi_c(T, dmu)[0]
@@ -600,11 +602,7 @@ class SlowInterpolatingPhase(Phase):
 
     def _find_phi_c(self, T, dmu):
         phi, c = np.squeeze(np.vectorize(self._find_phi_c_scalar)(T, dmu))
-        if c.ndim == 0:
-            c = c.item()
-        if phi.ndim == 0:
-            phi = phi.item()
-        return phi, c
+        return _scalarize(phi), _scalarize(c)
 
     def semigrand_potential(self, T, dmu):
         return self._find_phi_c(T, dmu)[0]

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -5,8 +5,42 @@ from scipy.constants import Boltzmann, eV
 from landau.interpolate import SGTE
 from landau.interpolate.basic import G_calphad
 from landau.phases import IdealSolution, LinePhase, TemperatureDependentLinePhase
+from landau.phases import _scalarize
 
 kB = Boltzmann / eV
+
+
+# --- _scalarize tests ---
+
+
+def test_scalarize_zero_d_float_array_returns_python_float():
+    out = _scalarize(np.array(3.5))
+    assert type(out) is float
+    assert out == 3.5
+
+
+def test_scalarize_zero_d_int_array_returns_python_int():
+    out = _scalarize(np.array(7))
+    assert type(out) is int
+    assert out == 7
+
+
+def test_scalarize_one_d_array_passes_through_unchanged():
+    arr = np.array([1.0, 2.0, 3.0])
+    out = _scalarize(arr)
+    assert out is arr
+
+
+def test_scalarize_python_float_passes_through_unchanged():
+    out = _scalarize(2.5)
+    assert type(out) is float
+    assert out == 2.5
+
+
+def test_scalarize_non_array_with_no_ndim_passes_through():
+    payload = [1, 2, 3]
+    out = _scalarize(payload)
+    assert out is payload
 
 
 def _make_line_phase(c=0.25, energy=-1.0, entropy=0.01):


### PR DESCRIPTION
Five spots in `landau/phases/__init__.py` hand-rolled the same "if result is a 0-d numpy array, return `result.item()` else return result" collapse to keep the scalar-in/scalar-out contract intact:

- `AbstractLinePhase.concentration`
- `IdealSolution.semigrand_potential`
- `RegularSolution.semigrand_potential` (scalar-`dmu` branch)
- `InterpolatingPhase._find_phi_c`
- `SlowInterpolatingPhase._find_phi_c`

Two checked `isinstance(x, np.ndarray)`, one checked `x.shape == ()`, two checked `x.ndim == 0`; the cleanup variants drifted independently.

## Changes

- Add a module-private `_scalarize(x)` helper in `landau/phases/__init__.py`. Returns `x.item()` for 0-d `np.ndarray`, else returns `x` unchanged.
- Route all five sites through it. Net change is `+51 / -19`.

## Tests

- New direct tests for `_scalarize` in `tests/unit/test_phases.py`: 0-d float → `float`, 0-d int → `int`, 1-d array unchanged (identity), Python `float` unchanged, list payload (no `ndim`) unchanged.
- Existing scalar/array parity tests for `LinePhase`, `TemperatureDependentLinePhase`, `IdealSolution` continue to pass unchanged.
- `pytest tests/unit/ tests/regression/` — 374 passed.

Refs #116.

---
_Generated by [Claude Code](https://claude.ai/code/session_019kgMDEd45UQHcmvdfHzdzq)_