### PR TITLE
Make testplot Haiku selector emit JSON, not prose

### DIFF
--- a/.github/scripts/testplot_args.py
+++ b/.github/scripts/testplot_args.py
@@ -21,7 +21,7 @@ import argparse
 import json
 import os
 
-from testplot_common import PLOT_NAMES, POLY_METHODS, run_haiku
+from testplot_common import PLOT_LIST, PLOT_NAMES, POLY_METHODS, run_haiku
 
 # ---------------------------------------------------------------------------
 # parse subcommand
@@ -38,15 +38,10 @@ every matching value rather than picking one.
 
 Flags:
 
-  --only {{{','.join(PLOT_NAMES)}}} [...]
-        restrict to a subset of plots. Plot keys:
-          1d_T_three_stable : 1D temperature diagram (pure-A fcc/hcp/liquid line phases)
-          1d_mu             : 1D chemical-potential diagram (hcp vs fcc isothermal)
-          2d_basics         : 2D c-T diagram (ideal-solution hcp/fcc/liquid)
-          2d_basics_mu      : 2D T-mu diagram (same phases as 2d_basics)
-          2d_toy            : 2D c-T diagram (regular-solution liquid + intermediate solid)
-          2d_toy_mu         : 2D T-mu diagram (same phases as 2d_toy)
-          excess_free_energy: excess free energy vs concentration (Intermetallics example)
+  --only <plot> [...]
+        restrict to a subset of plots. Available plot keys (the ONLY valid
+        values for --only — never invent or guess a key that is not listed):
+{PLOT_LIST}
 
   --poly-method {{{','.join(POLY_METHODS)}}} [...]
         one or more polygon-construction methods, cross-producted over the
@@ -54,16 +49,17 @@ Flags:
 
   --tielines {{on,off}} [...]
         one or more tieline modes, cross-producted over 2D c-T plots
-        (only affects 2d_basics / 2d_toy). Default: on.
+        (only affects 2d_* c-T plots). Default: on.
 
-Mapping conventions:
-  - "1d T" / "1D temperature" -> --only 1d_T_three_stable
-  - "1d mu" / "1D chemical potential" -> --only 1d_mu
-  - "1d" alone -> --only 1d_T_three_stable 1d_mu
-  - "2d" alone -> all four 2D c-T/mu plots
-  - "2d basics" -> 2d_basics 2d_basics_mu ; "2d basics c" -> 2d_basics
-  - "2d toy" -> 2d_toy 2d_toy_mu ; "2d toy mu" -> 2d_toy_mu
-  - "excess" / "excess free energy" -> --only excess_free_energy
+Mapping conventions (match against the plot keys listed above; if several
+keys share a prefix, e.g. multiple `1d_mu_*`, include all of them):
+  - "1d T" / "1D temperature" -> every 1d_T_* key
+  - "1d mu" / "1D chemical potential" -> every 1d_mu_* key
+  - "1d" alone -> every 1d_* key
+  - "2d" alone -> every 2d_* key
+  - "2d basics" -> every 2d_basics* key ; "2d basics c" -> 2d_basics
+  - "2d toy" -> every 2d_toy* key ; "2d toy mu" -> 2d_toy_mu
+  - "excess" / "excess free energy" -> every excess_free_energy* key
   - "fasttsp" / "fast tsp" -> --poly-method fasttsp
   - "all tsp methods" / "tsp methods" -> --poly-method tsp fasttsp segment-tsp segment-fasttsp
   - "segment methods" / "segment tsp methods" -> --poly-method segment-tsp segment-fasttsp
@@ -105,14 +101,9 @@ def _cmd_parse() -> None:
 
 _SELECT_SYSTEM = f"""You pick which phase-diagram tests to render for a PR.
 
-The script tests/integration/testplots.py renders these plots:
-  1d_T_three_stable : 1D temperature diagram (pure-A line phases)
-  1d_mu             : 1D chemical-potential diagram (ideal solutions)
-  2d_basics         : 2D c-T diagram (ideal-solution hcp/fcc/liquid)
-  2d_basics_mu      : 2D T-mu diagram (same phases as 2d_basics)
-  2d_toy            : 2D c-T diagram (regular-solution liquid + intermediate solid)
-  2d_toy_mu         : 2D T-mu diagram (same phases as 2d_toy)
-  excess_free_energy: excess free energy vs concentration (Intermetallics example)
+The script tests/integration/testplots.py renders these plots. These keys are
+the ONLY valid values for --only; never invent or guess a key not listed here:
+{PLOT_LIST}
 
 Flags you can emit:
   --only <plot> [...]                     subset of plots (omit = all {len(PLOT_NAMES)})

--- a/.github/scripts/testplot_common.py
+++ b/.github/scripts/testplot_common.py
@@ -6,38 +6,64 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 POLY_METHODS = ["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"]
 
 
-def _read_plot_names() -> list[str]:
-    """Read available plot names from tests/integration/testplots.py via AST.
+_FALLBACK_PLOTS = [
+    ("1d_T_three_stable", "1D temperature diagram"),
+    ("1d_mu_three_stable", "1D chemical-potential diagram"),
+    ("2d_basics", "2D c-T diagram (ideal solutions)"),
+    ("2d_basics_mu", "2D T-mu diagram (ideal solutions)"),
+    ("2d_toy", "2D c-T diagram (regular solution)"),
+    ("2d_toy_mu", "2D T-mu diagram (regular solution)"),
+    ("excess_free_energy", "excess free energy vs concentration"),
+]
 
-    Parses the PLOTS dict keys without importing landau, so it works in
-    the trusted parse/select job before the package is installed. Always stays
-    in sync with whatever is on the main checkout.
+
+def _read_plots() -> list[tuple[str, str]]:
+    """Read (plot name, one-line description) pairs from testplots.py via AST.
+
+    Parses the PLOTS dict keys and the first docstring line of each mapped
+    plot function, without importing landau, so it works in the trusted
+    parse/select job before the package is installed. The list always stays
+    in sync with whatever plots exist on the main checkout, so the Haiku
+    prompts never reference a renamed or removed plot.
     """
     script = Path(__file__).parents[2] / "tests" / "integration" / "testplots.py"
     try:
         tree = ast.parse(script.read_text())
+        summaries = {
+            node.name: next(iter((ast.get_docstring(node) or "").strip().splitlines()), "").strip()
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.Assign)
                 and any(isinstance(t, ast.Name) and t.id == "PLOTS" for t in node.targets)
                 and isinstance(node.value, ast.Dict)
             ):
-                return [
-                    k.value
-                    for k in node.value.keys
-                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
-                ]
+                plots = []
+                for key, value in zip(node.value.keys, node.value.values):
+                    if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                        continue
+                    fn = value.elts[0] if isinstance(value, ast.Tuple) and value.elts else None
+                    summary = summaries.get(fn.id, "") if isinstance(fn, ast.Name) else ""
+                    plots.append((key.value, summary))
+                if plots:
+                    return plots
     except Exception as exc:
         print(f"warning: could not read PLOTS from testplots.py ({exc}); using fallback list", file=sys.stderr)
-    return ["1d_T_three_stable", "1d_mu", "2d_basics", "2d_basics_mu", "2d_toy", "2d_toy_mu", "excess_free_energy"]
+    return list(_FALLBACK_PLOTS)
 
 
-PLOT_NAMES = _read_plot_names()
+PLOTS = _read_plots()
+PLOT_NAMES = [name for name, _ in PLOTS]
+# Markdown bullet list of "  name : description" lines for the Haiku prompts.
+PLOT_LIST = "\n".join(f"  {name:<22}: {desc}" if desc else f"  {name}" for name, desc in PLOTS)
 
 _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 
@@ -76,20 +102,32 @@ def _validate(payload: dict) -> dict:
 
 
 def _call_claude(prompt: str, system: str) -> str:
-    result = subprocess.run(
-        [
-            "claude",
-            "--model", "claude-haiku-4-5-20251001",
-            "--append-system-prompt", system,
-            "--output-format", "text",
-            "--permission-mode", "plan",
-            "-p", prompt,
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=120,
-    )
+    # Run Haiku as a pure text->JSON transform, not an interactive agent:
+    #   --system-prompt   replaces the default agentic prompt (instead of
+    #                     appending to it), so the model follows our JSON
+    #                     instructions rather than asking the user what to do;
+    #   --tools ""        disables every tool, so there is no plan-mode dance
+    #                     and the model can only emit text;
+    #   cwd=<tmp>         isolates the call from the repo so CLAUDE.md is not
+    #                     auto-discovered and read as a PR-review task.
+    # Without these, Haiku loaded the landau CLAUDE.md and replied with prose
+    # like "What would you like me to do with these changes?" instead of JSON.
+    with tempfile.TemporaryDirectory() as workdir:
+        result = subprocess.run(
+            [
+                "claude",
+                "--model", "claude-haiku-4-5-20251001",
+                "--system-prompt", system,
+                "--tools", "",
+                "--output-format", "text",
+                "-p", prompt,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+            cwd=workdir,
+        )
     return result.stdout
 
 


### PR DESCRIPTION
Run the Haiku CLI as a pure text->JSON transform (--system-prompt replace, --tools "", isolated cwd) so the testplot select stage stops falling back to "render all plots". Also derive the prompt's plot list from testplots.py docstrings so keys never go stale.

Closes #180

Generated with [Claude Code](https://claude.ai/code)