### PR TITLE
Remove dead arctan2 sort in Segments._sort_segments

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -226,7 +226,6 @@ class Segments(AbstractPolyMethod):
         if df.empty:
             return pd.DataFrame(columns=df.columns)
 
-        com = df[[x_col, y_col]].mean()
         norm = np.ptp(df[[x_col, y_col]], axis=0).values
         norm = np.where(norm == 0, 1, norm)
 
@@ -247,13 +246,9 @@ class Segments(AbstractPolyMethod):
         if not segments:
             return pd.DataFrame(columns=df.columns)
 
-        # initial sorting by center of mass angle
-        segments = sorted(
-                segments,
-                key=lambda s: np.arctan2( (s[y_col].mean() - com[y_col]) / norm[1],
-                                          (s[x_col].mean() - com[x_col]) / norm[0])
-        )
-
+        # _greedy_stitch fixes the order: it picks the min-x_col segment as head and
+        # nearest-neighbour stitches the rest, so the segment order on entry here does
+        # not matter.
         ordered = _greedy_stitch(segments, norm, x_col, y_col)
         return pd.concat(ordered, ignore_index=True)
 

--- a/landau/poly.py
+++ b/landau/poly.py
@@ -246,9 +246,6 @@ class Segments(AbstractPolyMethod):
         if not segments:
             return pd.DataFrame(columns=df.columns)
 
-        # _greedy_stitch fixes the order: it picks the min-x_col segment as head and
-        # nearest-neighbour stitches the rest, so the segment order on entry here does
-        # not matter.
         ordered = _greedy_stitch(segments, norm, x_col, y_col)
         return pd.concat(ordered, ignore_index=True)
 

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -319,6 +319,39 @@ def test_greedy_stitch_custom_columns(unit_norm):
     assert out[1].iloc[0]["x"] == pytest.approx(2.0)
 
 
+# --- Segments._sort_segments tests ---
+
+
+def test_sort_segments_orders_by_min_x_not_com_angle():
+    # Three segments in a "^" arrangement (low-left, high-mid, low-right). Their
+    # order around the joint centre of mass differs from their min(c) order, so a
+    # COM-angle pre-sort would lead with a different segment than min(c). The order
+    # of the output is fixed solely by _greedy_stitch's min(c) head heuristic, so it
+    # must follow min(c). Pins that the removed arctan2 pre-sort had no effect.
+    df = pd.DataFrame({
+        "c": [0.0, 0.0, 0.5, 0.5, 1.0, 1.0],
+        "T": [0.0, 0.3, 0.6, 0.9, 0.0, 0.3],
+        "border_segment": [0, 0, 1, 1, 2, 2],
+    })
+
+    com = df[["c", "T"]].mean()
+    norm = np.ptp(df[["c", "T"]], axis=0).values
+    com_angle = {
+        lab: np.arctan2((g["T"].mean() - com["T"]) / norm[1],
+                        (g["c"].mean() - com["c"]) / norm[0])
+        for lab, g in df.groupby("border_segment")
+    }
+    com_order = sorted(com_angle, key=com_angle.get)
+    min_x_order = sorted(com_angle, key=lambda lab: df.loc[df["border_segment"] == lab, "c"].min())
+    # premise: the two orderings disagree, so the test can distinguish them
+    assert com_order != min_x_order
+
+    out = Segments._sort_segments(df)
+    # order in which each segment's c-level first appears in the stitched output
+    first_appearance = list(dict.fromkeys(out["c"].round(6)))
+    assert first_appearance == [0.0, 0.5, 1.0]
+
+
 # --- _pca_sort_segment tests ---
 
 


### PR DESCRIPTION
Closes #209.

Removes the dead COM-angle pre-sort in `Segments._sort_segments`. Experiment on the toy and basics refined diagrams confirms removing it gives byte-identical polygons, while the `min(x_col)` head pick in `_greedy_stitch` is live (head choice changes non-convex polygons) and stays. Adds a test pinning the live `min(x_col)` heuristic.

Generated with [Claude Code](https://claude.ai/code)