### PR TITLE
fix(calculate): replace single-T f_excess branch with isinstance check

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -229,11 +229,10 @@ def calc_phase_diagram(
         return dd.f - (f0 * (1 - dd.c) + f1 * dd.c)
 
     fex = pdf.groupby("T", group_keys=False).apply(sub, include_groups=False)
-    if len(Ts) > 1:
-        pdf["f_excess"] = fex
-    else:
-        # thank you pandas, this saved me -10min of my life.
-        pdf["f_excess"] = fex.T
+    if isinstance(fex, pd.DataFrame):
+        # pandas 3 returns a DataFrame for single-group groupby.apply; undo that.
+        fex = fex.stack().reset_index(level=0, drop=True)
+    pdf["f_excess"] = fex
     if not keep_unstable:
         pdf = pdf.query("stable")
     return pdf

--- a/tests/regression/test_single_group_apply.py
+++ b/tests/regression/test_single_group_apply.py
@@ -1,14 +1,16 @@
-"""Regression tests for pandas 2/3 single-group groupby.apply (issue #134).
+"""Regression tests for pandas 2/3 single-group groupby.apply (issue #134, #160).
 
 Sites tested:
   - get_transitions: calculate.py:309 ``isinstance(res, pd.DataFrame)`` branch
   - AbstractPolyMethod.apply: poly.py:99 single-group dropna semantics
+  - calc_phase_diagram f_excess: calculate.py:231 single-T groupby.apply shape
 """
 import numpy as np
 import pandas as pd
 from matplotlib.patches import Polygon as MplPolygon
 
-from landau.calculate import get_transitions
+from landau.calculate import calc_phase_diagram, get_transitions
+from landau.phases import IdealSolution, LinePhase
 from landau.poly import Concave
 
 
@@ -56,3 +58,24 @@ def test_poly_apply_single_group():
     assert isinstance(result, pd.Series), "apply must return pd.Series not DataFrame"
     assert len(result) == 1
     assert isinstance(result.iloc[0], MplPolygon)
+
+
+def test_calc_phase_diagram_single_T_f_excess():
+    """calc_phase_diagram with a single temperature populates f_excess correctly.
+
+    Pins the single-T groupby.apply site at calculate.py:231. On pandas 3 a
+    single-group ``groupby("T").apply(sub)`` returns a DataFrame instead of a
+    Series; the production fix drops back to a Series before the assignment.
+    Without it ``f_excess`` would be NaN or misaligned.
+    """
+    l1 = LinePhase("A", 0, 0, 0)
+    l2 = LinePhase("B", 1, 0.1, 0)
+    sol = IdealSolution("sol", l1, l2)
+    mu = np.linspace(-0.15, 0.15, 8)
+
+    df = calc_phase_diagram([l1, l2, sol], Ts=[700.0], mu=mu, refine=False, keep_unstable=True)
+
+    assert "f_excess" in df.columns
+    assert len(df["f_excess"]) == len(df)
+    assert pd.api.types.is_float_dtype(df["f_excess"])
+    assert df["f_excess"].notna().all()


### PR DESCRIPTION
Closes #160.

## Changes

`calc_phase_diagram` used a `len(Ts) > 1` guard and an `fex.T` transpose to
work around pandas 3 returning a `DataFrame` for single-group
`groupby("T").apply(sub)` instead of a `Series`. This is the same pandas 3
quirk already fixed in `get_transitions` (`calculate.py:340`) with an
`isinstance(fex, pd.DataFrame)` check.

Replace the `len(Ts)` branch with the same pattern:

```python
fex = pdf.groupby("T", group_keys=False).apply(sub, include_groups=False)
if isinstance(fex, pd.DataFrame):
    fex = fex.stack().reset_index(level=0, drop=True)
pdf["f_excess"] = fex
```

The new `test_calc_phase_diagram_single_T_f_excess` regression test in
`tests/regression/test_single_group_apply.py` pins the single-T path:
it calls `calc_phase_diagram([...], Ts=[700.0], ..., keep_unstable=True)`
and asserts `f_excess` is present, float, and fully non-null.

Full suite: 376 passed, 5 skipped (`pytest`).

https://claude.ai/code/session_014qYKR3a3asKud3MmxuqAkg

---
_Generated by [Claude Code](https://claude.ai/code/session_014qYKR3a3asKud3MmxuqAkg)_