### PR TITLE
Drop title from single-temperature excess free energy plot

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -1413,7 +1413,6 @@ def plot_excess_free_energy(
     else:
         ax = axes[0]
         ax.axhline(0, color=".5", linestyle="--")
-        ax.set_title(f"T = {temperatures[0]:.0f} K")
         ax.set(xlabel="Concentration", ylabel="Free Energy of Formation")
 
     # Place inline labels last so they see the final axis limits (refline/relplot).


### PR DESCRIPTION
Removes the `ax.set_title(...)` from the single-temperature branch of `plot_excess_free_energy`, as requested in the review of #215. The multi-temperature `FacetGrid` path keeps its per-facet titles; a single axes has nothing to distinguish.

Generated with [Claude Code](https://claude.ai/code)