### PR TITLE
Pin handle_poly_method(None) default fall-through chain

### DIFF
--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import shapely
 from hypothesis import given, strategies as st, settings
+import landau.poly as poly_module
 from landau.poly import (
     AbstractPolyMethod,
     Concave,
@@ -227,6 +228,30 @@ def test_handle_poly_method():
 
     with pytest.raises(TypeError):
         handle_poly_method(123)
+
+
+@pytest.mark.skipif(not HAS_FAST_TSP, reason="fast-tsp not installed")
+def test_handle_poly_method_default_chain_both_tsp():
+    # segment-fasttsp heads the chain when fast-tsp is available.
+    assert isinstance(handle_poly_method(None), SegmentFastTsp)
+
+
+@pytest.mark.skipif(not HAS_PYTHON_TSP, reason="python-tsp not installed")
+def test_handle_poly_method_default_chain_no_fasttsp(monkeypatch):
+    # Without fast-tsp, segment-tsp is next in the chain.
+    stripped = [x for x in poly_module.__all__ if x not in ("FastTsp", "SegmentFastTsp")]
+    monkeypatch.setattr(poly_module, "__all__", stripped)
+    assert isinstance(handle_poly_method(None), SegmentPythonTsp)
+
+
+def test_handle_poly_method_default_chain_no_tsp(monkeypatch):
+    # Without any TSP, concave is the fallback.
+    stripped = [
+        x for x in poly_module.__all__
+        if x not in ("FastTsp", "SegmentFastTsp", "PythonTsp", "SegmentPythonTsp")
+    ]
+    monkeypatch.setattr(poly_module, "__all__", stripped)
+    assert isinstance(handle_poly_method(None), Concave)
 
 
 # --- AbstractPolyMethod.make repair tests ---


### PR DESCRIPTION
Closes #173.

Three tests added to `tests/unit/test_poly.py` pinning the `segment-fasttsp → segment-tsp → concave` default selection order of `handle_poly_method(None)`.

Each test uses `monkeypatch.setattr(poly_module, "__all__", ...)` to remove TSP registrations from the module's public list, making the chain verifiable independently of which optional extras are installed:

- `test_handle_poly_method_default_chain_both_tsp` — fast-tsp present → `SegmentFastTsp` (skipped if `fast-tsp` not installed)
- `test_handle_poly_method_default_chain_no_fasttsp` — fast-tsp stripped → `SegmentPythonTsp` (skipped if `python-tsp` not installed)
- `test_handle_poly_method_default_chain_no_tsp` — all TSP stripped → `Concave` (always runs)

No production code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rk1FNJX8tRitzd3tHzARPy)_