### PR TITLE
Draw single-T excess-free-energy plot on the current axes

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -1170,8 +1170,8 @@ def plot_excess_free_energy(
             columns ``c``, ``f_excess``, ``phase``, ``T``, ``stable``, and
             optionally ``border`` and ``mu``.
         col_wrap: Maximum subplot columns per row.
-        height: Height of each facet in inches.
-        aspect: Width-to-height ratio of each facet.
+        height: Height of each facet in inches (multiple temperatures only).
+        aspect: Width-to-height ratio of each facet (multiple temperatures only).
         color_override: Optional ``dict[name -> color]`` overriding phase colours.
         convex_hull: If True, distinguish stable (solid curves) from metastable
             (faded lines) and overlay the common-tangent segments in black.
@@ -1183,9 +1183,11 @@ def plot_excess_free_energy(
             False, keep the figure legend box on the right.
 
     Returns:
-        For a single temperature, the :class:`matplotlib.axes.Axes` holding the
-        plain lineplot.  For multiple temperatures, a :class:`seaborn.FacetGrid`
-        with one column per temperature (figure via ``.fig``, axes via ``.axes``).
+        For a single temperature, the current :class:`matplotlib.axes.Axes`
+        holding the plain lineplot; no figure is allocated, so pre-create one
+        to control its size.  For multiple temperatures, a
+        :class:`seaborn.FacetGrid` with one column per temperature (figure via
+        ``.fig``, axes via ``.axes``).
     """
     import matplotlib.lines as mlines
 
@@ -1225,11 +1227,12 @@ def plot_excess_free_energy(
         base_data = df_sol
         units_col = None
 
-    # A single temperature does not need a facet grid; draw a plain lineplot on one
-    # axes and return that axes.  Multiple temperatures fan out into a FacetGrid.
+    # A single temperature does not need a facet grid; draw a plain lineplot onto
+    # the current axes (the caller controls figure allocation) and return that axes.
+    # Multiple temperatures fan out into a FacetGrid.
     single = len(temperatures) == 1
     if single:
-        fig, single_ax = plt.subplots(figsize=(height * aspect, height))
+        single_ax = plt.gca()
         if not base_data.empty:
             sns.lineplot(
                 data=base_data,
@@ -1375,7 +1378,7 @@ def plot_excess_free_energy(
     # The single-temperature path draws onto one axes whose legend lives on the axes
     # itself; the FacetGrid path keeps its legend on ``g._legend``.  Resolve both here.
     legend = g._legend if g is not None else axes[0].get_legend()
-    figure = g.figure if g is not None else fig
+    figure = g.figure if g is not None else axes[0].figure
 
     if inline_legend:
         # Inline labels replace the legend box; drop seaborn's legend.

--- a/tests/unit/plot/test_excess_free_energy.py
+++ b/tests/unit/plot/test_excess_free_energy.py
@@ -132,12 +132,12 @@ def test_single_temperature_convex_hull_true():
     plt.close(ax.figure)
 
 
-def test_single_temperature_figure_not_wide():
-    """Figure width for one temperature must not span more than one column."""
-    # default height=3.0, aspect=1.3 → one column ≈ 3.9 in; col_wrap=3 would give 11.7 in.
-    ax = plot_excess_free_energy(_minimal_df([1000]))
-    assert ax.figure.get_figwidth() < 2 * 3.0 * 1.3
-    plt.close(ax.figure)
+def test_single_temperature_draws_on_current_axes():
+    """One temperature draws on the caller's current axes instead of a new figure."""
+    fig, ax = plt.subplots()
+    ret = plot_excess_free_energy(_minimal_df([1000]))
+    assert ret is ax
+    plt.close(fig)
 
 
 def test_all_line_phases_no_crash():


### PR DESCRIPTION
For a single temperature, `plot_excess_free_energy` no longer calls `plt.subplots` itself; `sns.lineplot` draws onto `plt.gca()`, so the caller controls figure allocation and size. `height`/`aspect` now apply to the facet grid only; docstring updated accordingly. The empty-`base_data` path also uses `plt.gca()`, and the legend/figure resolution downstream reads `axes[0].figure` instead of the removed local `fig`.

Replaced `test_single_temperature_figure_not_wide` (asserted the figsize that is no longer set) with `test_single_temperature_draws_on_current_axes`, which pins that the returned axes is the caller's pre-created one. `pytest tests/unit/plot/` passes: 164 tests.

https://claude.ai/code/session_01JDPDQK3RcA3zi53pYCyz5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDPDQK3RcA3zi53pYCyz5S)_