### PR TITLE
Rotate segment-TSP tours off intra-segment wrap-around edges

### DIFF
--- a/benchmarks/segment_tsp_tour_rotation.py
+++ b/benchmarks/segment_tsp_tour_rotation.py
@@ -1,0 +1,137 @@
+"""Diagnosis benchmark for the segment-TSP tour rotation in `_segment_tsp_polygon`.
+
+Builds the segment-endpoint TSP instances of the toy T-mu phase diagram
+(`tests/integration/testplots.py::plot_2d_toy_mu`), then for each phase region
+solves the tour repeatedly with `solve_tsp_record_to_record` and reports, per
+trial:
+
+* whether the tour length equals the exact (dynamic programming) optimum,
+* whether the *naive* chunk reconstruction (first-encounter direction, no
+  rotation) yields a valid polygon,
+* whether rotating the tour off an intra-segment wrap-around edge — what
+  `_segment_tsp_polygon` does — yields a valid polygon.
+
+The heuristic finds the optimal tour length in every trial; invalid polygons
+come exclusively from tours returned in a rotation that cuts through a
+segment's zero-cost intra edge, and the rotation repairs every one of them.
+
+Run: ``python benchmarks/segment_tsp_tour_rotation.py``
+"""
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+import numpy as np
+import shapely
+from python_tsp.exact import solve_tsp_dynamic_programming
+from python_tsp.heuristics import solve_tsp_record_to_record
+from sklearn.metrics import pairwise_distances
+from sklearn.preprocessing import StandardScaler
+
+import landau.calculate as ldc
+import landau.interpolate as ldi
+import landau.phases as ldp
+from landau.plot import cluster_phase
+from landau.poly import SegmentPythonTsp, _segments_from_labels
+
+TRIALS = 30
+MAX_ITERATIONS = 10
+
+
+def toy_mu_instances():
+    """Segment lists and endpoint distance matrices per phase region of the
+    toy T-mu diagram."""
+    l1 = ldp.TemperatureDependentLinePhase(
+        "l0", fixed_concentration=0, temperatures=[1, 750, 1000],
+        free_energies=[2.00, 1.80, 1.00], interpolator=ldi.PolyFit(3))
+    l2 = ldp.TemperatureDependentLinePhase(
+        "l1", fixed_concentration=1, temperatures=[1, 750, 1000],
+        free_energies=[3.00, 2.80, 2.00], interpolator=ldi.PolyFit(3))
+    l3 = ldp.TemperatureDependentLinePhase(
+        "l2", fixed_concentration=0.5, temperatures=[1, 750, 1000],
+        free_energies=[2.45, 2.00, 1.42], interpolator=ldi.PolyFit(3))
+    s1 = ldp.TemperatureDependentLinePhase(
+        "s0", fixed_concentration=0, temperatures=[1, 750, 1000],
+        free_energies=[1.9, 1.6, 1.2], interpolator=ldi.SGTE(2))
+    s2 = ldp.TemperatureDependentLinePhase(
+        "s1", fixed_concentration=1, temperatures=[1, 750, 1000],
+        free_energies=[2.9, 2.6, 2.2], interpolator=ldi.SGTE(2))
+    s3 = ldp.TemperatureDependentLinePhase(
+        "s3", fixed_concentration=0.4, temperatures=[1, 750, 1000],
+        free_energies=np.array([2.4, 1.85, 1.45]) - 0.05, interpolator=ldi.SGTE(3))
+    rliq = ldp.RegularSolution("liquid", [l1, l3, l2])
+    sol = ldp.IdealSolution("solid", s1, s2)
+
+    c = np.linspace(0, 1, 75)[1:-1]
+    mu = 1 + ldp.kB * 4000 * np.log(c / (1 - c))
+    df = ldc.calc_phase_diagram([rliq, sol, s3], np.linspace(500, 1000, 40), mu, refine=True)
+    df = df.query("stable").copy()
+    df = cluster_phase(df)
+
+    instances = {}
+    prepared = SegmentPythonTsp().prepare(df)
+    for (phase, _unit), dd in prepared.groupby(["phase", "phase_unit"]):
+        dd = dd.drop(columns=["phase", "phase_unit"])
+        seg = dd["border_segment"].to_numpy()
+        idx = np.argsort(dd["mu"].to_numpy())
+        pp = dd[["mu", "T"]].to_numpy()[idx]
+        seg = seg[idx]
+        mask = np.isfinite(pp).all(axis=-1)
+        pp, seg = pp[mask], seg[mask]
+        _, unique_idx = np.unique(pp, axis=0, return_index=True)
+        unique_idx.sort()
+        pp, seg = pp[unique_idx], seg[unique_idx]
+        pp_scaled = StandardScaler().fit_transform(pp)
+        instances[phase] = _segments_from_labels(pp_scaled, seg)
+    return instances
+
+
+def endpoint_dm_int(segments):
+    n = len(segments)
+    endpoints = np.array([[s[0], s[-1]] for s in segments]).reshape(2 * n, -1)
+    dm = pairwise_distances(endpoints)
+    for i in range(n):
+        dm[2 * i, 2 * i + 1] = 0
+        dm[2 * i + 1, 2 * i] = 0
+    pos = dm[dm > 0]
+    return (dm / pos.min()).round().astype(int)
+
+
+def reconstruct(segments, tour):
+    seen, chunks = set(), []
+    for node in tour:
+        seg = node // 2
+        if seg in seen:
+            continue
+        seen.add(seg)
+        chunks.append(segments[seg] if node % 2 == 0 else segments[seg][::-1])
+    return shapely.Polygon(np.vstack(chunks))
+
+
+def rotate_off_intra_edge(tour):
+    tour = list(tour)
+    while tour[0] // 2 == tour[-1] // 2:
+        tour.append(tour.pop(0))
+    return tour
+
+
+def main():
+    for phase, segments in toy_mu_instances().items():
+        dm_int = endpoint_dm_int(segments)
+        _opt_tour, opt_len = solve_tsp_dynamic_programming(dm_int)
+        optimal = naive_valid = rotated_valid = 0
+        for _ in range(TRIALS):
+            tour, length = solve_tsp_record_to_record(dm_int, max_iterations=MAX_ITERATIONS)
+            optimal += length == opt_len
+            naive_valid += reconstruct(segments, tour).is_valid
+            rotated_valid += reconstruct(segments, rotate_off_intra_edge(tour)).is_valid
+        print(f"{phase}: {len(segments)} segments | tour length optimal {optimal}/{TRIALS} | "
+              f"valid polygon: naive {naive_valid}/{TRIALS}, rotated {rotated_valid}/{TRIALS}")
+
+
+if __name__ == "__main__":
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        main()

--- a/landau/poly.py
+++ b/landau/poly.py
@@ -387,7 +387,15 @@ def _segment_tsp_polygon(
         return shapely.convex_hull(shapely.MultiPoint(np.vstack(segments)))
     dm_int = (dm / pos.min()).round().astype(int)
 
-    tour = solve_tour(dm_int)
+    tour = list(solve_tour(dm_int))
+
+    # The tour is cyclic, so the solver is free to return a rotation whose
+    # ends fall inside a segment (the zero-cost intra-segment edge being the
+    # wrap-around). The first-encounter rule below would then walk that
+    # segment in the wrong direction relative to its neighbours and produce a
+    # self-intersecting ring, so rotate off the intra-segment edge first.
+    while tour[0] // 2 == tour[-1] // 2:
+        tour.append(tour.pop(0))
 
     seen = set()
     chunks = []
@@ -410,7 +418,6 @@ __all__ = ["Concave", "Segments"]
 
 
 with ImportAlarm("'python_tsp' package required for PythonTsp.  Install from conda or pip.") as python_tsp_alarm:
-    from python_tsp.exact import solve_tsp_dynamic_programming
     from python_tsp.heuristics import solve_tsp_record_to_record
 
     @dataclass
@@ -463,35 +470,16 @@ with ImportAlarm("'python_tsp' package required for PythonTsp.  Install from con
         formulation with zero-cost intra-segment edges.
         """
         max_iterations: int = 10
-        retries: int = 2
-        """How often to re-solve with a 10x larger iteration budget when the tour self-intersects."""
-        exact_node_limit: int = 16
-        """Solve the endpoint TSP exactly instead of retrying when it has at most this many nodes.
-
-        The record-to-record heuristic restarts from a random tour and frequently keeps
-        self-intersecting solutions on these small instances regardless of iteration budget,
-        while dynamic programming is exact and still fast up to about this size."""
 
         def _make(self, pp, border, segment_label):
             if np.all(segment_label == 1):
                 raise ValueError("SegmentPythonTsp requires refined phase boundaries (segment_label must be provided)!")
             segments = _segments_from_labels(pp, segment_label)
 
-            iterations = self.max_iterations
-            for _ in range(self.retries + 1):
-                def solve(dm_int, iterations=iterations):
-                    return solve_tsp_record_to_record(dm_int, max_iterations=iterations)[0]
+            def solve(dm_int):
+                return solve_tsp_record_to_record(dm_int, max_iterations=self.max_iterations)[0]
 
-                shape = _segment_tsp_polygon(segments, solve)
-                if not isinstance(shape, shapely.Polygon) or shape.is_valid:
-                    return shape
-                if 2 * len(segments) <= self.exact_node_limit:
-                    def solve_exact(dm_int):
-                        return solve_tsp_dynamic_programming(dm_int)[0]
-
-                    return _segment_tsp_polygon(segments, solve_exact)
-                iterations *= 10
-            return shape
+            return _segment_tsp_polygon(segments, solve)
 
     __all__ += ["PythonTsp", "SegmentPythonTsp"]
 

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -556,3 +556,17 @@ class TestSegmentTspPolygonTraversalDirection:
         coords = np.array(result.exterior.coords)[:-1]
         np.testing.assert_allclose(coords[:2], seg0[::-1])
         np.testing.assert_allclose(coords[2:], seg1[::-1])
+
+
+def test_segment_tsp_polygon_rotated_tour_cut_inside_segment():
+    # A cyclic tour may be returned in a rotation whose ends fall inside a
+    # segment: [1, 2, 3, 0] is the same cycle as [0, 1, 2, 3], cut through
+    # seg0's zero-cost intra edge. Reconstructing it naively walks seg0
+    # backward (first encounter at node 1) while keeping its position in the
+    # sequence, yielding a self-intersecting bow-tie instead of the square.
+    seg0 = np.array([[0.0, 0.0], [1.0, 0.0]])
+    seg1 = np.array([[1.0, 1.0], [0.0, 1.0]])
+    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [1, 2, 3, 0])
+    assert isinstance(result, shapely.Polygon)
+    assert result.is_valid
+    assert result.equals(shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]))


### PR DESCRIPTION
Follow-up to #221. The self-intersecting segment-tsp polygons were never the solver's fault: `solve_tsp_record_to_record` finds the optimal tour length in every trial on the toy T-mu endpoint instances (30/30 per phase, `benchmarks/segment_tsp_tour_rotation.py`).

The actual defect was in `_segment_tsp_polygon`'s reconstruction. A cyclic tour can be returned in a rotation whose ends fall inside a segment — node `2k` first, partner `2k+1` last, the zero-cost intra-segment edge being the wrap-around. The first-encounter rule then walks that segment in the wrong direction relative to its neighbours, producing a self-intersecting ring out of a geometrically correct cycle. python-tsp restarts from a random permutation, so the returned rotation varies and 11–22 of 30 naive reconstructions were invalid; fast_tsp returns a deterministic rotation that happened to be safe on the gallery systems, but the same latent bug sat in its path. Single-point segments (refined triple points with their own `border_segment` label) make the degenerate rotations common: their two TSP nodes coincide, so valid and invalid node sequences describe the same closed curve at exactly equal tour length — which is why no iteration budget could ever help.

Fix: rotate the tour off the intra-segment edge before reconstruction. With it, every reconstruction in the benchmark is valid (30/30 across all phases) and repeated `segment-tsp` renders of `2d_toy_mu`/`2d_basics_mu` complete without a single "invalid polygon; repairing it" warning.

The exact dynamic-programming fallback and the retry ladder added to `SegmentPythonTsp` in #221 treated the symptom — DP merely returned one fixed rotation that happened to reconstruct validly — so both are removed along with the `retries`/`exact_node_limit` fields and the `python_tsp.exact` import. `PythonTsp` keeps its iteration ladder: its failure mode is genuine solver underconvergence on the full point set, which a larger budget demonstrably cures.

`tests/unit/test_poly.py::test_segment_tsp_polygon_rotated_tour_cut_inside_segment` pins the rotation: the tour `[1, 2, 3, 0]` (the unit-square cycle cut through seg0's intra edge) must reconstruct to the square, not a bow-tie. Fails on main, passes here. Full suite: 396 passed, 1 xfailed; the border-coverage integration test from #221 covers the pipeline end to end.

https://claude.ai/code/session_01PQDckXjinohTr6LiByat3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQDckXjinohTr6LiByat3g)_