### PR TITLE
Rotate or offset inline labels that do not fit their polygon

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -42,6 +42,24 @@ def _text_with_outline(ax, x, y, s, *, outline_width=3, **kwargs):
     return ax.text(x, y, s, **kwargs)
 
 
+def _shapely_polygon(coords):
+    """Valid shapely polygon from an (N, 2) coordinate array, or ``None``.
+
+    A self-intersecting outline (as the TSP-based poly methods can produce) is
+    repaired with :func:`shapely.make_valid`; if the repair splits it into
+    several pieces, the largest one is kept.  Degenerate (empty or zero-area)
+    input gives ``None``.
+    """
+    poly = shapely.Polygon(coords)
+    if not poly.is_valid:
+        poly = shapely.make_valid(poly)
+        if isinstance(poly, shapely.MultiPolygon):
+            poly = max(poly.geoms, key=lambda g: g.area)
+    if not isinstance(poly, shapely.Polygon) or poly.is_empty or poly.area == 0:
+        return None
+    return poly
+
+
 def _largest_inscribed_circle_center(polygon_xy, ax):
     """Centre of the largest circle inscribable in a polygon, in data units.
 
@@ -60,30 +78,45 @@ def _largest_inscribed_circle_center(polygon_xy, ax):
     sx = (x1 - x0) or 1.0
     sy = (y1 - y0) or 1.0
     coords = np.asarray(polygon_xy, dtype=float)
-    poly = shapely.Polygon(np.column_stack([coords[:, 0] / sx, coords[:, 1] / sy]))
-    if not poly.is_valid:
-        poly = shapely.make_valid(poly)
-        if isinstance(poly, shapely.MultiPolygon):
-            poly = max(poly.geoms, key=lambda g: g.area)
-    if not isinstance(poly, shapely.Polygon) or poly.is_empty or poly.area == 0:
+    poly = _shapely_polygon(np.column_stack([coords[:, 0] / sx, coords[:, 1] / sy]))
+    if poly is None:
         return None
     point = polylabel(poly, tolerance=1e-3)
     return point.x * sx, point.y * sy
+
+
+def _label_fits(poly_px, text, renderer):
+    """Whether ``text``'s rendered bounding box lies inside a pixel-space polygon."""
+    return poly_px.contains(shapely.box(*text.get_window_extent(renderer).extents))
 
 
 def _add_inline_polygon_labels(ax, polys):
     """Label each phase polygon in place instead of drawing a legend box.
 
     Every polygon is annotated with its phase name (with trailing apostrophes
-    for repeated stability regions, matching :func:`plot_polygons`) at the
-    centre of its largest inscribed circle, with a white outline.  The text is
-    black: the polygon fill already carries the phase colour, and black with a
-    white stroke stays legible even over the pale pastel fills.
+    for repeated stability regions, matching :func:`plot_polygons`), with a
+    white outline.  The text is black: the polygon fill already carries the
+    phase colour, and black with a white stroke stays legible even over the
+    pale pastel fills.
+
+    Placement tries three positions in turn, keeping the first whose rendered
+    bounding box fits inside the polygon:
+
+    1. horizontal at the centre of the largest inscribed circle,
+    2. rotated by 90° at the same point — for tall, narrow regions,
+    3. still rotated, but moved horizontally off the polygon — for line phases
+       too thin to hold any label.  The label sits just right of the polygon
+       unless that would leave the axes (a terminal line phase at the right
+       edge), in which case it sits to the left; it is clamped into the axes
+       both ways, vertically too.
 
     Args:
         ax: matplotlib Axes the polygons were drawn on.
         polys: Series of matplotlib Polygons indexed as in :func:`get_polygons`.
     """
+    renderer = _get_renderer(ax.figure)
+    axbb = ax.get_window_extent(renderer)
+    pad = 0.004 * axbb.width  # clearance between an offset label box and its polygon
     for key, p in polys.items():
         if isinstance(key, tuple):
             phase, rep = key
@@ -92,11 +125,29 @@ def _add_inline_polygon_labels(ax, polys):
         center = _largest_inscribed_circle_center(p.get_xy(), ax)
         if center is None:
             continue
-        _text_with_outline(
+        text = _text_with_outline(
             ax, center[0], center[1], phase + "'" * rep,
             ha="center", va="center", fontsize="small", fontweight="bold",
             color="black",
         )
+        poly_px = _shapely_polygon(ax.transData.transform(p.get_xy()))
+        if poly_px is None or _label_fits(poly_px, text, renderer):
+            continue
+        text.set_rotation(90)
+        if _label_fits(poly_px, text, renderer):
+            continue
+        # Too thin even for a rotated label (a line phase): move it beside the
+        # polygon, keeping the rotation.
+        bbox = text.get_window_extent(renderer)
+        half_w, half_h = bbox.width / 2, bbox.height / 2
+        minx, _, maxx, _ = poly_px.bounds
+        cx = maxx + pad + half_w
+        if cx + half_w > axbb.x1:
+            cx = minx - pad - half_w
+        cx = min(max(cx, axbb.x0 + half_w), axbb.x1 - half_w)
+        cy = ax.transData.transform(center)[1]
+        cy = min(max(cy, axbb.y0 + half_h), axbb.y1 - half_h)
+        text.set_position(ax.transData.inverted().transform((cx, cy)))
 
 
 def cluster_phase(df, distance_threshold=0.5):  # 0.5 hand-tuned

--- a/tests/unit/plot/test_polygons.py
+++ b/tests/unit/plot/test_polygons.py
@@ -351,6 +351,104 @@ def test_add_inline_polygon_labels_one_text_per_polygon():
     plt.close(fig)
 
 
+def _rect_patch(x0, x1, y0, y1):
+    return Polygon(np.array([(x0, y0), (x1, y0), (x1, y1), (x0, y1)]), closed=True)
+
+
+def _label_rect(ax, phase, x0, x1, y0, y1):
+    """Run `_add_inline_polygon_labels` on one rectangle and return its text artist."""
+    polys = pd.Series(
+        [_rect_patch(x0, x1, y0, y1)],
+        index=pd.MultiIndex.from_tuples([(phase, 0)], names=["phase", "phase_unit"]),
+    )
+    _add_inline_polygon_labels(ax, polys)
+    (text,) = ax.texts
+    return text
+
+
+def _wide_axes():
+    """Axes mimicking a c-T diagram: x in [0, 1], T in [0, 1000]."""
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1000)
+    return fig, ax
+
+
+def _extent_px(ax, text):
+    return text.get_window_extent(plot_mod._get_renderer(ax.figure))
+
+
+# Label placement is clamped in pixel space but stored in data coordinates, so
+# round-tripping through the transform can wobble the bbox by float epsilon.
+PX_TOL = 1e-6
+
+
+def _assert_inside_axes(ax, bbox, vertical=True):
+    axbb = ax.get_window_extent(plot_mod._get_renderer(ax.figure))
+    assert axbb.x0 - PX_TOL <= bbox.x0 and bbox.x1 <= axbb.x1 + PX_TOL
+    if vertical:
+        assert axbb.y0 - PX_TOL <= bbox.y0 and bbox.y1 <= axbb.y1 + PX_TOL
+
+
+def test_inline_label_horizontal_when_it_fits():
+    fig, ax = _wide_axes()
+    text = _label_rect(ax, "A", 0.1, 0.9, 100, 900)
+    assert text.get_rotation() == 0
+    x, y = text.get_position()
+    assert x == pytest.approx(0.5, abs=2e-3)
+    assert y == pytest.approx(500, abs=2)
+    plt.close(fig)
+
+
+def test_inline_label_rotates_in_tall_narrow_polygon():
+    """A region narrower than the label but tall enough for it rotated keeps the pole anchor."""
+    fig, ax = _wide_axes()
+    text = _label_rect(ax, "ABCDEFGH", 0.47, 0.53, 50, 950)
+    assert text.get_rotation() == 90
+    x, y = text.get_position()
+    assert x == pytest.approx(0.5, abs=2e-3)
+    assert y == pytest.approx(500, abs=2)
+    # The rotated box really is inside the polygon.
+    bbox = _extent_px(ax, text)
+    px0 = ax.transData.transform((0.47, 0.0))[0]
+    px1 = ax.transData.transform((0.53, 0.0))[0]
+    assert px0 < bbox.x0 and bbox.x1 < px1
+    plt.close(fig)
+
+
+def test_inline_label_moves_off_thin_polygon():
+    """A line phase too thin for even a rotated label gets it placed beside, inside the axes."""
+    fig, ax = _wide_axes()
+    text = _label_rect(ax, "ABCDEFGH", 0.499, 0.501, 50, 950)
+    assert text.get_rotation() == 90
+    bbox = _extent_px(ax, text)
+    px1 = ax.transData.transform((0.501, 0.0))[0]
+    assert bbox.x0 > px1  # clear of the polygon, to its right
+    _assert_inside_axes(ax, bbox)
+    plt.close(fig)
+
+
+def test_inline_label_off_polygon_flips_left_at_right_edge():
+    """A terminal line phase at c=1 gets its label to the left, not outside the axes."""
+    fig, ax = _wide_axes()
+    text = _label_rect(ax, "ABCDEFGH", 0.998, 1.0, 50, 950)
+    assert text.get_rotation() == 90
+    bbox = _extent_px(ax, text)
+    px0 = ax.transData.transform((0.998, 0.0))[0]
+    assert bbox.x1 < px0  # clear of the polygon, to its left
+    _assert_inside_axes(ax, bbox, vertical=False)
+    plt.close(fig)
+
+
+def test_inline_label_off_polygon_clamped_vertically():
+    """A short line phase near the bottom edge keeps its label inside the axes."""
+    fig, ax = _wide_axes()
+    text = _label_rect(ax, "ABCDEFGH", 0.499, 0.501, 0, 60)
+    assert text.get_rotation() == 90
+    _assert_inside_axes(ax, _extent_px(ax, text))
+    plt.close(fig)
+
+
 def test_plot_phase_diagram_inline_legend_default_labels_in_place():
     fig, ax = plt.subplots()
     plot_phase_diagram(_stable_df(), ax=ax, poly_method=Concave(drop_interior=False))


### PR DESCRIPTION
Inline 2d phase-diagram labels are always drawn horizontally at the pole of inaccessibility, which overplots badly for thin line-phase polygons (and their neighbours' tielines).

`_add_inline_polygon_labels` now tests whether the rendered label box fits inside its polygon, in pixel space, and falls back in two steps:

1. rotate the label by 90° in place — covers tall, narrow regions,
2. if it still does not fit, move it horizontally off the polygon, keeping the rotation — covers line phases too thin to hold any label.

Offset labels go to the right of the polygon, flip to the left when the right side would leave the axes (terminal line phases at the upper concentration limit), and are clamped into the axes in both directions, so terminal-phase labels at c=0/c=1 stay visible. Wide regions are unaffected and keep the horizontal pole label.

The `make_valid` repair in `_largest_inscribed_circle_center` is factored into `_shapely_polygon` so the pixel-space fit test shares it.

Tests: five new cases in `tests/unit/plot/test_polygons.py` pin each placement (horizontal kept when it fits, rotation anchored at the pole for narrow-but-tall regions, offset clear of the polygon and inside the axes, left flip at the right axis edge, vertical clamp near the bottom edge). Full suite: 400 passed, 1 xfailed at e50b835.

Visual check: `python tests/integration/testplots.py --only 2d_toy 2d_basics` — the `s3` line phase in `2d_toy` now gets a rotated label beside its line; `2d_basics` (no thin polygons) renders unchanged.

https://claude.ai/code/session_01QYvNjM8JksCJuAGzcgKPUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYvNjM8JksCJuAGzcgKPUm)_