### PR TITLE
Fan overlapping off-polygon inline labels apart vertically

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -90,6 +90,26 @@ def _label_fits(poly_px, text, renderer):
     return poly_px.contains(shapely.box(*text.get_window_extent(renderer).extents))
 
 
+def _group_overlapping_intervals(intervals, gap=0.0):
+    """Group 1-d intervals that overlap, transitively, closer than ``gap``.
+
+    Returns lists of indices into ``intervals``; within a group every interval
+    overlaps (or comes within ``gap`` of) another one, so the members have to be
+    laid out together along the other axis.
+    """
+    order = sorted(range(len(intervals)), key=lambda i: intervals[i][0])
+    groups, hi = [], None
+    for i in order:
+        lo_i, hi_i = intervals[i]
+        if hi is None or lo_i > hi + gap:
+            groups.append([])
+            hi = hi_i
+        else:
+            hi = max(hi, hi_i)
+        groups[-1].append(i)
+    return groups
+
+
 def _add_inline_polygon_labels(ax, polys):
     """Label each phase polygon in place instead of drawing a legend box.
 
@@ -110,6 +130,12 @@ def _add_inline_polygon_labels(ax, polys):
        edge), in which case it sits to the left; it is clamped into the axes
        both ways, vertically too.
 
+    Offset labels are no longer anchored inside their own polygon, so two close
+    line phases can land on top of each other; a final pass fans labels with
+    overlapping horizontal extents apart vertically (via :func:`_spread_labels`,
+    within the axes), so each one slides along its line instead of covering its
+    neighbour.
+
     Args:
         ax: matplotlib Axes the polygons were drawn on.
         polys: Series of matplotlib Polygons indexed as in :func:`get_polygons`.
@@ -117,6 +143,7 @@ def _add_inline_polygon_labels(ax, polys):
     renderer = _get_renderer(ax.figure)
     axbb = ax.get_window_extent(renderer)
     pad = 0.004 * axbb.width  # clearance between an offset label box and its polygon
+    moved = []  # (text, cx, cy, width, height) of off-polygon labels, in pixels
     for key, p in polys.items():
         if isinstance(key, tuple):
             phase, rep = key
@@ -139,15 +166,29 @@ def _add_inline_polygon_labels(ax, polys):
         # Too thin even for a rotated label (a line phase): move it beside the
         # polygon, keeping the rotation.
         bbox = text.get_window_extent(renderer)
-        half_w, half_h = bbox.width / 2, bbox.height / 2
+        half_w = bbox.width / 2
         minx, _, maxx, _ = poly_px.bounds
         cx = maxx + pad + half_w
         if cx + half_w > axbb.x1:
             cx = minx - pad - half_w
         cx = min(max(cx, axbb.x0 + half_w), axbb.x1 - half_w)
         cy = ax.transData.transform(center)[1]
-        cy = min(max(cy, axbb.y0 + half_h), axbb.y1 - half_h)
-        text.set_position(ax.transData.inverted().transform((cx, cy)))
+        moved.append((text, cx, cy, bbox.width, bbox.height))
+
+    # Vertical overlap pass: spread offset labels whose horizontal extents
+    # collide.  _spread_labels also clamps every stack — singletons included —
+    # into the axes vertically.
+    inv = ax.transData.inverted()
+    intervals = [(cx - w / 2, cx + w / 2) for _, cx, _, w, _ in moved]
+    for group in _group_overlapping_intervals(intervals, gap=pad):
+        spread = _spread_labels(
+            [moved[i][2] for i in group],
+            [moved[i][4] for i in group],
+            axbb.y0, axbb.y1, gap=pad,
+        )
+        for i, cy in zip(group, spread):
+            text, cx = moved[i][0], moved[i][1]
+            text.set_position(inv.transform((cx, cy)))
 
 
 def cluster_phase(df, distance_threshold=0.5):  # 0.5 hand-tuned

--- a/tests/unit/plot/test_polygons.py
+++ b/tests/unit/plot/test_polygons.py
@@ -355,14 +355,22 @@ def _rect_patch(x0, x1, y0, y1):
     return Polygon(np.array([(x0, y0), (x1, y0), (x1, y1), (x0, y1)]), closed=True)
 
 
-def _label_rect(ax, phase, x0, x1, y0, y1):
-    """Run `_add_inline_polygon_labels` on one rectangle and return its text artist."""
+def _label_rects(ax, items):
+    """Run `_add_inline_polygon_labels` on `(phase, x0, x1, y0, y1)` rectangles.
+
+    Returns the created text artists, one per rectangle, in input order.
+    """
     polys = pd.Series(
-        [_rect_patch(x0, x1, y0, y1)],
-        index=pd.MultiIndex.from_tuples([(phase, 0)], names=["phase", "phase_unit"]),
+        [_rect_patch(x0, x1, y0, y1) for _, x0, x1, y0, y1 in items],
+        index=pd.MultiIndex.from_tuples([(p, 0) for p, *_ in items], names=["phase", "phase_unit"]),
     )
     _add_inline_polygon_labels(ax, polys)
-    (text,) = ax.texts
+    return list(ax.texts)
+
+
+def _label_rect(ax, phase, x0, x1, y0, y1):
+    """Run `_add_inline_polygon_labels` on one rectangle and return its text artist."""
+    (text,) = _label_rects(ax, [(phase, x0, x1, y0, y1)])
     return text
 
 
@@ -446,6 +454,36 @@ def test_inline_label_off_polygon_clamped_vertically():
     text = _label_rect(ax, "ABCDEFGH", 0.499, 0.501, 0, 60)
     assert text.get_rotation() == 90
     _assert_inside_axes(ax, _extent_px(ax, text))
+    plt.close(fig)
+
+
+def test_inline_offset_labels_spread_apart_vertically():
+    """Coinciding line phases get offset labels fanned apart instead of stacked."""
+    fig, ax = _wide_axes()
+    t1, t2 = _label_rects(
+        ax,
+        [("ABCDEFGH", 0.499, 0.501, 50, 950), ("HGFEDCBA", 0.499, 0.501, 50, 950)],
+    )
+    assert t1.get_rotation() == 90 and t2.get_rotation() == 90
+    b1, b2 = _extent_px(ax, t1), _extent_px(ax, t2)
+    # Both polygons share the pole, so the boxes would coincide without the
+    # overlap pass; now they must be vertically disjoint and stay in the axes.
+    assert b1.y1 <= b2.y0 or b2.y1 <= b1.y0
+    _assert_inside_axes(ax, b1)
+    _assert_inside_axes(ax, b2)
+    plt.close(fig)
+
+
+def test_inline_offset_labels_far_apart_keep_pole_anchor():
+    """Offset labels whose horizontal extents are clear of each other do not move."""
+    fig, ax = _wide_axes()
+    t1, t2 = _label_rects(
+        ax,
+        [("ABCDEFGH", 0.199, 0.201, 50, 950), ("HGFEDCBA", 0.799, 0.801, 50, 950)],
+    )
+    for t in (t1, t2):
+        assert t.get_rotation() == 90
+        assert t.get_position()[1] == pytest.approx(500, abs=2)
     plt.close(fig)
 
 


### PR DESCRIPTION
Follow-up to #228. Off-polygon inline labels are anchored at their polygon's pole but no longer confined to it, so two close line phases — or two terminal phases flipped to the same side of an axis edge — can land on top of each other.

After placement, labels whose horizontal extents overlap (transitively, via the new `_group_overlapping_intervals`) are now spread vertically with the existing `_spread_labels` helper, clamped to the axes. The previous per-label vertical clamp falls out of the same call, since `_spread_labels` bounds singleton stacks too. Labels whose extents are clear of each other keep their pole anchor; in-place labels (horizontal or rotated) are contained in their own polygon and stay untouched.

Tests: two new cases in `tests/unit/plot/test_polygons.py` — coinciding line phases produce vertically disjoint label boxes inside the axes, and far-apart offset labels keep their pole y. Full suite: 403 passed, 1 xfailed at e1fd911.

https://claude.ai/code/session_01QYvNjM8JksCJuAGzcgKPUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYvNjM8JksCJuAGzcgKPUm)_