### PR TITLE
fix(calculate): compare f_excess endpoint references at the pure concentrations

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -217,11 +217,21 @@ def calc_phase_diagram(
         lo_thr = c_min + 0.01 * c_span
         hi_thr = c_max - 0.01 * c_span
         f0, f1 = np.inf, np.inf
+        # Compare candidate reference phases by the value of their tangent
+        # line at the pure concentrations, not by f at their extreme sample:
+        # f has slope mu in c, so phi is the tangent value at c=0 and phi+mu
+        # the one at c=1.  For a phase sampled only up to c=1-eps, f lies
+        # below its own tangent value at c=1 by ~mu*eps, which would let it
+        # steal the reference from a line phase sitting exactly at c=1 and
+        # lift that phase's f_excess off zero.  For line phases located
+        # exactly at an endpoint both expressions reduce to f.
+        tangent0 = dd["phi"]
+        tangent1 = dd["phi"] + dd["mu"]
         for _, g in dd.groupby("phase"):
             if g["c"].min() <= lo_thr:
-                f0 = min(f0, g.loc[g["c"].idxmin(), "f"])
+                f0 = min(f0, tangent0[g["c"].idxmin()])
             if g["c"].max() >= hi_thr:
-                f1 = min(f1, g.loc[g["c"].idxmax(), "f"])
+                f1 = min(f1, tangent1[g["c"].idxmax()])
         if not np.isfinite(f0):
             f0 = dd.loc[dd["c"].idxmin(), "f"]
         if not np.isfinite(f1):

--- a/tests/regression/test_excess_endpoint_reference.py
+++ b/tests/regression/test_excess_endpoint_reference.py
@@ -1,0 +1,66 @@
+"""Regression tests for the f_excess endpoint reference with near-endpoint samples.
+
+Follow-up to #155.  The per-phase endpoint selection introduced there compared
+candidate reference phases by f at their extreme sampled concentration.  A
+solution phase whose last sample lands at c=1-eps (inside the 1% qualification
+band, e.g. because the mu window does not push it all the way to saturation)
+has f below its own value at c=1 by ~mu*eps, since f is convex with slope mu.
+Comparing raw f therefore let such a phase steal the c=1 reference from a line
+phase sitting exactly at c=1, lifting the f_excess of the actually stable
+endpoint phase off zero.
+
+The fix compares tangent-line values at the pure concentrations instead: phi
+is the c=0 value of the tangent at a sample (c, f) with slope mu, phi+mu the
+c=1 value.  Both reduce to f for a line phase located exactly at an endpoint.
+
+Setup: ideal-solution liquid between f_A=0 and f_B=0.05 eV at T=800 K, with a
+mu window stopping the liquid near c=0.995, and a line phase at c=1 placed
+between the liquid's last-sample f (~0.0477 eV) and its true endpoint value
+(0.05 eV).  Before the fix the line phase had f_excess ~ +3e-4 despite being
+the stable phase at c=1.
+"""
+
+import numpy as np
+import pytest
+from landau.calculate import calc_phase_diagram
+from landau.phases import LinePhase, IdealSolution
+
+ATOL = 1e-12
+
+
+@pytest.fixture(scope="module")
+def liquid():
+    liq_a = LinePhase("A(l)", fixed_concentration=0, line_energy=0.0, line_entropy=0)
+    liq_b = LinePhase("B(l)", fixed_concentration=1, line_energy=0.05, line_entropy=0)
+    return IdealSolution("liquid", liq_a, liq_b)
+
+
+def diagram(liquid, bcc_energy):
+    bcc = LinePhase("bcc", fixed_concentration=1.0, line_energy=bcc_energy, line_entropy=0)
+    # window chosen so the liquid's largest sample is ~0.995: inside the 1%
+    # qualification band but short of c=1
+    mu = np.linspace(-0.5, 0.42, 60)
+    return calc_phase_diagram([liquid, bcc], Ts=[800.0], mu=mu, keep_unstable=True, refine=False)
+
+
+def test_stable_endpoint_line_phase_is_reference(liquid):
+    """bcc at c=1 below the liquid's f(1) is the reference; its f_excess is exactly 0."""
+    df = diagram(liquid, bcc_energy=0.048)
+    liq_c_max = df.query("phase=='liquid'").c.max()
+    assert 0.99 < liq_c_max < 1, "liquid must stop inside the qualification band for this test"
+    bcc = df.query("phase=='bcc'")
+    assert bcc.stable.any()
+    np.testing.assert_allclose(bcc.f_excess, 0, atol=ATOL)
+
+
+def test_metastable_endpoint_line_phase_above_reference(liquid):
+    """bcc at c=1 above the liquid's f(1)=0.05 gets f_excess of its 0.01 eV gap.
+
+    The liquid reference is its tangent value at c=1 taken from the last
+    sample, which underestimates f(1) by the convexity error, so the gap comes
+    out slightly above 0.01 eV.
+    """
+    df = diagram(liquid, bcc_energy=0.06)
+    fex = df.query("phase=='bcc'").f_excess
+    assert (fex > 0.01).all()
+    assert (fex < 0.011).all()


### PR DESCRIPTION
Follow-up to #155 / #166.

## Problem

The per-phase endpoint selection in `calc_phase_diagram`'s `sub()` compares candidate reference phases by `f` at their extreme sampled concentration. `f(c)` is convex with slope `mu`, so a solution phase whose last sample lands at `c = 1-eps` lies below its own value at `c = 1` by `~mu*eps`. Any phase ending inside the 1% qualification band could therefore steal the `c = 1` reference from a line phase sitting exactly at `c = 1`, lifting the f_excess of the actually stable endpoint phase off zero (the reported symptom: stable terminal phase plotted above the zero line in `plot_excess_free_energy`).

Reducing the band does not fix this in general: genuine numerical shortfall and "phase legitimately stops short" overlap in magnitude. With a guessed mu window an `IdealSolution` sampled down only to `c = 5.7e-4` in my runs, while the #155 deviations were `~5e-6` — no fixed threshold separates the two cases, and even with the right phase selected, `f(1-eps)` used as the `c = 1` anchor is still biased by `mu*eps`.

## Fix

Compare (and anchor) by the tangent-line value at the pure concentrations instead of raw `f`: the tangent at a sample `(c, f)` has slope `mu`, so its value at `c = 0` is `phi` and at `c = 1` is `phi + mu` — both already in the dataframe, no approximation. For line phases located exactly at an endpoint both reduce to `f`, so the reference is unchanged there. The 1% band is kept as the candidate filter (it still excludes interior line phases, the `c = 0.08` case from #166).

Reproducer: ideal-solution liquid between 0 and 0.05 eV at 800 K with a mu window stopping it at `c = 0.9954`, line phase at `c = 1` with `f = 0.048` (stable, since liquid `f(1) = 0.05`). Before: line phase `f_excess = +2.7e-4`. After: exactly 0. The converse ordering (line phase metastable at 0.06 eV) gives `f_excess = +0.0103`, slightly above the true 0.01 eV gap because the tangent from the last sample underestimates the liquid's `f(1)` by the convexity error.

## Tests

`tests/regression/test_excess_endpoint_reference.py`: stable endpoint line phase has `f_excess = 0` to `atol = 1e-12`; metastable one lands in `(0.01, 0.011)`. Full suite: 403 passed, 1 xfailed.

https://claude.ai/code/session_01Hh9GmFb4W7LWnUKCa3tUwc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh9GmFb4W7LWnUKCa3tUwc)_