### PR TITLE
Recover transitions through stable windows narrower than the scan grid

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -876,6 +876,13 @@ def _add_1d_phase_legend(ax, df, scan_col, top_labels=True, side_labels=True, yl
             mask = (df[scan_col] > lo) & (df[scan_col] < hi) & df["stable"]
             stable_phases = df.loc[mask, "phase"].unique()
             if len(stable_phases) != 1:
+                # A stable window narrower than the grid spacing has no sample
+                # strictly inside its two borders; the phase marked stable on
+                # both enclosing rows is the one stable throughout.
+                at_lo = set(df.loc[(df[scan_col] == lo) & df["stable"], "phase"])
+                at_hi = set(df.loc[(df[scan_col] == hi) & df["stable"], "phase"])
+                stable_phases = sorted(at_lo & at_hi)
+            if len(stable_phases) != 1:
                 raise RuntimeError(
                     f"expected exactly one stable phase in [{lo}, {hi}], "
                     f"got {list(stable_phases)}"

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -314,21 +314,40 @@ class ScanRefiner(Refiner):
                 )
 
     def solve(self, cand: _ScanCandidate, phases) -> list[RefinedPoint]:
-        p1, p2 = phases[cand.phase1], phases[cand.phase2]
         if self.by == "mu":
-            mu = _find_one_point(
-                p1, p2,
-                lambda p, x: p.semigrand_potential(cand.T, x),
-                cand.bracket,
-            )
-            return [RefinedPoint(T=cand.T, mu=mu, phases=(cand.phase1, cand.phase2))]
+            def potential(p, x):
+                return p.semigrand_potential(cand.T, x)
+
+            def point(x, pair):
+                return RefinedPoint(T=cand.T, mu=x, phases=pair)
         else:
-            T = _find_one_point(
-                p1, p2,
-                lambda p, x: p.semigrand_potential(x, cand.mu),
-                cand.bracket,
-            )
-            return [RefinedPoint(T=T, mu=cand.mu, phases=(cand.phase1, cand.phase2))]
+            def potential(p, x):
+                return p.semigrand_potential(x, cand.mu)
+
+            def point(x, pair):
+                return RefinedPoint(T=x, mu=cand.mu, phases=pair)
+        return self._solve_pair(cand.phase1, cand.phase2, cand.bracket, potential, point, phases)
+
+    def _solve_pair(self, name1, name2, bracket, potential, point, phases) -> list[RefinedPoint]:
+        """Root-find the (name1, name2) crossing inside ``bracket``.
+
+        When a third phase is more stable at the crossing, the pair does not
+        actually coexist there: the stable phase changes name1 → dominator →
+        name2 inside the bracket, with the dominator's stable window narrower
+        than the sampling grid.  Recurse into the two sub-brackets so both real
+        transitions are found instead of leaving the candidate to be dropped
+        by :func:`_dominated` in :meth:`Refiner.run`.
+        """
+        x = _find_one_point(phases[name1], phases[name2], potential, bracket)
+        rivals = {p.name: potential(p, x) for p in phases.values() if p.name not in (name1, name2)}
+        if rivals:
+            dom = min(rivals, key=rivals.get)
+            if rivals[dom] < potential(phases[name1], x):
+                return (
+                    self._solve_pair(name1, dom, (bracket[0], x), potential, point, phases)
+                    + self._solve_pair(dom, name2, (x, bracket[1]), potential, point, phases)
+                )
+        return [point(x, (name1, name2))]
 
 
 # -- Delaunay-based refiners --------------------------------------------------

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -990,6 +990,41 @@ def test_top_spine_labels_bold_with_white_outline(df_T_three_stable):
         plt.close(fig)
 
 
+@pytest.fixture(scope="module")
+def df_mu_narrow_window():
+    """Isothermal mu scan where B's stable window (2.4, 2.6) is narrower than
+    the grid spacing of 1, so B is stable only on its two refined border rows
+    and no sample lies strictly between them."""
+    a = ldp.LinePhase("A", fixed_concentration=0.0, line_energy=0.0)
+    b = ldp.LinePhase("B", fixed_concentration=0.5, line_energy=1.2)
+    c = ldp.LinePhase("C", fixed_concentration=1.0, line_energy=2.5)
+    return ldc.calc_phase_diagram([a, b, c], 300.0, mu=np.linspace(0.0, 4.0, 5), keep_unstable=True)
+
+
+def test_top_labels_narrow_stable_window(df_mu_narrow_window):
+    """A phase with no sample strictly inside its borders still gets its top label."""
+    df = df_mu_narrow_window
+    inside = (df["mu"] > 2.4) & (df["mu"] < 2.6)
+    assert not inside.any(), "fixture must have no sample strictly inside B's window"
+    fig, ax = plt.subplots()
+    try:
+        plot_1d_mu_phase_diagram(df, ax=ax)
+        assert _top_labels(ax) == ["A", "B", "C"]
+    finally:
+        plt.close(fig)
+
+
+def test_top_labels_missing_border_raises(df_mu_narrow_window):
+    """A stable-phase change with no border row anywhere is still an error."""
+    df = df_mu_narrow_window[~df_mu_narrow_window["border"]]
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(RuntimeError, match="expected exactly one stable phase"):
+            plot_1d_mu_phase_diagram(df, ax=ax)
+    finally:
+        plt.close(fig)
+
+
 @pytest.mark.parametrize(
     "label, expected",
     [

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -13,6 +13,7 @@ from landau.refine import (
     DelaunayTripleRefiner,
     RefinedPoint,
     RefinedMiscibilityGap,
+    ScanRefiner,
 )
 from landau.refine import (
     _point_on_line,
@@ -571,3 +572,70 @@ def test_boundary_id_delaunay_triple_rows_share_id():
     assert "boundary_id" in out.columns
     # One triple point (3 rows) → all rows share the same boundary_id.
     assert out["boundary_id"].nunique() == 1
+
+
+# -- ScanRefiner --------------------------------------------------------------
+
+SCAN_ATOL = 1e-6  # xtol of _find_one_point
+
+
+def _narrow_window_system():
+    """Three LinePhases where B is stable only in mu = (2.4, 2.6).
+
+    With phi = E - mu*c the stable phase along mu at any T is A below 2.4,
+    B inside (2.4, 2.6), and C above 2.6.  On an integer mu grid no sample
+    ever sees B stable, so a scan only shows an A→C change between mu=2 and
+    mu=3 while the metastable A-C crossing at mu=2.5 is dominated by B.
+    """
+    ph_a = LinePhase(name="A", fixed_concentration=0.0, line_energy=0.0)
+    ph_b = LinePhase(name="B", fixed_concentration=0.5, line_energy=1.2)
+    ph_c = LinePhase(name="C", fixed_concentration=1.0, line_energy=2.5)
+    return {"A": ph_a, "B": ph_b, "C": ph_c}
+
+
+def test_scan_refiner_locates_pairwise_transition():
+    """Two-phase scan: the exact crossing is found within root-finder tolerance."""
+    phases = _narrow_window_system()
+    del phases["B"]
+    df = _coarse_df(phases, [300.0], np.linspace(0.0, 4.0, 5))
+    out = ScanRefiner("mu").run(df, phases)
+    # A-C crossing at phi_A = phi_C: mu = 2.5; one point, one row per phase.
+    assert sorted(out["phase"]) == ["A", "C"]
+    np.testing.assert_allclose(out["mu"], 2.5, atol=SCAN_ATOL)
+    assert out["stable"].all() and out["border"].all()
+
+
+def test_scan_refiner_splits_dominated_crossing():
+    """A stable window narrower than the grid spacing yields both real transitions.
+
+    The A-C crossing at mu=2.5 is dominated by B, so the refiner must recurse
+    and return the A-B and B-C transitions instead of dropping the candidate
+    (which left no border row at all between two stably-sampled phases).
+    """
+    phases = _narrow_window_system()
+    df = _coarse_df(phases, [300.0], np.linspace(0.0, 4.0, 5))
+    assert set(df["phase"]) == {"A", "C"}, "grid must not sample B stable"
+    out = ScanRefiner("mu").run(df, phases)
+    by_mu = out.groupby("mu")["phase"].agg(lambda s: tuple(sorted(s)))
+    assert len(by_mu) == 2
+    # phi_A = phi_B at mu = 2*1.2; phi_B = phi_C at mu = 2*(2.5 - 1.2).
+    np.testing.assert_allclose(by_mu.index, [2.4, 2.6], atol=SCAN_ATOL)
+    assert by_mu.tolist() == [("A", "B"), ("B", "C")]
+
+
+def test_scan_refiner_splits_dominated_crossing_T_scan():
+    """Same recursion along the T axis: entropy opens a narrow B window in T."""
+    # phi_A = 0, phi_B = 0.49 - 0.001*T, phi_C = 1 - 0.002*T at mu=0:
+    # B is stable only for T in (490, 510), inside the (350, 550) grid gap.
+    phases = {
+        "A": LinePhase(name="A", fixed_concentration=0.0, line_energy=0.0),
+        "B": LinePhase(name="B", fixed_concentration=0.5, line_energy=0.49, line_entropy=0.001),
+        "C": LinePhase(name="C", fixed_concentration=1.0, line_energy=1.0, line_entropy=0.002),
+    }
+    df = _coarse_df(phases, np.linspace(150.0, 950.0, 5), [0.0])
+    assert set(df["phase"]) == {"A", "C"}, "grid must not sample B stable"
+    out = ScanRefiner("T").run(df, phases)
+    by_T = out.groupby("T")["phase"].agg(lambda s: tuple(sorted(s)))
+    assert len(by_T) == 2
+    np.testing.assert_allclose(by_T.index, [490.0, 510.0], atol=SCAN_ATOL)
+    assert by_T.tolist() == [("A", "B"), ("B", "C")]


### PR DESCRIPTION
Fixes the `RuntimeError: expected exactly one stable phase in [lo, hi], got ['Al$_{4}$Ca$_{2}$', 'Ca (bcc)']` crash in `plot_1d_mu_phase_diagram`.

The bridge rows from `_bridge_unstable_segments` are not the cause: `_add_1d_phase_legend` receives the un-bridged frame and the bridge rows are marked `stable=False`.

Root cause: when a phase's stable window along the scan is narrower than the grid spacing, no sample sees it stable. `ScanRefiner` then proposes only the crossing of the two phases stable on either side of the gap; that crossing lies inside the hidden window, so `_dominated` in `Refiner.run()` drops it. The result is no border row at all between two stably-sampled phases, and the legend's per-interval stable-phase lookup finds two.

Reproducer (three `LinePhase`s, B stable only for mu in (2.4, 2.6) on a grid of spacing 1):

```python
A = LinePhase("A", 0.0, 0.0)
B = LinePhase("B", 0.5, 1.2)
C = LinePhase("C", 1.0, 2.5)
pdf = calc_phase_diagram([A, B, C], 300.0, mu=np.linspace(0, 4, 5), keep_unstable=True)
plot_1d_mu_phase_diagram(pdf)  # raised: expected exactly one stable phase in [0.0, 4.0], got ['A', 'C']
```

Changes:

- `ScanRefiner.solve` checks the located crossing for a dominating third phase and recurses into the two sub-brackets, returning the transitions on both edges of the narrow window (mu=2.4 and 2.6 above, both at root-finder tolerance) instead of leaving the candidate to be dropped. Both sub-brackets are guaranteed sign changes: the original pair phase is stable at the grid end, the dominator at the crossing.
- `_add_1d_phase_legend`: the recovered window has no sample strictly between its two border rows, so when the strict interior mask does not identify exactly one phase, fall back to the phase marked stable on both enclosing rows. A stable-phase change with no border row anywhere still raises.

Tests: `tests/unit/test_refine.py` gains three `ScanRefiner` tests (plain two-phase crossing, dominated-crossing split along mu, same along T; all assert analytic transition positions at 1e-6). `tests/unit/plot/test_1d_plots.py` pins the narrow-window plot labels (A, B, C) and that a frame with the border rows stripped still raises. Full suite: 391 passed, 15 skipped, 1 xfailed.

https://claude.ai/code/session_01CrAjMDHtuQ3gaqsZyjWBsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrAjMDHtuQ3gaqsZyjWBsr)_