### PR TITLE
Move DelaunayTripleRefiner dedup state from solve() into run()

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -410,12 +410,15 @@ class DelaunayTripleRefiner(Refiner):
     For every Delaunay simplex containing three distinct phases, locate the
     triple point by minimizing the sum of pairwise potential differences,
     starting from the simplex centroid.
+
+    Deduplication is handled by :meth:`run`, not :meth:`solve`. A point
+    returned by ``solve`` is dropped by ``run`` when it falls within the
+    enclosing simplex's ``(T, mu)`` extent of an already-emitted triple
+    point. Subclasses that override ``solve`` do not need to reimplement
+    this logic.
     """
 
     label = "delaunay-triple"
-
-    def __init__(self):
-        self._found: list[TMuPoint] = []
 
     def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
         for simplex, n in _delaunay_simplices(df):
@@ -427,8 +430,6 @@ class DelaunayTripleRefiner(Refiner):
         T0, mu0 = tr[["T", "mu"]].mean()
         names = tuple(tr.phase.unique())
         p1, p2, p3 = (phases[n] for n in names)
-        T_tol = float(tr["T"].max() - tr["T"].min())
-        mu_tol = float(tr["mu"].max() - tr["mu"].min())
 
         def triplemin(x):
             T, mu = x
@@ -438,11 +439,34 @@ class DelaunayTripleRefiner(Refiner):
             return abs(phi1 - phi2) + abs(phi2 - phi3) + abs(phi3 - phi1)
 
         T, mu = so.fmin(triplemin, (T0, mu0), disp=False)
-        if any(abs(T - fT) <= T_tol and abs(mu - fmu) <= mu_tol
-               for fT, fmu in self._found):
-            return []
-        self._found.append((T, mu))
         return [RefinedPoint(T=T, mu=mu, phases=names)]
+
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        """propose → solve → dedup by simplex-extent tolerance → dataframe."""
+        rows: list[dict] = []
+        found: list[TMuPoint] = []
+        boundary_id = 0
+        for cand in self.propose(df):
+            pts = [pt for pt in self.solve(cand, phases)
+                   if pt.T >= 0 and not _dominated(pt, phases)]
+            tr = cand.simplex
+            T_tol = float(tr["T"].max() - tr["T"].min())
+            mu_tol = float(tr["mu"].max() - tr["mu"].min())
+            kept = [pt for pt in pts
+                    if not any(abs(pt.T - fT) <= T_tol and abs(pt.mu - fmu) <= mu_tol
+                               for fT, fmu in found)]
+            for pt in kept:
+                found.append((pt.T, pt.mu))
+                rows.extend(replace(pt, boundary_id=boundary_id).to_rows(phases))
+            if kept:
+                boundary_id += 1
+        out = pd.DataFrame(rows)
+        if out.empty:
+            return out
+        out["stable"] = True
+        out["border"] = True
+        out["refined"] = self.label
+        return out
 
 
 # -- Clausius-Clapeyron tracers ----------------------------------------------

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -459,6 +459,31 @@ def _coarse_df(phases, Ts, mus):
     return pd.DataFrame(rows)
 
 
+def test_delaunay_triple_solve_is_pure():
+    """solve() returns a result every time it is called; dedup is run()'s job."""
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 6)
+    mus = np.linspace(-0.05, 0.55, 7)
+    df = _coarse_df(phases, Ts, mus)
+
+    from landau.refine import _SimplexCandidate, _delaunay_simplices
+    triple_cands = [
+        _SimplexCandidate(simplex=s)
+        for s, n in _delaunay_simplices(df)
+        if n == 3
+    ]
+    assert len(triple_cands) >= 1
+
+    refiner = DelaunayTripleRefiner()
+    cand = triple_cands[0]
+    result1 = refiner.solve(cand, phases)
+    result2 = refiner.solve(cand, phases)
+    assert len(result1) == 1
+    assert len(result2) == 1
+    assert result1[0].T == result2[0].T
+    assert result1[0].mu == result2[0].mu
+
+
 def test_delaunay_triple_refiner_deduplicates():
     """Triple refiner emits each triple point exactly once even when
     multiple three-phase Delaunay simplices independently detect it."""


### PR DESCRIPTION
Closes #210. Sub-issue of #116.

## Changes

`landau/refine.py` — `DelaunayTripleRefiner`:

- Remove `__init__` and `self._found`. `solve()` is now a pure function of `(cand, phases)`: it minimizes the triple potential and returns the `RefinedPoint` unconditionally.
- Add a `run()` override. It maintains a local `found: list[TMuPoint]` across candidates and drops any result whose `(T, mu)` falls within the enclosing simplex's extent of an already-emitted point — the same tolerance logic that was previously inside `solve()`. The docstring documents that `run()` owns dedup so future subclassers do not reintroduce it in `solve()`.

`tests/unit/test_refine.py`:

- Add `test_delaunay_triple_solve_is_pure`: calls `solve()` twice on the same candidate and asserts both calls return a non-empty result at the same location.
- `test_delaunay_triple_refiner_deduplicates` and `test_boundary_id_delaunay_triple_rows_share_id` pass unchanged.

Full suite: 397 passed, 0 failed.

https://claude.ai/code/session_01D4u5mwhm3nkZru3DB6KYAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4u5mwhm3nkZru3DB6KYAs)_