### PR TITLE
Add locus column classifying phase diagram points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ These are project-specific preferences distilled from past PR/issue feedback. So
 - Match a terse, imperative tone. No "Happy to...", no apologies, no enthusiasm filler. (Restates the harness default — keep it in mind anyway.)
 - PR bodies are plain technical reports. No **bold** "headline numbers", no "Conclusion" sections, no `[Fix this →]` action links, no marketing claims ("dramatic speedup", "significantly improves").
 - Do not invoke the maintainer's name or authority in PR bodies or comments (PR #94: "don't use my name in vain").
+- Keep the PR description (the OP) in sync with the diff. When review feedback or later commits invalidate something in the body, edit the body — never leave a stale claim standing (e.g. a dropped export still described as exported, an outdated test count).
 
 ### Comments and docstrings
 - Reflect only the current state of the code. Historical motivation is acceptable (why a threshold exists, why an approach was chosen), but never narrate the intermediate steps, rejected alternatives, or "old 10% vs new 1%" comparisons that arose during a PR. Those belong in the PR description, not in the source.

--- a/landau/__init__.py
+++ b/landau/__init__.py
@@ -1,5 +1,3 @@
-from .features import Locus
-
 from .phases import (
     LinePhase,
     TemperatureDepandantLinePhase,

--- a/landau/__init__.py
+++ b/landau/__init__.py
@@ -1,3 +1,5 @@
+from .features import Locus
+
 from .phases import (
     LinePhase,
     TemperatureDepandantLinePhase,

--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -11,6 +11,7 @@ from scipy.constants import Boltzmann, eV
 from sklearn.cluster import AgglomerativeClustering
 
 
+from .features import Locus
 from .phases import Phase, AbstractLinePhase
 from .refine import Refiner, default_refiners, _find_one_point as find_one_point  # noqa: F401
 
@@ -45,14 +46,21 @@ def _split_phase_unit(combined: pd.Series) -> tuple[pd.Series, pd.Series]:
 def _split_stable(df):
     udf = df.query("not stable").reset_index(drop=True)
     udf["border"] = False
+    udf["locus"] = Locus.INTERIOR
     sdf = df.query("stable").reset_index(drop=True)
     sdf["border"] = False
     sdf["refined"] = "no"
+    sdf["locus"] = Locus.INTERIOR
     return sdf, udf
 
 
 def _border_edges(df, min_c, max_c):
-    """Mark T extremes as border and emit synthetic +-inf mu edges (2D only)."""
+    """Mark T extremes as border and emit synthetic +-inf mu edges (2D only).
+
+    The synthetic edge points only close the sampling window for polygon
+    construction, they are no thermodynamic transitions, so they keep
+    ``locus = Locus.INTERIOR`` despite ``border = True``.
+    """
     df.loc[df["T"] == df["T"].min(), "border"] = True
     df.loc[df["T"] == df["T"].max(), "border"] = True
     left = df.loc[df["mu"] == df["mu"].min()][["phase", "T"]].copy()
@@ -60,11 +68,13 @@ def _border_edges(df, min_c, max_c):
     left["c"] = min_c
     left["border"] = True
     left["stable"] = True
+    left["locus"] = Locus.INTERIOR
     right = df.loc[df["mu"] == df["mu"].max()][["phase", "T"]].copy()
     right["mu"] = +np.inf
     right["c"] = max_c
     right["border"] = True
     right["stable"] = True
+    right["locus"] = Locus.INTERIOR
     return left, right
 
 
@@ -174,7 +184,9 @@ def calc_phase_diagram(
         keep_unstable (bool): only keep entries of stable phases, otherwise keep entries of all phases at all sampling points
 
     Returns:
-        dataframe of phase points
+        dataframe of phase points; the ``locus`` column classifies each row
+        as a :class:`~landau.features.Locus` value (``"interior"``,
+        ``"boundary"`` or ``"triple"``)
     """
     if not isinstance(Ts, Iterable):
         Ts = [Ts]
@@ -201,6 +213,7 @@ def calc_phase_diagram(
     pdf = pdf.explode(["mu", "phi", "c"]).infer_objects().reset_index(drop=True)
     pdf["stable"] = False
     pdf.loc[pdf.groupby(["T", "mu"], group_keys=False).phi.idxmin(), "stable"] = True
+    pdf["locus"] = Locus.INTERIOR
     if refine:
         min_c = pdf.c.min()
         max_c = pdf.c.max()

--- a/landau/features.py
+++ b/landau/features.py
@@ -1,0 +1,30 @@
+"""Domain vocabulary for features of a phase diagram."""
+
+from enum import StrEnum
+
+__all__ = ["Locus"]
+
+
+class Locus(StrEnum):
+    """Classifies what part of the phase diagram a sampled point belongs to.
+
+    Backs the ``locus`` column of the dataframes returned by
+    :func:`landau.calculate.calc_phase_diagram`.  Members are strings, so
+    rows can be selected either by member or by plain value::
+
+        df.query("locus == 'triple'")
+        df[df["locus"] == Locus.TRIPLE]
+
+    INTERIOR
+        A regular sample inside a single-phase region, including the
+        synthetic frame points emitted at the edges of the sampling window.
+    BOUNDARY
+        A refined point on a two-phase coexistence line, including the two
+        branches of a miscibility gap.
+    TRIPLE
+        A refined point at which three phases coexist.
+    """
+
+    INTERIOR = "interior"
+    BOUNDARY = "boundary"
+    TRIPLE = "triple"

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -56,6 +56,7 @@ import scipy.optimize as so
 import shapely
 from scipy.spatial import Delaunay
 
+from .features import Locus
 from .phases import Phase
 
 
@@ -104,6 +105,10 @@ class RefinedPoint:
     boundary_id : int
         Identifier shared by all rows that belong to the same coexistence
         line (assigned by the refiner's ``run()``).
+
+    :meth:`to_rows` tags each emitted row with ``locus``:
+    :attr:`~landau.features.Locus.TRIPLE` for three coexisting phases,
+    :attr:`~landau.features.Locus.BOUNDARY` otherwise.
     """
 
     T: float
@@ -116,8 +121,10 @@ class RefinedPoint:
 
     def to_rows(self, phases: Mapping[str, Phase]) -> list[dict]:
         rows = [_state_row(phases[name], self.T, self.mu) for name in self.phases]
+        locus = Locus.TRIPLE if len(self.phases) == 3 else Locus.BOUNDARY
         for row in rows:
             row["boundary_id"] = self.boundary_id
+            row["locus"] = locus
         return rows
 
 
@@ -130,7 +137,8 @@ class RefinedMiscibilityGap:
     share that exact ``mu`` value but carry the pre-computed
     branch concentrations ``c_left`` and ``c_right`` directly — so
     the two branches show up as distinct ``(c, T)`` points while
-    still sitting on the exact coexistence chemical potential.
+    still sitting on the exact coexistence chemical potential. Both
+    rows are tagged ``locus = Locus.BOUNDARY``.
 
     Attributes
     ----------
@@ -164,9 +172,11 @@ class RefinedMiscibilityGap:
         phi = float(ph.semigrand_potential(self.T, self.mu))
         return [
             {"T": self.T, "mu": self.mu, "phi": phi,
-             "c": self.c_left,  "phase": ph.name, "boundary_id": self.boundary_id},
+             "c": self.c_left,  "phase": ph.name, "boundary_id": self.boundary_id,
+             "locus": Locus.BOUNDARY},
             {"T": self.T, "mu": self.mu, "phi": phi,
-             "c": self.c_right, "phase": ph.name, "boundary_id": self.boundary_id},
+             "c": self.c_right, "phase": ph.name, "boundary_id": self.boundary_id,
+             "locus": Locus.BOUNDARY},
         ]
 
 

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -380,7 +380,8 @@ def test_cluster_use_mu_false_dispatches_to_cluster_T_c():
 # --- locus column tests ---
 
 
-def _triple_point_phases():
+@pytest.fixture
+def triple_point_phases():
     """Three LinePhases with a single triple point at (T=300 K, mu=0.2 eV)."""
     return [
         LinePhase("A", 0.0, -1.0, 0.004),
@@ -395,8 +396,8 @@ def test_calc_phase_diagram_unrefined_locus_all_interior(two_phase_ideal):
     assert (df["locus"] == Locus.INTERIOR).all()
 
 
-def test_calc_phase_diagram_refined_locus():
-    df = calc_phase_diagram(_triple_point_phases(), Ts=np.linspace(220, 480, 12),
+def test_calc_phase_diagram_refined_locus(triple_point_phases):
+    df = calc_phase_diagram(triple_point_phases, Ts=np.linspace(220, 480, 12),
                             mu=np.linspace(-0.05, 0.55, 15), keep_unstable=True)
     assert not df["locus"].isna().any()
     assert set(map(str, df["locus"])) <= {"interior", "boundary", "triple"}
@@ -412,8 +413,8 @@ def test_calc_phase_diagram_refined_locus():
     assert (df.loc[edges, "locus"] == Locus.INTERIOR).all()
 
 
-def test_calc_phase_diagram_locus_triple():
-    df = calc_phase_diagram(_triple_point_phases(), Ts=np.linspace(220, 480, 12),
+def test_calc_phase_diagram_locus_triple(triple_point_phases):
+    df = calc_phase_diagram(triple_point_phases, Ts=np.linspace(220, 480, 12),
                             mu=np.linspace(-0.05, 0.55, 15))
     triple = df[df["locus"] == Locus.TRIPLE]
     assert not triple.empty

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from hypothesis import given, strategies as st
 from landau.calculate import (
+    calc_phase_diagram,
     find_one_point,
     cluster,
     cluster_T_c,
@@ -14,6 +15,7 @@ from landau.calculate import (
     _split_stable,
     guess_mu_range,
 )
+from landau.features import Locus
 from unittest.mock import MagicMock
 
 def test_find_one_point_success():
@@ -268,6 +270,9 @@ def test_split_stable_adds_border_and_refined_columns(stable_unstable_frame):
     # only the stable half gets refined="no"
     assert (sdf["refined"] == "no").all()
     assert "refined" not in udf.columns
+    # plain samples in both halves are interior points
+    assert (sdf["locus"] == Locus.INTERIOR).all()
+    assert (udf["locus"] == Locus.INTERIOR).all()
 
 
 def test_split_stable_does_not_mutate_input(stable_unstable_frame):
@@ -315,6 +320,9 @@ def test_border_edges_left_right_use_extreme_mu_rows(grid_frame):
     assert (right["border"] == True).all()  # noqa: E712
     assert (left["stable"] == True).all()  # noqa: E712
     assert (right["stable"] == True).all()  # noqa: E712
+    # frame edges only close the sampling window, they are no transitions
+    assert (left["locus"] == Locus.INTERIOR).all()
+    assert (right["locus"] == Locus.INTERIOR).all()
 
 
 def test_border_edges_preserves_T_and_phase_from_source(grid_frame):
@@ -367,3 +375,49 @@ def test_cluster_use_mu_false_dispatches_to_cluster_T_c():
     labels = cluster(dd, use_mu=False, distance_threshold=0.5)
     assert labels.nunique() == 1
     assert len(labels) == len(dd)
+
+
+# --- locus column tests ---
+
+
+def _triple_point_phases():
+    """Three LinePhases with a single triple point at (T=300 K, mu=0.2 eV)."""
+    return [
+        LinePhase("A", 0.0, -1.0, 0.004),
+        LinePhase("B", 0.5, -1.2, 0.003),
+        LinePhase("C", 1.0, -1.7, 0.001),
+    ]
+
+
+def test_calc_phase_diagram_unrefined_locus_all_interior(two_phase_ideal):
+    df = calc_phase_diagram(two_phase_ideal, Ts=np.linspace(300, 1000, 5),
+                            mu=np.linspace(-0.5, 0.5, 5), refine=False, keep_unstable=True)
+    assert (df["locus"] == Locus.INTERIOR).all()
+
+
+def test_calc_phase_diagram_refined_locus():
+    df = calc_phase_diagram(_triple_point_phases(), Ts=np.linspace(220, 480, 12),
+                            mu=np.linspace(-0.05, 0.55, 15), keep_unstable=True)
+    assert not df["locus"].isna().any()
+    assert set(map(str, df["locus"])) <= {"interior", "boundary", "triple"}
+    assert (df["locus"] == Locus.BOUNDARY).any()
+    # refined rows are exactly the non-interior ones
+    refined = df["refined"].fillna("no") != "no"
+    assert (df.loc[refined, "locus"] != Locus.INTERIOR).all()
+    assert (df.loc[~refined, "locus"] == Locus.INTERIOR).all()
+    # frame edges are border=True but still interior
+    edges = df["mu"].abs() == np.inf
+    assert edges.any()
+    assert df.loc[edges, "border"].all()
+    assert (df.loc[edges, "locus"] == Locus.INTERIOR).all()
+
+
+def test_calc_phase_diagram_locus_triple():
+    df = calc_phase_diagram(_triple_point_phases(), Ts=np.linspace(220, 480, 12),
+                            mu=np.linspace(-0.05, 0.55, 15))
+    triple = df[df["locus"] == Locus.TRIPLE]
+    assert not triple.empty
+    # every triple point consists of three coexisting phases at one (T, mu)
+    assert (triple.groupby(["T", "mu"])["phase"].nunique() == 3).all()
+    assert np.allclose(triple["T"], 300.0, atol=10.0)
+    assert np.allclose(triple["mu"], 0.2, atol=0.05)

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from landau.features import Locus
 from landau.phases import LinePhase, TemperatureDependentLinePhase
 from landau.interpolate import SGTE
 from landau.interpolate.basic import G_calphad
@@ -68,6 +69,9 @@ def test_clausius_clapeyron_refiner_traces_coexistence(two_phase_system):
     assert not out.empty
     assert (out["refined"] == "clausius-clapeyron").all()
     assert out["stable"].all() and out["border"].all()
+    # locus is comparable both by enum member and by plain string value.
+    assert (out["locus"] == Locus.BOUNDARY).all()
+    assert (out["locus"] == "boundary").all()
 
     # Pair up coexistence rows by (T, mu); each unique location should carry
     # both phase names.
@@ -476,6 +480,7 @@ def test_delaunay_triple_refiner_deduplicates():
 
     assert not out.empty
     assert (out["refined"] == "delaunay-triple").all()
+    assert (out["locus"] == Locus.TRIPLE).all()
     # Exactly one triple point → 3 rows (one per phase).
     assert len(out) == 3
     assert set(out["phase"]) == {"A", "B", "C"}
@@ -535,6 +540,8 @@ def test_boundary_id_miscibility_gap_refiner():
     assert "boundary_id" in cc.columns
     # One miscibility gap → one boundary_id.
     assert cc["boundary_id"].nunique() == 1
+    # Gap branches are coexistence points, not triple points.
+    assert (cc["locus"] == Locus.BOUNDARY).all()
 
 
 def test_boundary_id_refined_point_to_rows():
@@ -558,6 +565,32 @@ def test_boundary_id_refined_miscibility_gap_to_rows():
     rows = pt.to_rows({"p": _Phase()})
     assert len(rows) == 2
     assert all(row["boundary_id"] == 3 for row in rows)
+
+
+def test_locus_refined_point_to_rows():
+    """RefinedPoint.to_rows tags rows by phase count: two coexisting phases
+    make a boundary point, three a triple point."""
+    mapping = {
+        n: LinePhase(name=n, fixed_concentration=c, line_energy=-1.0, line_entropy=0.0)
+        for n, c in [("x", 0.1), ("y", 0.5), ("z", 0.9)]
+    }
+    pair = RefinedPoint(T=500.0, mu=0.05, phases=("x", "y"))
+    assert all(row["locus"] is Locus.BOUNDARY for row in pair.to_rows(mapping))
+    triple = RefinedPoint(T=500.0, mu=0.05, phases=("x", "y", "z"))
+    assert all(row["locus"] is Locus.TRIPLE for row in triple.to_rows(mapping))
+
+
+def test_locus_refined_miscibility_gap_to_rows():
+    """RefinedMiscibilityGap.to_rows tags both branch rows as boundary."""
+    class _Phase:
+        name = "p"
+
+        def semigrand_potential(self, T, mu):
+            return 0.0
+
+    pt = RefinedMiscibilityGap(T=400.0, mu=0.0, phase="p", c_left=0.1, c_right=0.9)
+    rows = pt.to_rows({"p": _Phase()})
+    assert all(row["locus"] is Locus.BOUNDARY for row in rows)
 
 
 def test_boundary_id_delaunay_triple_rows_share_id():


### PR DESCRIPTION
Tag every row of the `calc_phase_diagram` dataframe with a `locus` column: `interior` for plain grid samples, `boundary` for refined two-phase coexistence points and miscibility-gap branches, `triple` for refined three-phase points. Until now triple points were only recognizable via `refined == "delaunay-triple"` or by counting phases per `(T, mu)` group.

Values are backed by the new `Locus` StrEnum in `landau/features.py` (import via `from landau.features import Locus`; not re-exported at the package level yet), so rows select both by plain string and by member:

```python
df.query("locus == 'triple'")
df[df["locus"] == Locus.TRIPLE]
```

Implementation:
- `RefinedPoint.to_rows` tags by the number of coexisting phases (3 → `triple`, else `boundary`), keeping the tagging refiner-agnostic; `RefinedMiscibilityGap.to_rows` tags both branch rows `boundary`.
- Grid samples are tagged `interior` in `calc_phase_diagram` (covers `refine=False`) and in `_split_stable` (covers direct `refine_phase_diagram` calls).
- The synthetic frame rows from `_border_edges` (`mu=±inf`, T extremes) keep `locus = interior` despite `border = True` — they only close the sampling window and are no thermodynamic transitions.

Tests: locus assertions added to the existing ClausiusClapeyron, DelaunayTriple, and miscibility-gap refiner tests plus direct `to_rows` unit tests in `tests/unit/test_refine.py`; `_split_stable`/`_border_edges` and end-to-end `calc_phase_diagram` coverage (unrefined all-interior, refined ⇔ non-interior, frame edges, triple point location) in `tests/unit/test_calculate.py`. Full suite: 410 passed, 1 xfailed on pandas 3.0.3.

https://claude.ai/code/session_01Q38JJsxAV8sErJiYoCFY6p