### PR TITLE
refactor(refine): move DelaunayTripleRefiner dedup out of solve() into run()

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -429,12 +429,15 @@ class DelaunayTripleRefiner(Refiner):
     For every Delaunay simplex containing three distinct phases, locate the
     triple point by minimizing the sum of pairwise potential differences,
     starting from the simplex centroid.
+
+    Deduplication is done in :meth:`run`, not in :meth:`solve`. Each located
+    ``(T, mu)`` is compared against previously emitted triple points using the
+    current candidate's simplex extents as tolerances; duplicates are dropped
+    before the output rows are built. Subclasses that only override ``solve``
+    inherit this behaviour automatically and must not reintroduce dedup there.
     """
 
     label = "delaunay-triple"
-
-    def __init__(self):
-        self._found: list[TMuPoint] = []
 
     def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
         for simplex, n in _delaunay_simplices(df):
@@ -446,8 +449,6 @@ class DelaunayTripleRefiner(Refiner):
         T0, mu0 = tr[["T", "mu"]].mean()
         names = tuple(tr.phase.unique())
         p1, p2, p3 = (phases[n] for n in names)
-        T_tol = float(tr["T"].max() - tr["T"].min())
-        mu_tol = float(tr["mu"].max() - tr["mu"].min())
 
         def triplemin(x):
             T, mu = x
@@ -457,11 +458,36 @@ class DelaunayTripleRefiner(Refiner):
             return abs(phi1 - phi2) + abs(phi2 - phi3) + abs(phi3 - phi1)
 
         T, mu = so.fmin(triplemin, (T0, mu0), disp=False)
-        if any(abs(T - fT) <= T_tol and abs(mu - fmu) <= mu_tol
-               for fT, fmu in self._found):
-            return []
-        self._found.append((T, mu))
         return [RefinedPoint(T=T, mu=mu, phases=names)]
+
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        rows: list[dict] = []
+        found: list[TMuPoint] = []
+        boundary_id = 0
+        for cand in self.propose(df):
+            tr = cand.simplex
+            T_tol = float(tr["T"].max() - tr["T"].min())
+            mu_tol = float(tr["mu"].max() - tr["mu"].min())
+            pts = [pt for pt in self.solve(cand, phases)
+                   if pt.T >= 0 and not _dominated(pt, phases)]
+            new_pts = []
+            for pt in pts:
+                if any(abs(pt.T - fT) <= T_tol and abs(pt.mu - fmu) <= mu_tol
+                       for fT, fmu in found):
+                    continue
+                found.append((pt.T, pt.mu))
+                new_pts.append(pt)
+            for pt in new_pts:
+                rows.extend(replace(pt, boundary_id=boundary_id).to_rows(phases))
+            if new_pts:
+                boundary_id += 1
+        out = pd.DataFrame(rows)
+        if out.empty:
+            return out
+        out["stable"] = True
+        out["border"] = True
+        out["refined"] = self.label
+        return out
 
 
 # -- Clausius-Clapeyron tracers ----------------------------------------------

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -19,6 +19,7 @@ from landau.refine import (
     _point_on_line,
     _simplex_straddles,
     _InterCandidate,
+    _SimplexCandidate,
     _delaunay_simplices,
 )
 
@@ -482,6 +483,48 @@ def test_delaunay_triple_refiner_deduplicates():
     assert set(out["phase"]) == {"A", "B", "C"}
     assert np.allclose(out["T"], 300.0, atol=10.0)
     assert np.allclose(out["mu"], 0.2, atol=0.05)
+
+
+def test_delaunay_triple_refiner_solve_is_pure():
+    """solve() is stateless: calling it twice on the same candidate returns
+    the same RefinedPoint both times, not [] on the second call."""
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 6)
+    mus = np.linspace(-0.05, 0.55, 7)
+    df = _coarse_df(phases, Ts, mus)
+
+    triple_simplices = [s for s, n in _delaunay_simplices(df) if n == 3]
+    assert triple_simplices, "need at least one three-phase simplex"
+    cand = _SimplexCandidate(simplex=triple_simplices[0])
+
+    refiner = DelaunayTripleRefiner()
+    pts1 = refiner.solve(cand, phases)
+    pts2 = refiner.solve(cand, phases)
+    assert len(pts1) == 1
+    assert len(pts2) == 1, "second call must not return [] (solve must be pure)"
+    assert np.isclose(pts1[0].T, pts2[0].T, atol=1.0)
+    assert np.isclose(pts1[0].mu, pts2[0].mu, atol=0.01)
+
+
+def test_delaunay_triple_refiner_run_deduplicates_adjacent_simplices():
+    """run() emits exactly one triple point even when multiple adjacent
+    three-phase simplices all converge to the same (T, mu)."""
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 6)
+    mus = np.linspace(-0.05, 0.55, 7)
+    df = _coarse_df(phases, Ts, mus)
+
+    n_triple = sum(1 for _, n in _delaunay_simplices(df) if n == 3)
+    assert n_triple >= 2, "grid must produce at least two three-phase simplices"
+
+    out = DelaunayTripleRefiner().run(df, phases)
+
+    # One triple point → 3 rows (one per phase); all rows share one boundary_id.
+    assert len(out) == 3
+    assert set(out["phase"]) == {"A", "B", "C"}
+    assert out["boundary_id"].nunique() == 1
+    np.testing.assert_allclose(out["T"], 300.0, atol=10.0)
+    np.testing.assert_allclose(out["mu"], 0.2, atol=0.05)
 
 
 def test_boundary_id_cc_refiner_single_line(two_phase_system):


### PR DESCRIPTION
Closes #210, sub-issue of #116.

## Changes

### `landau/refine.py`

`DelaunayTripleRefiner.__init__` and `self._found` removed.

`solve()` is now pure: it always returns the located `RefinedPoint` without consulting or mutating instance state.

A thin `run()` override handles deduplication. It walks `propose()`, calls `solve()`, then for each returned point checks whether `(T, mu)` falls within one simplex-width of any already-emitted triple point — using `T_tol = simplex.T.max() - simplex.T.min()` and `mu_tol` from the current candidate's bounding box, the same tolerances as before. Points that pass are appended to a local `found` list; duplicates are dropped before `to_rows` is called. `boundary_id` assignment follows the same pattern as `Refiner.run()`: one id per non-empty `new_pts` list.

The docstring documents that `run()` owns the dedup so subclassers who override only `solve()` do not have to replicate it.

### `tests/unit/test_refine.py`

Two new tests:

- `test_delaunay_triple_refiner_solve_is_pure`: calls `solve()` twice on the same `_SimplexCandidate`; asserts both calls return one point (not `[]` on the second).
- `test_delaunay_triple_refiner_run_deduplicates_adjacent_simplices`: same three-phase system as the existing dedup test; asserts `≥ 2` three-phase simplices are present, then that `run()` still emits exactly 3 rows (one triple point) with a single `boundary_id`.

Full suite: 412 passed, 1 xfailed.

https://claude.ai/code/session_01DQME7AKmXspSdB4ghYKhbi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQME7AKmXspSdB4ghYKhbi)_