### PR TITLE
Factor pandas 2/3 single-group groupby.apply workaround into `_apply_series`

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -25,6 +25,20 @@ __all__ = ["calc_phase_diagram", "get_transitions", "cluster_T_c", "cluster_T_c_
 _PHASE_UNIT_SEP = "_"
 
 
+def _apply_series(grouped, fn, name: str) -> pd.Series:
+    """Run ``fn`` per group, return a row-indexed :class:`pd.Series`.
+
+    Wraps :meth:`pandas.core.groupby.DataFrameGroupBy.apply` so that the result
+    has the same shape across pandas 2 and 3.  In pandas 3 a single-group
+    ``groupby.apply`` whose callable returns a Series collapses to a one-row
+    DataFrame indexed by the group key; returning a DataFrame from the callable
+    is the documented workaround that combines consistently across both
+    versions (pandas user guide, "Flexible apply").  ``include_groups=False``
+    is passed through.
+    """
+    return grouped.apply(lambda g: fn(g).to_frame(name), include_groups=False)[name]
+
+
 def _join_phase_unit(phase: pd.Series, unit: pd.Series) -> pd.Series:
     """Encode ``(phase, unit)`` pairs as ``f"{phase}{_PHASE_UNIT_SEP}{unit}"`` strings.
 
@@ -251,11 +265,7 @@ def calc_phase_diagram(
             f1 = dd.loc[dd["c"].idxmax(), "f"]
         return dd.f - (f0 * (1 - dd.c) + f1 * dd.c)
 
-    fex = pdf.groupby("T", group_keys=False).apply(sub, include_groups=False)
-    if isinstance(fex, pd.DataFrame):
-        # pandas 3 returns a DataFrame for single-group groupby.apply; undo that.
-        fex = fex.stack().reset_index(level=0, drop=True)
-    pdf["f_excess"] = fex
+    pdf["f_excess"] = _apply_series(pdf.groupby("T", group_keys=False), sub, "f_excess")
     if not keep_unstable:
         pdf = pdf.query("stable")
     return pdf
@@ -355,14 +365,11 @@ def get_transitions(df):
     # cluster points that are assigned as one transition, because the same transition can appear multiple times in "disconnected" manner in a phase
     # diagram, e.g. a solid solution in contact with the melt interrupted by a higher melting intermetallic
     if not tdf.empty:
-        res = tdf.groupby("transition", group_keys=False).apply(
+        tdf["transition_unit"] = _apply_series(
+            tdf.groupby("transition", group_keys=False),
             lambda g: cluster_T_c_mu(g, distance_threshold=0.5),  # 0.5 hand-tuned
-            include_groups=False,
+            "transition_unit",
         )
-        if isinstance(res, pd.DataFrame):
-             # sometimes pandas returns a DataFrame instead of a Series when only one group exists
-             res = res.stack().reset_index(level=0, drop=True)
-        tdf["transition_unit"] = res
         tdf["border_segment"] = _join_phase_unit(tdf["transition"], tdf["transition_unit"])
     else:
         tdf["transition_unit"] = []

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -9,6 +9,7 @@ from landau.calculate import (
     cluster_T_c,
     cluster_T_c_mu,
     reduce,
+    _apply_series,
     _border_edges,
     _join_phase_unit,
     _split_phase_unit,
@@ -121,6 +122,61 @@ def test_cluster_T_c_mu_empty():
     labels = cluster_T_c_mu(dd, distance_threshold=0.5)
     assert len(labels) == 0
     assert labels.dtype.kind == "i"
+
+
+# --- _apply_series tests ---
+
+
+def test_apply_series_multi_group_returns_row_indexed_series():
+    df = pd.DataFrame({"g": ["a", "a", "b", "b"], "x": [1.0, 2.0, 10.0, 20.0]})
+    out = _apply_series(df.groupby("g", group_keys=False), lambda d: d["x"] * 2, "y")
+    assert isinstance(out, pd.Series)
+    pd.testing.assert_series_equal(
+        out.sort_index(),
+        pd.Series([2.0, 4.0, 20.0, 40.0], name="y"),
+        check_dtype=False,
+    )
+
+
+def test_apply_series_single_group_returns_row_indexed_series():
+    # The whole point of the helper: pandas 3 returns a one-row DataFrame
+    # from groupby.apply when only one group exists and the callable returns
+    # a Series.  The helper must yield a row-aligned Series regardless.
+    df = pd.DataFrame({"g": ["a", "a", "a"], "x": [1.0, 2.0, 3.0]})
+    out = _apply_series(df.groupby("g", group_keys=False), lambda d: d["x"] + 1, "y")
+    assert isinstance(out, pd.Series)
+    pd.testing.assert_series_equal(
+        out.sort_index(),
+        pd.Series([2.0, 3.0, 4.0], name="y"),
+        check_dtype=False,
+    )
+
+
+def test_apply_series_aligns_to_assignment():
+    # Round-trip via DataFrame column assignment is the primary call shape in
+    # calc_phase_diagram / get_transitions; the returned Series must align by
+    # the original row index.
+    df = pd.DataFrame({"g": ["a", "b", "a", "b"], "x": [1, 2, 3, 4]}, index=[10, 20, 30, 40])
+    df["y"] = _apply_series(df.groupby("g", group_keys=False), lambda d: d["x"] * 10, "y")
+    assert df.loc[10, "y"] == 10
+    assert df.loc[20, "y"] == 20
+    assert df.loc[30, "y"] == 30
+    assert df.loc[40, "y"] == 40
+
+
+def test_apply_series_callable_does_not_see_group_column():
+    # include_groups=False contract: the callable must not receive the group
+    # key column.  Asserting this here is what lets the call sites stay terse.
+    seen_columns = []
+
+    def fn(d):
+        seen_columns.append(list(d.columns))
+        return d["x"]
+
+    df = pd.DataFrame({"g": ["a", "a", "b"], "x": [1, 2, 3]})
+    _apply_series(df.groupby("g", group_keys=False), fn, "y")
+    for cols in seen_columns:
+        assert "g" not in cols
 
 
 # --- _join_phase_unit / _split_phase_unit tests ---


### PR DESCRIPTION
Sub-issue of #116. Picked off the backlog watchout: "a `pd.Series(..., index=pdf.index)` wrap would let the `else` branch go away" — generalised to the documented `to_frame(name)` workaround that the `cluster_phase` site in `plot.py` already uses.

## Changes

### `landau/calculate.py`

New private helper `_apply_series(grouped, fn, name)` that runs `fn` per group via `grouped.apply(..., include_groups=False)` and projects the result back to a row-aligned Series. Implementation: wrap `fn(g)` in `.to_frame(name)`, then index back out — the pandas user guide's "Flexible apply" path that combines consistently across pandas 2 and 3.

Two call sites collapse:
- `calc_phase_diagram` `f_excess`: was `groupby("T").apply(sub)` + `isinstance(fex, pd.DataFrame)` + `fex.stack().reset_index(level=0, drop=True)`.
- `get_transitions` `transition_unit`: was `groupby("transition").apply(...)` + the same `isinstance` post-process.

Both shrink to a one-line `_apply_series(...)` call.

### `tests/unit/test_calculate.py`

Four direct unit tests for `_apply_series`, orthogonal:
- `test_apply_series_multi_group_returns_row_indexed_series` — two groups, asserts row-aligned `Series` out.
- `test_apply_series_single_group_returns_row_indexed_series` — one group, the pandas 3 case the helper exists to fix; a `Series`-returning callable through plain `groupby.apply` collapses to a DataFrame here.
- `test_apply_series_aligns_to_assignment` — non-default row index; round-trips through DataFrame column assignment to pin the calling shape used in `calc_phase_diagram` / `get_transitions`.
- `test_apply_series_callable_does_not_see_group_column` — pins `include_groups=False` pass-through so the call sites stay terse.

The existing regression tests in `tests/regression/test_single_group_apply.py` continue to pin the higher-level invariants (`f_excess` populated, `transition_unit` integer-typed, etc.) and pass unchanged.

Full suite: 419 passed, 1 xfailed on pandas 3.0.3.

https://claude.ai/code/session_01Mbb9Kyv4JpFHRrsnzfuJow

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbb9Kyv4JpFHRrsnzfuJow)_