### PR TITLE
Add legend toggle to 2d phase-diagram plots

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -379,6 +379,7 @@ def _plot_phase_diagram(
     poly_method: Literal["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"] | poly.AbstractPolyMethod | None = None,
     variables: list[str] | None = None,
     inline_legend=True,
+    legend=True,
     ax=None,
 ):
     if variables is None:
@@ -400,10 +401,11 @@ def _plot_phase_diagram(
     ax.set_ylim(df_stable["T"].min(), df_stable["T"].max())
     # Inline labels need the final axis limits to place each label at the centre
     # of its polygon, so this runs after the limits above are set.
-    if inline_legend:
-        _add_inline_polygon_labels(ax, polys)
-    else:
-        ax.legend(ncols=2)
+    if legend:
+        if inline_legend:
+            _add_inline_polygon_labels(ax, polys)
+        else:
+            ax.legend(ncols=2)
     ax.set_ylabel("$T$ [K]")
 
 
@@ -421,6 +423,7 @@ def plot_phase_diagram(
     poly_method: Literal["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"] | poly.AbstractPolyMethod | None = None,
     variables: list[str] | None = None,
     inline_legend=True,
+    legend=True,
     ax=None,
 ):
     return _plot_phase_diagram(
@@ -433,6 +436,7 @@ def plot_phase_diagram(
         poly_method=poly_method,
         variables=variables,
         inline_legend=inline_legend,
+        legend=legend,
         ax=ax,
     )
 
@@ -461,6 +465,7 @@ def plot_mu_phase_diagram(
     color_override: dict[str, str] = {},
     poly_method: Literal["concave", "segments", "fasttsp", "tsp", "segment-fasttsp", "segment-tsp"] | poly.AbstractPolyMethod | None = None,
     inline_legend=True,
+    legend=True,
     ax=None,
 ):
     return _plot_phase_diagram(
@@ -471,6 +476,7 @@ def plot_mu_phase_diagram(
         poly_method=poly_method,
         variables=["mu", "T"],
         inline_legend=inline_legend,
+        legend=legend,
         ax=ax,
     )
 

--- a/tests/unit/plot/test_polygons.py
+++ b/tests/unit/plot/test_polygons.py
@@ -511,6 +511,18 @@ def test_plot_phase_diagram_inline_legend_false_draws_legend():
     plt.close(fig)
 
 
+def test_plot_phase_diagram_legend_false_draws_no_labels():
+    fig, ax = plt.subplots()
+    plot_phase_diagram(
+        _stable_df(), ax=ax, poly_method=Concave(drop_interior=False), legend=False
+    )
+    assert ax.get_legend() is None
+    assert len(ax.texts) == 0
+    # Polygons are still drawn, only the labelling is suppressed.
+    assert len(ax.patches) > 0
+    plt.close(fig)
+
+
 def _point(xy):
     from shapely import Point
 


### PR DESCRIPTION
`plot_phase_diagram` and `plot_mu_phase_diagram` always labelled phases — `inline_legend` only chose between in-place labels (`True`) and a legend box (`False`). There was no way to render the diagram without any labelling.

Add a `legend=True` flag to both functions (and the shared `_plot_phase_diagram`). `legend=False` suppresses both labelling paths so the bare polygons render; `inline_legend` still selects the style when `legend=True`. Default behaviour is unchanged.

Pinned by `test_plot_phase_diagram_legend_false_draws_no_labels` (no legend, no `ax.texts`, polygons still drawn).

https://claude.ai/code/session_016Km82G71WjbjtGaZxX9cfL

---
_Generated by [Claude Code](https://claude.ai/code/session_016Km82G71WjbjtGaZxX9cfL)_