### PR TITLE
Add PhaseDiagram object interface over the diagram frame

### DIFF
--- a/landau/__init__.py
+++ b/landau/__init__.py
@@ -20,6 +20,8 @@ from .interpolate import (
 
 from .plot import plot_phase_diagram, plot_excess_free_energy
 
+from .features import Locus, Domain, Coexistence, PhaseDiagram
+
 try:
     from ._version import __version__
 except ImportError:

--- a/landau/features.py
+++ b/landau/features.py
@@ -1,8 +1,29 @@
-"""Domain vocabulary for features of a phase diagram."""
+"""Object interface over the dataframe returned by :func:`landau.calculate.calc_phase_diagram`.
 
+The free functions in :mod:`landau.calculate` and :mod:`landau.plot` operate
+directly on the ``(T, mu, phase, c, phi, ...)`` dataframe.  This module wraps
+that same frame in a small read-only object layer so callers can ask for the
+*features* of a diagram by name instead of re-deriving them from the columns:
+
+* a :class:`Domain` is a connected single-phase region (one phase, ``k = 1``),
+* a :class:`Coexistence` is a region where ``k >= 2`` phases coexist; its
+  :attr:`~Coexistence.codimension` is ``k - 1``, so a two-phase boundary line
+  and a triple point are the same kind of object at different ``k``.
+
+The frame stays the source of truth and is always reachable via
+:attr:`PhaseDiagram.frame`; the objects only parse it.
+"""
+
+from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import TYPE_CHECKING, Mapping
 
-__all__ = ["Locus"]
+import pandas as pd
+
+if TYPE_CHECKING:
+    from .phases import Phase
+
+__all__ = ["Locus", "Domain", "Coexistence", "PhaseDiagram"]
 
 
 class Locus(StrEnum):
@@ -28,3 +49,176 @@ class Locus(StrEnum):
     INTERIOR = "interior"
     BOUNDARY = "boundary"
     TRIPLE = "triple"
+
+
+@dataclass(frozen=True, eq=False)
+class Domain:
+    """A connected single-phase region of a phase diagram (``k = 1``).
+
+    One phase is stable across a single connected window of the sampled
+    variables.  A phase that is stable in two disjoint windows (a solid
+    solution interrupted by an intermetallic, say) yields two separate
+    ``Domain`` objects.
+
+    Attributes
+    ----------
+    phase : str or Phase
+        The stable phase.  A :class:`~landau.phases.Phase` when
+        :meth:`PhaseDiagram.from_frame` was given a phase mapping, otherwise
+        the phase name.
+    frame : pandas.DataFrame
+        The sub-frame of interior sample rows that make up this region.
+    """
+
+    phase: "str | Phase"
+    frame: pd.DataFrame = field(repr=False)
+
+    def __repr__(self) -> str:
+        return f"Domain(phase={self.phase!r}, points={len(self.frame)})"
+
+
+@dataclass(frozen=True, eq=False)
+class Coexistence:
+    """A region where ``k >= 2`` phases coexist.
+
+    Covers what are geometrically a two-phase boundary line (``k = 2``) and a
+    triple point (``k = 3``) as a single kind of object, distinguished only by
+    :attr:`codimension`.  A miscibility gap is the ``k = 2`` case where both
+    coexisting phases are the same phase (two composition branches), see
+    :attr:`is_miscibility_gap`.
+
+    Attributes
+    ----------
+    phases : tuple of (str or Phase)
+        The coexisting phases as a multiset of length ``k``: two equal entries
+        for a miscibility gap, ``k`` distinct entries otherwise.
+        :class:`~landau.phases.Phase` instances when
+        :meth:`PhaseDiagram.from_frame` was given a phase mapping, otherwise
+        names.
+    frame : pandas.DataFrame
+        The refined boundary rows that trace this coexistence (one
+        ``boundary_id`` group).
+    """
+
+    phases: tuple
+    frame: pd.DataFrame = field(repr=False)
+
+    @property
+    def codimension(self) -> int:
+        """``k - 1``: 1 for a coexistence line, 2 for a triple point."""
+        return len(self.phases) - 1
+
+    @property
+    def is_miscibility_gap(self) -> bool:
+        """True when the two coexisting phases are the same phase."""
+        return len(self.phases) == 2 and self.phases[0] == self.phases[1]
+
+    def __repr__(self) -> str:
+        return f"Coexistence(phases={tuple(self.phases)!r}, points={len(self.frame)})"
+
+
+_REQUIRED_COLUMNS = ("phase", "stable", "locus")
+
+
+@dataclass(frozen=True, eq=False)
+class PhaseDiagram:
+    """Object view over a :func:`~landau.calculate.calc_phase_diagram` frame.
+
+    Build with :meth:`from_frame`.  The wrapped :attr:`frame` stays the source
+    of truth; :attr:`domains` and :attr:`coexistences` only parse it.
+    """
+
+    frame: pd.DataFrame = field(repr=False)
+    phase_map: "Mapping[str, Phase] | None" = None
+
+    @classmethod
+    def from_frame(
+        cls, frame: pd.DataFrame, phases: "Mapping[str, Phase] | object | None" = None
+    ) -> "PhaseDiagram":
+        """Wrap a phase-diagram dataframe.
+
+        Args:
+            frame: a dataframe as returned by
+                :func:`landau.calculate.calc_phase_diagram` (needs the
+                ``phase``, ``stable`` and ``locus`` columns).
+            phases: optional mapping of name to :class:`~landau.phases.Phase`,
+                or any iterable of phases.  When given, :attr:`Domain.phase`
+                and :attr:`Coexistence.phases` are resolved to the phase
+                objects instead of bare names.
+        """
+        missing = [c for c in _REQUIRED_COLUMNS if c not in frame.columns]
+        if missing:
+            raise ValueError(
+                f"frame is missing required column(s) {missing}; pass a frame from "
+                "calc_phase_diagram"
+            )
+        if phases is not None and not isinstance(phases, Mapping):
+            phases = {p.name: p for p in phases}
+        return cls(frame=frame, phase_map=phases)
+
+    @property
+    def phases(self):
+        """The phases of the diagram.
+
+        The ``{name: Phase}`` mapping if one was passed to :meth:`from_frame`,
+        otherwise the set of phase names present in :attr:`frame`.
+        """
+        if self.phase_map is not None:
+            return self.phase_map
+        return set(self.frame["phase"].unique())
+
+    def _resolve(self, name: str):
+        if self.phase_map is not None:
+            return self.phase_map[name]
+        return name
+
+    def domains(self, distance_threshold: float = 0.5) -> list[Domain]:
+        """The single-phase regions, one :class:`Domain` per connected window.
+
+        Args:
+            distance_threshold: passed to
+                :func:`landau.plot.cluster_phase`; the agglomerative-clustering
+                cut-off in normalised ``(T, c)`` space that decides which
+                interior samples belong to the same connected region.  Lower it
+                when two stable windows of one phase are wrongly merged.
+        """
+        from .plot import cluster_phase
+
+        interior = self.frame.query("stable and locus == 'interior'").copy()
+        if interior.empty:
+            return []
+        interior = cluster_phase(interior, distance_threshold=distance_threshold)
+        # cluster_phase marks points it could not assign with phase_unit == -1
+        # (mirrors get_polygons, which drops them).
+        interior = interior[interior["phase_unit"] >= 0]
+        helper = ["phase_unit", "phase_id"]
+        return [
+            Domain(phase=self._resolve(g["phase"].iloc[0]), frame=g.drop(columns=helper))
+            for _, g in interior.groupby("phase_id", sort=False)
+        ]
+
+    @property
+    def coexistences(self) -> list[Coexistence]:
+        """The coexistence features (``k >= 2``), one per ``boundary_id`` line.
+
+        ``boundary_id`` only counts up from zero within a single refiner, so
+        the ``(refined, boundary_id)`` pair is what identifies one coexistence
+        line across the whole frame.
+        """
+        boundary = self.frame[self.frame["locus"] != Locus.INTERIOR]
+        if boundary.empty or "boundary_id" not in boundary.columns:
+            return []
+        out = []
+        for _, g in boundary.groupby(["refined", "boundary_id"], sort=False):
+            names = tuple(sorted(g["phase"].unique()))
+            k = 3 if (g["locus"] == Locus.TRIPLE).any() else 2
+            if len(names) < k:
+                # a miscibility gap is one phase splitting into k branches
+                names = names * k
+            phases = tuple(self._resolve(n) for n in names)
+            out.append(Coexistence(phases=phases, frame=g))
+        return out
+
+    def __repr__(self) -> str:
+        phases = self.phase_map if self.phase_map is not None else self.phases
+        return f"PhaseDiagram(phases={len(phases)}, rows={len(self.frame)})"

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,176 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from landau.calculate import calc_phase_diagram
+from landau.features import Coexistence, Domain, Locus, PhaseDiagram
+from landau.phases import IdealSolution, LinePhase
+
+
+@pytest.fixture
+def regular_frame(three_phase_regular_solution):
+    """A refined c-T frame for a three-LinePhase regular solution (A, B, C + sol)."""
+    sol = three_phase_regular_solution
+    phases = [*sol.phases, sol]
+    df = calc_phase_diagram(phases, np.linspace(200, 1100, 10), 20, refine=True)
+    return df, {p.name: p for p in phases}
+
+
+def _names(coex):
+    """Coexistence phase tuple as plain names regardless of how it was built."""
+    return tuple(getattr(p, "name", p) for p in coex.phases)
+
+
+def test_from_frame_requires_columns():
+    with pytest.raises(ValueError, match="missing required column"):
+        PhaseDiagram.from_frame(pd.DataFrame({"phase": ["A"]}))
+
+
+def test_frame_is_escape_hatch(regular_frame):
+    df, _ = regular_frame
+    pd_ = PhaseDiagram.from_frame(df)
+    assert pd_.frame is df
+
+
+def test_phases_without_mapping_are_names(regular_frame):
+    df, _ = regular_frame
+    pd_ = PhaseDiagram.from_frame(df)
+    # only stable phases appear in the frame; C is covered by the solution
+    assert pd_.phases == set(df["phase"].unique())
+    assert pd_.phases <= {"A", "B", "C", "sol"}
+
+
+def test_phases_with_mapping_is_the_mapping(regular_frame):
+    df, mapping = regular_frame
+    pd_ = PhaseDiagram.from_frame(df, mapping)
+    assert pd_.phases is mapping
+
+
+def test_domains_are_single_connected_phase_regions(regular_frame):
+    df, _ = regular_frame
+    pd_ = PhaseDiagram.from_frame(df)
+    domains = pd_.domains()
+    assert domains, "expected at least one domain"
+    assert all(isinstance(d, Domain) for d in domains)
+    for d in domains:
+        # a domain is exactly one phase, drawn from interior stable samples
+        assert set(d.frame["phase"].unique()) == {d.phase}
+        assert (d.frame["locus"] == Locus.INTERIOR).all()
+        assert d.frame["stable"].all()
+        assert len(d.frame) > 0
+    # the three terminal/solution phases that are stable each own a domain
+    assert {d.phase for d in domains} == set(df.query("stable")["phase"].unique())
+
+
+def test_domains_resolve_to_phase_objects_with_mapping(regular_frame):
+    df, mapping = regular_frame
+    pd_ = PhaseDiagram.from_frame(df, mapping)
+    for d in pd_.domains():
+        assert d.phase is mapping[d.phase.name]
+
+
+def test_disconnected_phase_yields_multiple_domains():
+    """A solution stable in two disjoint windows must split into two domains."""
+    l1 = LinePhase("A", 0, 0, 0)
+    l2 = LinePhase("B", 1, 0.1, 0)
+    sol = IdealSolution("sol", l1, l2)
+    df = calc_phase_diagram([l1, l2, sol], np.linspace(100, 1200, 12), 20, refine=True)
+    pd_ = PhaseDiagram.from_frame(df)
+    sol_domains = [d for d in pd_.domains() if d.phase == "sol"]
+    assert len(sol_domains) == 2
+    # the split is geometric: the two windows occupy disjoint concentration ranges
+    lo, hi = sorted(sol_domains, key=lambda d: d.frame["c"].mean())
+    assert lo.frame["c"].max() < hi.frame["c"].min()
+
+
+def test_coexistence_classification():
+    """codimension and miscibility-gap classification off the phase multiset."""
+    empty = pd.DataFrame({"phase": [], "locus": []})
+    line = Coexistence(("A", "sol"), empty)
+    gap = Coexistence(("sol", "sol"), empty)
+    triple = Coexistence(("A", "B", "C"), empty)
+
+    assert line.codimension == 1 and not line.is_miscibility_gap
+    assert gap.codimension == 1 and gap.is_miscibility_gap
+    assert triple.codimension == 2 and not triple.is_miscibility_gap
+
+
+def _coex_row(phase, locus, boundary_id, refined, T, c):
+    return {
+        "phase": phase, "stable": True, "locus": locus, "border": True,
+        "boundary_id": boundary_id, "refined": refined, "T": T, "mu": 0.1, "c": c,
+    }
+
+
+def test_miscibility_gap_parsed_as_doubled_phase():
+    """One phase splitting into two branches parses to a (X, X) k=2 coexistence."""
+    rows = [
+        _coex_row("X", Locus.BOUNDARY, 0, "miscibility-gap", T, c)
+        for T in (300.0, 350.0, 400.0)
+        for c in (0.2, 0.8)
+    ]
+    pd_ = PhaseDiagram.from_frame(pd.DataFrame(rows))
+    (gap,) = pd_.coexistences
+    assert _names(gap) == ("X", "X")
+    assert gap.codimension == 1
+    assert gap.is_miscibility_gap
+
+
+def test_triple_point_parsed_as_three_phases():
+    rows = [
+        _coex_row(ph, Locus.TRIPLE, 0, "delaunay-triple", T, c)
+        for T in (300.0, 400.0)
+        for ph, c in (("A", 0.1), ("B", 0.5), ("C", 0.9))
+    ]
+    pd_ = PhaseDiagram.from_frame(pd.DataFrame(rows))
+    (triple,) = pd_.coexistences
+    assert _names(triple) == ("A", "B", "C")
+    assert triple.codimension == 2
+    assert not triple.is_miscibility_gap
+
+
+def test_boundary_id_collision_across_refiners_kept_separate():
+    """boundary_id restarts per refiner, so (refined, boundary_id) keys a line."""
+    rows = [
+        _coex_row("A", Locus.BOUNDARY, 0, "clausius-clapeyron", 300.0, 0.1),
+        _coex_row("sol", Locus.BOUNDARY, 0, "clausius-clapeyron", 300.0, 0.4),
+        _coex_row("X", Locus.BOUNDARY, 0, "miscibility-gap", 300.0, 0.2),
+        _coex_row("X", Locus.BOUNDARY, 0, "miscibility-gap", 300.0, 0.8),
+    ]
+    pd_ = PhaseDiagram.from_frame(pd.DataFrame(rows))
+    cox = pd_.coexistences
+    assert len(cox) == 2  # not merged into one despite the shared boundary_id
+    assert {_names(c) for c in cox} == {("A", "sol"), ("X", "X")}
+
+
+def test_coexistences_parse_boundary_lines(regular_frame):
+    df, _ = regular_frame
+    pd_ = PhaseDiagram.from_frame(df)
+    cox = pd_.coexistences
+    assert cox, "expected refined coexistence lines"
+    assert all(isinstance(c, Coexistence) for c in cox)
+    # the regular solution coexists with each terminal line phase
+    by_names = {_names(c): c for c in cox}
+    assert ("A", "sol") in by_names
+    assert ("B", "sol") in by_names
+    for c in cox:
+        assert c.codimension == 1
+        assert (c.frame["locus"] != Locus.INTERIOR).all()
+        assert len(c.frame) > 0
+
+
+def test_coexistence_phases_resolve_with_mapping(regular_frame):
+    df, mapping = regular_frame
+    pd_ = PhaseDiagram.from_frame(df, mapping)
+    line = next(c for c in pd_.coexistences if _names(c) == ("A", "sol"))
+    assert line.phases == (mapping["A"], mapping["sol"])
+
+
+def test_no_coexistences_without_refinement(three_phase_regular_solution):
+    sol = three_phase_regular_solution
+    phases = [*sol.phases, sol]
+    df = calc_phase_diagram(phases, np.linspace(200, 1100, 6), 15, refine=False)
+    pd_ = PhaseDiagram.from_frame(df)
+    assert pd_.coexistences == []
+    # unrefined diagram still has single-phase domains
+    assert pd_.domains()


### PR DESCRIPTION
Wraps the `calc_phase_diagram` dataframe in a read-only object layer so callers can ask for a diagram's features by name instead of re-deriving them from columns. Parse-only: the frame stays the source of truth and is unchanged; `calc_phase_diagram`'s return type is untouched.

Two feature types, organised by the number of coexisting phases `k` rather than by geometry, so the vocabulary extends to more variables later:

- `Domain` (`k = 1`) — a connected single-phase region. One per connected window, so a phase stable in two disjoint ranges yields two `Domain`s. Built by reusing `cluster_phase` on the interior stable rows (`stable & locus == 'interior'`), which excludes the degenerate refined boundary rows.
- `Coexistence` (`k >= 2`) — a region where `k` phases coexist, one per `(refined, boundary_id)` group. `codimension = k - 1`, so a two-phase line and a triple point are the same object at different `k`. A miscibility gap parses as a doubled multiset `(X, X)` and reports `is_miscibility_gap`.

API:

```python
pd = PhaseDiagram.from_frame(df, phases=None)
pd.frame                      # escape hatch — the wrapped frame
pd.phases                     # {name: Phase} if a mapping was passed, else set of names
pd.domains(distance_threshold=0.5)   # [Domain]      (heuristic visible at call site)
pd.coexistences               # [Coexistence]
```

`distance_threshold` lives on `domains()` rather than `from_frame` because the connected-region split is the only heuristic part — coexistences split deterministically by `boundary_id`. An optional `phases` mapping resolves `Domain.phase` / `Coexistence.phases` to `Phase` objects instead of names.

Implementation notes:
- `boundary_id` restarts at zero within each refiner (`Refiner.run`), so it collides across refiners; coexistences key on `(refined, boundary_id)`. Pinned by a test.
- `k` is read from the `locus` column (`triple` → 3, else 2), which classifies miscibility gaps (one phase name, `k = 2`) correctly without counting unique names.
- `features.py` lazy-imports `cluster_phase` inside `domains()` to avoid the `features → plot → calculate → features` cycle.

Tests in `tests/unit/test_features.py` (14): classification on hand-built objects and synthetic frames (gap, triple point, the `boundary_id`-collision keying — none of which the live refiners reliably produce at a given sampling, triple points per #32), plus integration assertions against a refined regular-solution frame (single-phase domains, the disconnected-solution split into two domains, the `A`/`B`–`sol` coexistence lines, phase-object resolution).

Follow-ups deliberately deferred: `.dimension` / `n_vars` (always `2 - codim` today, no third variable yet), and any polygon/plot logic on the objects.

https://claude.ai/code/session_011LVqyY9p8Q2GhRkoneyKRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011LVqyY9p8Q2GhRkoneyKRJ)_