### PR TITLE
refactor(refine): move DelaunayTripleRefiner dedup state out of solve() into run()

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -439,12 +439,15 @@ class DelaunayTripleRefiner(Refiner):
     For every Delaunay simplex containing three distinct phases, locate the
     triple point by minimizing the sum of pairwise potential differences,
     starting from the simplex centroid.
+
+    ``solve`` is a pure function of its candidate: it returns a refined point
+    for every three-phase simplex without tracking cross-call state.
+    ``run`` deduplicates across candidates using each simplex's own extent as
+    the tolerance, so adjacent simplices that converge to the same triple point
+    emit exactly one result.
     """
 
     label = "delaunay-triple"
-
-    def __init__(self):
-        self._found: list[TMuPoint] = []
 
     def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
         for simplex, n in _delaunay_simplices(df):
@@ -456,8 +459,6 @@ class DelaunayTripleRefiner(Refiner):
         T0, mu0 = tr[["T", "mu"]].mean()
         names = tuple(tr.phase.unique())
         p1, p2, p3 = (phases[n] for n in names)
-        T_tol = float(tr["T"].max() - tr["T"].min())
-        mu_tol = float(tr["mu"].max() - tr["mu"].min())
 
         def triplemin(x):
             T, mu = x
@@ -467,11 +468,34 @@ class DelaunayTripleRefiner(Refiner):
             return abs(phi1 - phi2) + abs(phi2 - phi3) + abs(phi3 - phi1)
 
         T, mu = so.fmin(triplemin, (T0, mu0), disp=False)
-        if any(abs(T - fT) <= T_tol and abs(mu - fmu) <= mu_tol
-               for fT, fmu in self._found):
-            return []
-        self._found.append((T, mu))
         return [RefinedPoint(T=T, mu=mu, phases=names)]
+
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        """propose → solve → deduplicate by simplex extents → dataframe."""
+        rows: list[dict] = []
+        found: list[TMuPoint] = []
+        boundary_id = 0
+        for cand in self.propose(df):
+            tr = cand.simplex
+            T_tol = float(tr["T"].max() - tr["T"].min())
+            mu_tol = float(tr["mu"].max() - tr["mu"].min())
+            pts = [pt for pt in self.solve(cand, phases)
+                   if pt.T >= 0
+                   and not _dominated(pt, phases)
+                   and not any(abs(pt.T - fT) <= T_tol and abs(pt.mu - fmu) <= mu_tol
+                               for fT, fmu in found)]
+            for pt in pts:
+                found.append((pt.T, pt.mu))
+                rows.extend(replace(pt, boundary_id=boundary_id).to_rows(phases))
+            if pts:
+                boundary_id += 1
+        out = pd.DataFrame(rows)
+        if out.empty:
+            return out
+        out["stable"] = True
+        out["border"] = True
+        out["refined"] = self.label
+        return out
 
 
 # -- Clausius-Clapeyron tracers ----------------------------------------------

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -464,6 +464,32 @@ def _coarse_df(phases, Ts, mus):
     return pd.DataFrame(rows)
 
 
+def test_delaunay_triple_refiner_solve_is_pure():
+    """solve() returns a point for every candidate; dedup is run()'s job.
+
+    Before #210, solve() maintained _found state and returned [] on the second
+    call with an adjacent simplex, making a repeated call silently a no-op.
+    Now solve() is stateless: every three-phase candidate produces exactly one
+    RefinedPoint regardless of call order.
+    """
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 6)
+    mus = np.linspace(-0.05, 0.55, 7)
+    df = _coarse_df(phases, Ts, mus)
+
+    refiner = DelaunayTripleRefiner()
+    cands = list(refiner.propose(df))
+    assert len(cands) > 1, "test requires multiple three-phase simplices"
+
+    for cand in cands:
+        result = refiner.solve(cand, phases)
+        assert len(result) == 1, "solve() must return one point per candidate"
+
+    # run() still deduplicates: one triple point → 3 rows (one per phase).
+    out = refiner.run(df, phases)
+    assert len(out) == 3
+
+
 def test_delaunay_triple_refiner_deduplicates():
     """Triple refiner emits each triple point exactly once even when
     multiple three-phase Delaunay simplices independently detect it."""


### PR DESCRIPTION
Closes #210.

`DelaunayTripleRefiner.__init__` carried a `_found: list[TMuPoint]` that
`solve()` mutated on every call to skip already-located triple points.
Every other refiner keeps `solve()` a pure function of its candidate;
the accumulated state made a repeated `solve()` call silently return `[]`
and tripped up any subclass that only overrides `solve()`.

`solve()` now returns `[RefinedPoint(...)]` for every three-phase
candidate without checking or updating any cross-call state. A thin
`run()` override holds the `found` list and the dedup logic: after the
standard dominated/negative-T filter, each candidate's simplex extents
(`T_tol`, `mu_tol`) gate whether the converged point is close enough to
a previously emitted triple point to be dropped.

New test `test_delaunay_triple_refiner_solve_is_pure` in
`tests/unit/test_refine.py` (28 → 29 tests) verifies that `solve()`
returns one point per candidate regardless of call order, and that
`run()` still deduplicates adjacent simplices down to one triple point.
The existing `test_delaunay_triple_refiner_deduplicates` and
`test_boundary_id_delaunay_triple_rows_share_id` continue to pin the
end-to-end invariants. 419 unit + regression tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8U94gHXR3vvNZzorPMDEy)_