### PR TITLE
ci: persist Hypothesis example database as GitHub artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,16 @@ jobs:
         pip install -e .[test,constraints,fast-tsp,python-tsp]
     - name: run tests
       shell: bash -l {0}
+      env:
+        HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-py${{ matrix.python-version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pytest
+    - name: Upload Hypothesis example database
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hypothesis-example-db-py${{ matrix.python-version }}
+        path: .hypothesis/examples
+        if-no-files-found: ignore
+        retention-days: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 ase = ["ase>=3.20.0"]
 test = [
     "pytest>=9,<10",
-    "hypothesis>=6.20,<7",
+    "hypothesis>=6.71,<7",
     "ase>=3.20.0",
 ]
 docs = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,30 @@
+import os
+
 import pytest
+from hypothesis import settings
+from hypothesis.database import (
+    DirectoryBasedExampleDatabase,
+    GitHubArtifactDatabase,
+    MultiplexedDatabase,
+    ReadOnlyDatabase,
+)
+
 from landau.phases import LinePhase, IdealSolution, RegularSolution
+
+
+if os.environ.get("GITHUB_ACTIONS") == "true":
+    _local = DirectoryBasedExampleDatabase(".hypothesis/examples")
+    _shared = ReadOnlyDatabase(
+        GitHubArtifactDatabase(
+            "eisenforschung",
+            "landau",
+            artifact_name=os.environ.get(
+                "HYPOTHESIS_ARTIFACT_NAME", "hypothesis-example-db"
+            ),
+        )
+    )
+    settings.register_profile("ci", database=MultiplexedDatabase(_local, _shared))
+    settings.load_profile("ci")
 
 
 @pytest.fixture


### PR DESCRIPTION
Port of pmrv/fleche#668.

`tests/conftest.py` registers a `ci` Hypothesis profile under `GITHUB_ACTIONS=true` that multiplexes a local `DirectoryBasedExampleDatabase(".hypothesis/examples")` with a read-only `GitHubArtifactDatabase("eisenforschung", "landau", artifact_name=...)`. The artifact name defaults to `hypothesis-example-db` and is overridden per matrix job via `HYPOTHESIS_ARTIFACT_NAME`.

`.github/workflows/tests.yml` sets `HYPOTHESIS_ARTIFACT_NAME=hypothesis-example-db-py${{ matrix.python-version }}` and `GITHUB_TOKEN` on the test step, then uploads `.hypothesis/examples` as that artifact (`if-no-files-found: ignore`, 90 day retention, `if: always()`).

No source / test changes outside CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkoH55C7xe3TBkqjFQVM5m)_