### PR TITLE
fix(phases): silence scatter UserWarning in check_interpolation

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -209,7 +209,7 @@ class TemperatureDependentLinePhase(AbstractLinePhase):
         (l,) = plt.plot(Ts, self.line_free_energy(Ts), label=self.name)
         # try to plot about 100 points
         n = max(int(len(self.temperatures) // 100), 1)
-        plt.scatter(self.temperatures[::n], self.free_energies[::n], c=l.get_color())
+        plt.scatter(self.temperatures[::n], self.free_energies[::n], color=l.get_color())
 
 
 @deprecate("use TemperatureDependentLinePhase instead", version="2.0")


### PR DESCRIPTION
`TemperatureDependentLinePhase.check_interpolation` passes the line colour to `plt.scatter` via the `c=` keyword:

```python
plt.scatter(self.temperatures[::n], self.free_energies[::n], c=l.get_color())
```

`Line2D.get_color()` returns an RGBA sequence. matplotlib's `c` parameter treats a single RGB(A) sequence ambiguously (value-mapping vs. single colour) and emits a `UserWarning` on every call:

```
UserWarning: *c* argument looks like a single numeric RGB or RGBA sequence,
which should be avoided as value-mapping will have precedence in case its
length matches with *x* & *y*.  Please use the *color* keyword-argument ...
```

Switching to the unambiguous `color=` keyword, as the warning recommends, removes it.

Verified with `python -W error::UserWarning`: the original `c=` call raises, the `color=` call completes cleanly. The other `scatter(..., c='k')` sites in the codebase pass an unambiguous single-character colour string and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcMau4aunL7zxLCKQy8aHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcMau4aunL7zxLCKQy8aHU)_