### PR TITLE
Add plot_error flag to interpolation check methods

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -204,12 +204,25 @@ class TemperatureDependentLinePhase(AbstractLinePhase):
     def line_free_energy(self, T):
         return self._interpolation(T)
 
-    def check_interpolation(self, Tl=0.9, Tu=1.1, samples=50):
-        Ts = np.linspace(np.min(self.temperatures) * Tl, np.max(self.temperatures) * Tu, samples)
-        (l,) = plt.plot(Ts, self.line_free_energy(Ts), label=self.name)
+    def check_interpolation(self, Tl=0.9, Tu=1.1, samples=50, plot_error=False):
+        """Plot the temperature interpolation against its samples to visually assess fit quality.
+
+        Args:
+            Tl (float): lower edge of the plotted range as a fraction of the minimum sampled temperature
+            Tu (float): upper edge of the plotted range as a fraction of the maximum sampled temperature
+            samples (int): number of points along the interpolated curve
+            plot_error (bool): if True, plot only the interpolation error at the samples instead of the free energies
+        """
         # try to plot about 100 points
         n = max(int(len(self.temperatures) // 100), 1)
-        plt.scatter(self.temperatures[::n], self.free_energies[::n], color=l.get_color())
+        ts = self.temperatures[::n]
+        fs = self.free_energies[::n]
+        if plot_error:
+            plt.scatter(ts, self.line_free_energy(ts) - fs, label=self.name)
+            return
+        Ts = np.linspace(np.min(self.temperatures) * Tl, np.max(self.temperatures) * Tu, samples)
+        (l,) = plt.plot(Ts, self.line_free_energy(Ts), label=self.name)
+        plt.scatter(ts, fs, color=l.get_color())
 
 
 @deprecate("use TemperatureDependentLinePhase instead", version="2.0")
@@ -403,6 +416,7 @@ class RegularSolution(Phase):
             T=1000,
             samples=50,
             plot_excess=False,
+            plot_error=False,
     ):
         """Plot free energies of an interpolating phase and its underlying line
         phases to visually assess fit quality.
@@ -411,8 +425,9 @@ class RegularSolution(Phase):
             T (float): at which temperature to check interpolation
             samples (int): number of sampling points for plot
             plot_excess (bool): if True, subtract free energy at concentration range endpoints for legibility
+            plot_error (bool): if True, plot only the interpolation error at the samples instead of the free energies
             """
-        check_concentration_interpolation(self, self.phases, T, samples, plot_excess, (0, 1))
+        check_concentration_interpolation(self, self.phases, T, samples, plot_excess, (0, 1), plot_error=plot_error)
 
 
 from numbers import Real
@@ -521,6 +536,7 @@ class InterpolatingPhase(Phase):
             T=1000,
             samples=50,
             plot_excess=False,
+            plot_error=False,
     ):
         """Plot free energies of an interpolating phase and its underlying line
         phases to visually assess fit quality.
@@ -529,13 +545,16 @@ class InterpolatingPhase(Phase):
             T (float): at which temperature to check interpolation
             samples (int): number of sampling points for plot
             plot_excess (bool): if True, subtract free energy at concentration range endpoints for legibility
+            plot_error (bool): if True, plot only the interpolation error at the samples instead of the free energies
             """
         cs = [p.line_concentration for p in self.phases]
         concentration_range = (
                 max(0, min(cs) - self.maximum_extrapolation),
                 min(1, max(cs) + self.maximum_extrapolation)
         )
-        check_concentration_interpolation(self, self.phases, T, samples, plot_excess, concentration_range)
+        check_concentration_interpolation(
+            self, self.phases, T, samples, plot_excess, concentration_range, plot_error=plot_error
+        )
 
 @dataclass(frozen=True, eq=True)
 class SlowInterpolatingPhase(Phase):
@@ -619,6 +638,7 @@ class SlowInterpolatingPhase(Phase):
             T=1000,
             samples=50,
             plot_excess=False,
+            plot_error=False,
     ):
         """Plot free energies of an interpolating phase and its underlying line
         phases to visually assess fit quality.
@@ -627,8 +647,11 @@ class SlowInterpolatingPhase(Phase):
             T (float): at which temperature to check interpolation
             samples (int): number of sampling points for plot
             plot_excess (bool): if True, subtract free energy at concentration range endpoints for legibility
+            plot_error (bool): if True, plot only the interpolation error at the samples instead of the free energies
             concentration_range (tuple of float): min/max concentration range"""
-        check_concentration_interpolation(self, self.phases, T, samples, plot_excess, self.concentration_range)
+        check_concentration_interpolation(
+            self, self.phases, T, samples, plot_excess, self.concentration_range, plot_error=plot_error
+        )
 
 def check_concentration_interpolation(
         phase: SlowInterpolatingPhase | InterpolatingPhase | RegularSolution,
@@ -636,7 +659,8 @@ def check_concentration_interpolation(
         T: float,
         samples: int,
         plot_excess: bool,
-        concentration_range: tuple[float, float]
+        concentration_range: tuple[float, float],
+        plot_error: bool = False,
 ):
     """Plot free energies of an interpolating phase and its underlying line
     phases to visually assess fit quality.
@@ -648,7 +672,21 @@ def check_concentration_interpolation(
         T (float): at which temperature to check interpolation
         samples (int): number of sampling points for plot
         plot_excess (bool): if True, subtract free energy at concentration range endpoints for legibility
-        concentration_range (tuple of float): min/max concentration range"""
+        concentration_range (tuple of float): min/max concentration range
+        plot_error (bool): if True, plot only the interpolation error at the samples instead of the free energies"""
+
+    if plot_error:
+        cs, err = [], []
+        for p in phases:
+            cline = p.line_concentration
+            line_free_energy = p.line_free_energy(T)
+            # line_free_energy doesn't automatically respect add_entropy, unlike free_energy
+            if phase.add_entropy:
+                line_free_energy -= T * S(cline)
+            cs.append(cline)
+            err.append(phase.free_energy(T, cline) - line_free_energy)
+        plt.scatter(cs, err, label=phase.name)
+        return
 
     cmin, cmax = concentration_range
     x = np.linspace(cmin, cmax, samples)

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -1,3 +1,7 @@
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from hypothesis import given, settings
@@ -5,7 +9,7 @@ from hypothesis import strategies as st
 from numpy.testing import assert_allclose
 from scipy.constants import Boltzmann, eV
 
-from landau.interpolate import SGTE
+from landau.interpolate import PolyFit, SGTE
 from landau.interpolate.basic import G_calphad
 from landau.phases import IdealSolution, InterpolatingPhase, LinePhase, RegularSolution, SlowInterpolatingPhase, TemperatureDependentLinePhase
 from landau.phases.pointdefects import (
@@ -15,7 +19,7 @@ from landau.phases.pointdefects import (
     PointDefectSublattice,
     PointDefectedPhase,
 )
-from landau.phases import _scalarize
+from landau.phases import S, _scalarize
 
 kB = Boltzmann / eV
 
@@ -836,3 +840,115 @@ def test_new_pointdefect_classes_not_added_to_landau_phases(name):
     import landau.phases as phases
 
     assert not hasattr(phases, name)
+
+
+# --- check_interpolation / check_concentration_interpolation plot_error ---
+
+# residuals are recomputed with the same deterministic public methods the plot
+# uses, so the plotted markers must match to numerical noise
+ERR_ATOL = 1e-9
+
+
+def _under_parametrised_interpolating_phase(add_entropy=False):
+    """An InterpolatingPhase whose fit cannot pass through every sample, so the
+    per-sample residuals are genuinely nonzero at the interior points."""
+    cs = [0.0, 0.25, 0.5, 0.75, 1.0]
+    fe = [0.0, -0.3, -0.1, -0.35, 0.05]
+    lps = [LinePhase(n, c, f) for n, c, f in zip("ABCDE", cs, fe)]
+    return InterpolatingPhase(name="sol", phases=lps, num_coeffs=3, add_entropy=add_entropy), lps
+
+
+def test_check_interpolation_plot_error_plots_only_residuals():
+    """plot_error=True draws interp(T) - sample at each sample and nothing else."""
+    Ts = np.linspace(300, 1200, 40)
+    Fs = -1e-3 * Ts**2 + 2.0  # nonlinear, so a 2-parameter (linear) fit leaves real residuals
+    phase = TemperatureDependentLinePhase("L", 0.0, Ts, Fs, interpolator=PolyFit(2))
+
+    fig, ax = plt.subplots()
+    try:
+        phase.check_interpolation(plot_error=True)
+        assert len(ax.lines) == 0  # the free-energy curve is not drawn
+        assert len(ax.collections) == 1  # only the error scatter
+        n = max(int(len(Ts) // 100), 1)
+        ts, fs = Ts[::n], Fs[::n]
+        expected = phase.line_free_energy(ts) - fs
+        # non-degenerate: a constant or all-zero residual plot would fail these
+        assert np.abs(expected).max() > 1.0
+        assert not np.allclose(expected, expected[0])
+        off = np.asarray(ax.collections[0].get_offsets())
+        assert_allclose(off[:, 0], ts)
+        assert_allclose(off[:, 1], expected, atol=ERR_ATOL)
+    finally:
+        plt.close(fig)
+
+
+def test_check_interpolation_default_plots_curve_and_samples():
+    """Without plot_error the curve and its samples are drawn (the flag is opt-in)."""
+    Ts = np.linspace(300, 1200, 20)
+    phase = TemperatureDependentLinePhase("L", 0.0, Ts, np.sqrt(Ts), interpolator=PolyFit(2))
+    fig, ax = plt.subplots()
+    try:
+        phase.check_interpolation()
+        assert len(ax.lines) == 1  # the interpolation curve
+        assert len(ax.collections) == 1  # the samples
+    finally:
+        plt.close(fig)
+
+
+def test_check_concentration_interpolation_plot_error_plots_only_residuals():
+    """plot_error=True draws free_energy(c) - sample at each line phase and nothing else."""
+    phase, lps = _under_parametrised_interpolating_phase()
+    fig, ax = plt.subplots()
+    try:
+        phase.check_concentration_interpolation(T=1000, plot_error=True)
+        assert len(ax.lines) == 0  # the interpolation curve is not drawn
+        cs = np.array([p.line_concentration for p in lps])
+        expected = np.array([phase.free_energy(1000, p.line_concentration) - p.line_free_energy(1000) for p in lps])
+        order = np.argsort(cs)
+        assert np.abs(expected).max() > 1e-3  # the under-parametrised fit really misses the interior
+        off = np.asarray(ax.collections[-1].get_offsets())
+        off = off[np.argsort(off[:, 0])]
+        assert_allclose(off[:, 0], cs[order])
+        assert_allclose(off[:, 1], expected[order], atol=ERR_ATOL)
+    finally:
+        plt.close(fig)
+
+
+def test_check_concentration_interpolation_error_invariant_to_plot_excess():
+    """The excess shift moves curve and sample together, so the residuals are unchanged."""
+    phase, _ = _under_parametrised_interpolating_phase()
+
+    def errors(plot_excess):
+        fig, ax = plt.subplots()
+        try:
+            phase.check_concentration_interpolation(T=1000, plot_excess=plot_excess, plot_error=True)
+            off = np.asarray(ax.collections[-1].get_offsets())
+            return off[np.argsort(off[:, 0])][:, 1]
+        finally:
+            plt.close(fig)
+
+    assert_allclose(errors(False), errors(True), atol=ERR_ATOL)
+
+
+def test_check_concentration_interpolation_error_respects_add_entropy():
+    """With add_entropy the sample is the entropy-adjusted line value, against which the
+    residual is measured."""
+    phase, lps = _under_parametrised_interpolating_phase(add_entropy=True)
+    fig, ax = plt.subplots()
+    try:
+        phase.check_concentration_interpolation(T=1000, plot_error=True)
+        cs = np.array([p.line_concentration for p in lps])
+        expected = np.array(
+            [
+                phase.free_energy(1000, p.line_concentration)
+                - (p.line_free_energy(1000) - 1000 * S(p.line_concentration))
+                for p in lps
+            ]
+        )
+        order = np.argsort(cs)
+        assert np.abs(expected).max() > 1e-3
+        off = np.asarray(ax.collections[-1].get_offsets())
+        off = off[np.argsort(off[:, 0])]
+        assert_allclose(off[:, 1], expected[order], atol=ERR_ATOL)
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
Both `TemperatureDependentLinePhase.check_interpolation` (temperature) and `check_concentration_interpolation` (concentration, plus the `RegularSolution` / `InterpolatingPhase` / `SlowInterpolatingPhase` methods forwarding to it) grow a `plot_error=False` flag.

When `plot_error=True` the methods plot only the interpolation error at the samples instead of the free energies:

- temperature: `line_free_energy(T) - sample` at each sampled temperature;
- concentration: `free_energy(c) - line value` at each line phase.

The concentration error is measured in the entropy-adjusted coordinates, so it is invariant to `plot_excess`.

Rebased onto current `main`, which already carries the `c=`→`color=` scatter fix from #271.

Tests in `tests/unit/test_phases.py`: in error mode the free-energy curve is not drawn and the scatter markers match an independently recomputed residual to `atol=1e-9` (under-parametrised fits so the residuals are genuinely nonzero); `plot_excess` invariance; `add_entropy` handling; and the default path still draws the curve and samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTsK8auS6EGVvERHztzrjd