### PR TITLE
fix(plot): refuse reference_phase subtraction on stable-only 1d frames

### DIFF
--- a/landau/plot.py
+++ b/landau/plot.py
@@ -563,12 +563,30 @@ def _bridge_unstable_segments(df: pd.DataFrame, scan_col: str) -> pd.DataFrame:
 
 
 def _subtract_reference_phase(df, scan_col, reference_phase):
-    """Subtract reference phase's phi from all phases along scan_col."""
+    """Subtract reference phase's phi from all phases along scan_col.
+
+    The reference phase must be sampled at every grid point of the scan. Otherwise
+    the ``np.interp`` below silently fabricates the missing reference values --
+    clamping to a constant beyond the reference's range, or bridging an interior
+    gap with a chord -- and corrupts every phase's curve. A frame keeping only
+    stable rows triggers this: the reference is then present only within its own
+    stability window(s), so recompute the diagram with ``keep_unstable=True``.
+    """
     if reference_phase not in df["phase"].values:
         raise ValueError(f"reference_phase {reference_phase!r} not found in data")
     ref = df.loc[df["phase"] == reference_phase, [scan_col, "phi"]].sort_values(scan_col)
-    # np.interp handles border points where the reference phase has no exact row
-    # (refinement adds rows only for the two transitioning phases, not all phases).
+    # Refined border rows are excluded: the reference legitimately has no row there
+    # (refinement adds rows only for the two transitioning phases), and np.interp
+    # interpolates them from the dense grid neighbours on either side.
+    grid = df.loc[~df["border"], scan_col] if "border" in df.columns else df[scan_col]
+    grid = np.unique(grid)
+    missing = np.setdiff1d(grid, ref[scan_col].to_numpy())
+    if missing.size:
+        raise ValueError(
+            f"reference_phase {reference_phase!r} is not sampled across the full "
+            f"{scan_col} range ({missing.size} of {grid.size} grid points have no "
+            f"reference row); recompute the diagram with keep_unstable=True."
+        )
     df["phi"] = df["phi"] - np.interp(df[scan_col], ref[scan_col], ref["phi"])
     return df
 

--- a/tests/unit/plot/test_1d_plots.py
+++ b/tests/unit/plot/test_1d_plots.py
@@ -34,6 +34,7 @@ from landau.plot import (
     _phase_visible_in_band,
     _place_transition_labels,
     _spread_labels,
+    _subtract_reference_phase,
     plot_1d_mu_phase_diagram,
     plot_1d_T_phase_diagram,
 )
@@ -534,6 +535,83 @@ def test_plot_1d_T_reference_phase_invalid_raises(df_T_three_stable):
             plot_1d_T_phase_diagram(df_T_three_stable, ax=ax, reference_phase="nonexistent")
     finally:
         plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "plot_func, fixture, ref",
+    [
+        (plot_1d_mu_phase_diagram, "df_mu_three_stable", "hcp"),
+        (plot_1d_T_phase_diagram, "df_T_three_stable", "bcc"),
+    ],
+)
+def test_plot_1d_reference_phase_stable_only_raises(plot_func, fixture, ref, request):
+    """reference_phase on a stable-only frame raises, pointing at keep_unstable=True.
+
+    Stripped to stable rows, the reference phase covers only its own stability
+    window; subtracting it then extrapolated/chorded the missing values and bent
+    every other phase's curve (the reported breakage).  It must refuse instead.
+    """
+    df = _stable_only_df(request.getfixturevalue(fixture))
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(ValueError, match="keep_unstable=True"):
+            plot_func(df, ax=ax, reference_phase=ref)
+    finally:
+        plt.close(fig)
+
+
+def _ref_frame(scan_col, ref_positions, other_positions, border_positions=()):
+    """Synthetic frame: a 'ref' and an 'other' phase at the given scan positions.
+
+    ``border_positions`` are added as rows of 'other' tagged ``border=True``, mimicking
+    refined transition rows that the reference phase has no sample at.
+    """
+    rows = (
+        [(p, "ref", float(p), False) for p in ref_positions]
+        + [(p, "other", 10.0 + p, False) for p in other_positions]
+        + [(p, "other", 10.0 + p, True) for p in border_positions]
+    )
+    return pd.DataFrame(rows, columns=[scan_col, "phase", "phi", "border"])
+
+
+def test_subtract_reference_phase_full_coverage_zeroes_reference():
+    """With the reference at every grid point, its own phi is subtracted to zero."""
+    df = _ref_frame("mu", ref_positions=[0, 1, 2, 3], other_positions=[0, 1, 2, 3])
+    out = _subtract_reference_phase(df, "mu", "ref")
+    np.testing.assert_allclose(out.loc[out["phase"] == "ref", "phi"], 0.0, atol=1e-12)
+
+
+def test_subtract_reference_phase_interior_gap_raises():
+    """A reference missing at an interior grid point raises (no silent chord fill).
+
+    This is the split-stability-window case: the reference is present on both sides
+    of a grid point it is unstable at, so np.interp would bridge it with a chord.
+    """
+    df = _ref_frame("mu", ref_positions=[0, 1, 3, 4], other_positions=[0, 1, 2, 3, 4])
+    with pytest.raises(ValueError, match="1 of 5 grid points"):
+        _subtract_reference_phase(df, "mu", "ref")
+
+
+def test_subtract_reference_phase_trailing_gap_raises():
+    """A reference absent past its range raises (np.interp would clamp to a constant)."""
+    df = _ref_frame("mu", ref_positions=[0, 1, 2], other_positions=[0, 1, 2, 3, 4])
+    with pytest.raises(ValueError, match="keep_unstable=True"):
+        _subtract_reference_phase(df, "mu", "ref")
+
+
+def test_subtract_reference_phase_border_rows_allowed():
+    """A refined border row the reference lacks does not trip the coverage check.
+
+    Border rows are excluded from the grid; np.interp fills the reference's value
+    there from its neighbouring grid samples, the pre-existing keep_unstable behaviour.
+    """
+    df = _ref_frame(
+        "mu", ref_positions=[0, 1, 2], other_positions=[0, 1, 2], border_positions=[1.5]
+    )
+    out = _subtract_reference_phase(df, "mu", "ref")
+    # The border row of 'other' (phi = 11.5) gets the interpolated reference (1.5).
+    border_row = out[(out["phase"] == "other") & out["border"]]
+    np.testing.assert_allclose(border_row["phi"].to_numpy(), [10.0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`plot_1d_mu_phase_diagram` / `plot_1d_T_phase_diagram` with `reference_phase=` produce wrong curves when the frame contains only stable rows (i.e. `calc_phase_diagram` without `keep_unstable=True`). Every non-reference phase bends away from its true relative potential.

## Cause

`_subtract_reference_phase` subtracts the reference via `np.interp(df[scan_col], ref[scan_col], ref["phi"])`. In a stable-only frame the reference phase has rows only inside its own stability window(s), so:

- past the reference's range, `np.interp` clamps to a constant — the other phase's curve plummets;
- across an interior gap (split stability window), `np.interp` bridges with a chord that sits off the true reference curve — the other phase's curve bulges.

Both fabricate reference values that were never sampled.

## Fix

Require the reference phase to be present at every grid point of the scan; raise `ValueError` pointing at `keep_unstable=True` otherwise. Refined `border` rows are excluded from the requirement, so the existing `keep_unstable` path (where the reference legitimately lacks a row at a refined transition and `np.interp` interpolates it from neighbouring grid samples) is unchanged. The check is an exact grid-point set comparison — threshold-free and grid-density independent.

The no-reference stable-only plot already rendered the correct stable envelope and is untouched.

## Tests

`tests/unit/plot/test_1d_plots.py`:
- both 1d plotters raise on a stable-only frame with `reference_phase` set;
- direct `_subtract_reference_phase` cases: full coverage zeroes the reference; an interior gap and a trailing gap each raise; a refined border row the reference lacks is interpolated, not rejected.

Full suite passes (`pytest tests/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMPgTpayNuxabfFzVLubxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMPgTpayNuxabfFzVLubxy)_