### PR TITLE
Fix SlowInterpolatingPhase to honour explicit concentration_range (XOR with maximum_extrapolation)

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -572,13 +572,19 @@ class SlowInterpolatingPhase(Phase):
     def __post_init__(self, *args, **kwargs):
         object.__setattr__(self, "phases", tuple(self.phases))
 
-        cs = [p.line_concentration for p in self.phases]
-        concentration_range = (
-            max(0, min(cs) - self.maximum_extrapolation),
-            min(1, max(cs) + self.maximum_extrapolation)
-        )
+        explicit_range = self.concentration_range != (0., 1.)
+        explicit_extrap = self.maximum_extrapolation != 0
 
-        object.__setattr__(self, "concentration_range", concentration_range)
+        if explicit_range and explicit_extrap:
+            raise ValueError("concentration_range and maximum_extrapolation are mutually exclusive")
+
+        if not explicit_range:
+            cs = [p.line_concentration for p in self.phases]
+            concentration_range = (
+                max(0, min(cs) - self.maximum_extrapolation),
+                min(1, max(cs) + self.maximum_extrapolation)
+            )
+            object.__setattr__(self, "concentration_range", concentration_range)
 
         if not (self.concentration_range[0] == 0 and self.concentration_range[1] == 1) and isinstance(self.interpolator, RedlichKister):
             raise ValueError("RedlichKister interpolation requires terminal phases at both c=0 and c=1")

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -566,6 +566,28 @@ def test_interpolating_vs_slow_concentration():
     assert_allclose(fast.concentration(1000.0, dmu), slow.concentration(1000.0, dmu), atol=_INTERP_ATOL)
 
 
+def test_slow_interpolating_phase_explicit_concentration_range_honoured():
+    """Explicitly passed concentration_range is not overridden by maximum_extrapolation=0."""
+    phases = [
+        LinePhase("A", fixed_concentration=0.2, line_energy=0.0),
+        LinePhase("mid", fixed_concentration=0.5, line_energy=-0.3),
+        LinePhase("B", fixed_concentration=0.8, line_energy=0.0),
+    ]
+    explicit = (0.1, 0.9)
+    phase = SlowInterpolatingPhase("sol", phases, concentration_range=explicit)
+    assert phase.concentration_range == explicit
+
+
+def test_slow_interpolating_phase_concentration_range_and_extrapolation_exclusive():
+    """Passing both concentration_range and maximum_extrapolation raises ValueError."""
+    phases = [
+        LinePhase("A", fixed_concentration=0.2, line_energy=0.0),
+        LinePhase("B", fixed_concentration=0.8, line_energy=0.0),
+    ]
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SlowInterpolatingPhase("sol", phases, concentration_range=(0.1, 0.9), maximum_extrapolation=0.05)
+
+
 # --- LowTemperatureExpansionSublattice tests ---
 
 _LTE_ATOL = 1e-12


### PR DESCRIPTION
## Summary

`SlowInterpolatingPhase.__post_init__` unconditionally overwrote the `concentration_range` field with the value derived from `maximum_extrapolation`, silently discarding any explicitly passed range.

The two parameters are now mutually exclusive (XOR):
- `concentration_range` is kept as-is when explicitly supplied (non-default `(0., 1.)`)
- `maximum_extrapolation` drives the computed range when `concentration_range` is at its default
- Passing both non-default raises `ValueError("concentration_range and maximum_extrapolation are mutually exclusive")`

Two new tests in `tests/unit/test_phases.py` pin both branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_015YwwZCguzM18bd9ZpN3tJE)_