### PR TITLE
Remove dead Sprime and c_from_dmu from landau.phases

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -40,18 +40,6 @@ def S(c):
     return kB * (se.entr(c) + se.entr(1 - c))
 
 
-def Sprime(c):
-    with np.errstate(divide="ignore"):
-        s = -kB * (np.log(c / (1 - c)))
-    s[np.isclose(c, 0)] = +np.inf
-    s[np.isclose(c, 1)] = -np.inf
-    return s
-
-
-def c_from_dmu(dmu, T, e_defect):
-    return 1 / (1 + np.exp(-(dmu - e_defect) / kB / T))
-
-
 def _scalarize(x):
     """Collapse a 0-d numpy result to a Python scalar; pass everything else through.
 


### PR DESCRIPTION
Closes #268.

`landau/phases/__init__.py:43-52` defined two module-level functions with no callers:

- `Sprime(c)` — derivative of the ideal entropy `S(c)`.
- `c_from_dmu(dmu, T, e_defect)` — Boltzmann two-level concentration.

Verified by ripgrep across the tree: only the definitions matched. Neither name appears in `__all__`, the notebooks, or `docs/`. Both are deleted outright (~12 lines).

No tests added — the right check is that nothing in the repo references these names.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbqpax9Z7QaqiijRPRhJND)_