### PR TITLE
ci(claude): switch model based on @claude[haiku|sonnet|opus] mention

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
           if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
             choice="${BASH_REMATCH[1],,}"
             case "$choice" in
-              haiku|opus)
+              haiku|sonnet|opus)
                 model="$choice"
                 ;;
               *)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Resolve model from mention
+        id: model
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          body="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}${ISSUE_TITLE}"
+          model=opus
+          if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
+            choice="${BASH_REMATCH[1],,}"
+            case "$choice" in
+              haiku|opus)
+                model="$choice"
+                ;;
+              *)
+                echo "::warning::Unknown @claude model alias '$choice'; using default ($model)."
+                ;;
+            esac
+          fi
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "Selected model: $model"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -46,5 +70,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model opus --effort high --allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)'
+          claude_args: '--model ${{ steps.model.outputs.model }} --effort high --allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)'
 


### PR DESCRIPTION
Parse `@claude[haiku]` / `@claude[sonnet]` / `@claude[opus]` out of the triggering issue, comment, or review body and route the alias to `--model`. Bare `@claude` mentions still resolve to opus, and unknown aliases fall back to opus with a workflow warning. Version numbers are not accepted — only the bare family name.

Implementation: a new `Resolve model from mention` step reads the comment, review, issue body, and issue title via env vars, matches `@claude\[([a-zA-Z]+)\]` in bash, lowercases the match, and emits `steps.model.outputs.model`. The existing `claude_args` interpolates that output instead of the hard-coded `opus`.
