### PR TITLE
docs(agents): flag FastInterpolatingPhase default, add resample.py + benchmarks/ rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,14 @@ Python `>=3.11,<3.14`. Extras: `test`, `constraints`, `fast-tsp`, `python-tsp`, 
 | Path | What's there |
 |------|--------------|
 | `landau/calculate.py` | `calc_phase_diagram`, `refine_phase_diagram`, `guess_mu_range`, `get_transitions`, clustering helpers |
-| `landau/phases/` | `Phase` ABC, `LinePhase`, `IdealSolution`, `RegularSolution`, `InterpolatingPhase`, `SlowInterpolatingPhase`, `FastInterpolatingPhase`; `pointdefects.py`, `asewrapper.py` siblings |
-| `landau/interpolate/` | `Interpolator` strategies: `PolyFit`, `SplineFit`, `SGTE`, `RedlichKister`, `StitchedFit`, `SoftplusFit`, `WhitneyTemperatureInterpolator` (the sklearn-style `WhitneyRBFInterpolator` it wraps is not re-exported). Each `fit()` returns an `Interpolation` whose `deriv()` returns `f'` as another `Interpolation` (analytic for `PolyFit` / `SGTE` / `RedlichKister`, numerical fallback otherwise) |
+| `landau/phases/` | `Phase` ABC, `LinePhase`, `IdealSolution`, `RegularSolution`, `InterpolatingPhase`, `SlowInterpolatingPhase`, `FastInterpolatingPhase` (the default solution-phase choice; `SlowInterpolatingPhase` stays as the per-scalar `scipy.optimize.brute` reference oracle); `pointdefects.py`, `asewrapper.py` siblings |
+| `landau/interpolate/` | `Interpolator` strategies: `PolyFit`, `SplineFit`, `SGTE`, `RedlichKister`, `StitchedFit`, `SoftplusFit`, `WhitneyTemperatureInterpolator` (the sklearn-style `WhitneyRBFInterpolator` it wraps is not re-exported). Central contract: `Interpolator.fit(x, y) → Interpolation`; `Interpolation.deriv() → Interpolation` returns `f'` (analytic for `PolyFit` / `SGTE` / `RedlichKister`, numerical-default for closure-wrapped fits) — `FastInterpolatingPhase` needs the analytic first derivative |
 | `landau/refine.py` | `Refiner` ABC + `ScanRefiner`, `DelaunayLineRefiner`, `DelaunayTripleRefiner`, `ClausiusClapeyronRefiner`, `MiscibilityGapRefiner` |
 | `landau/plot.py` | `plot_phase_diagram`, `plot_mu_phase_diagram`, 1d variants, `plot_excess_free_energy`, `get_polygons` |
 | `landau/poly.py` | Point-cloud → polygon: `Concave`, `Segments`, optional `PythonTsp` / `FastTsp` / segment variants |
+| `landau/resample.py` | `resample_borders`, `RandomlyShiftedPhase` — bootstrap-style border resampling |
 | `landau/features.py` | `Locus` enum (`INTERIOR`/`BOUNDARY`/`TRIPLE`); imported as `from landau.features import Locus` (not re-exported from package root) |
+| `benchmarks/` | Scripts backing any number cited in a PR body (working-style hard rule); committed alongside the PR that introduces the number |
 | `tests/unit/` | One subdirectory per module; filenames mirror what's under test |
 | `tests/regression/` | Bug pins — names contain issue numbers or descriptive labels |
 | `tests/integration/test_border_coverage.py` | Polygon-coverage smoke test across every `poly_method` × axis pair |


### PR DESCRIPTION
AGENTS.md audit picked up four gaps in the repo-layout table:

- `FastInterpolatingPhase` is now flagged as the default user-facing solution-phase choice (`SlowInterpolatingPhase` kept as the brute-search reference oracle), so a fresh agent doesn't pick the slow path by default.
- `Interpolator.fit() → Interpolation` / `Interpolation.deriv()` contract lifted out of the trailing sentence so the central PR #281 hook is skimmable; notes that `FastInterpolatingPhase` needs the analytic first derivative.
- Added `landau/resample.py` row (`resample_borders`, `RandomlyShiftedPhase`).
- Added `benchmarks/` row pointing at the working-style rule that any PR-body number gets a script in the same PR.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcnQRCFXZqem1UahWz3rXX)_