### PR TITLE
fix: uncross segment-TSP ring at the c=1 corner

### DIFF
--- a/landau/poly.py
+++ b/landau/poly.py
@@ -411,7 +411,54 @@ def _segment_tsp_polygon(
     coords = np.vstack(chunks)
     if len(coords) < 3:
         return None
-    return shapely.Polygon(coords)
+    polygon = shapely.Polygon(coords)
+    if not polygon.is_valid:
+        polygon = shapely.Polygon(_uncross_ring(coords))
+    return polygon
+
+
+def _segments_cross(p1: np.ndarray, p2: np.ndarray, p3: np.ndarray, p4: np.ndarray) -> bool:
+    """Whether the open segments ``p1 p2`` and ``p3 p4`` properly cross.
+
+    Shared endpoints or collinear touching do not count -- only a genuine
+    interior crossing of the two segments.
+    """
+    def ccw(a, b, c):
+        return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+    d1, d2 = ccw(p3, p4, p1), ccw(p3, p4, p2)
+    d3, d4 = ccw(p1, p2, p3), ccw(p1, p2, p4)
+    return ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0))
+
+
+def _uncross_ring(coords: np.ndarray) -> np.ndarray:
+    """Remove self-intersections from a closed ring of points by 2-opt reversal.
+
+    The segment-endpoint TSP minimises connecting distance but does not
+    guarantee a simple polygon: where a segment's PCA-ordered terminal point is
+    not its geometric extreme -- a curved nose, e.g. the left side of a phase
+    region whose opposite side touches the ``c=1`` corner -- the closing chord
+    can cut across the segment.  Reversing the sub-path between two crossing
+    edges removes that crossing while keeping every border point; each reversal
+    strictly shortens the ring, so iterating converges to a simple polygon
+    without dropping any of the boundary the way a ``make_valid`` repair would.
+    """
+    pts = coords.astype(float).copy()
+    n = len(pts)
+    for _ in range(n * n):
+        for i in range(n - 1):
+            j = next(
+                (j for j in range(i + 2, n)
+                 if (j + 1) % n != i
+                 and _segments_cross(pts[i], pts[i + 1], pts[j], pts[(j + 1) % n])),
+                None,
+            )
+            if j is not None:
+                pts[i + 1:j + 1] = pts[i + 1:j + 1][::-1]
+                break
+        else:
+            break
+    return pts
 
 
 __all__ = ["Concave", "Segments"]

--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -10,7 +10,9 @@ from landau.poly import (
     _greedy_stitch,
     _pca_sort_segment,
     _segment_tsp_polygon,
+    _segments_cross,
     _segments_from_labels,
+    _uncross_ring,
     handle_poly_method,
 )
 import pytest
@@ -570,3 +572,59 @@ def test_segment_tsp_polygon_rotated_tour_cut_inside_segment():
     assert isinstance(result, shapely.Polygon)
     assert result.is_valid
     assert result.equals(shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]))
+
+
+def test_segment_tsp_polygon_uncrosses_protruding_nose():
+    # A segment whose terminal point is not its geometric extreme (a curved
+    # nose: the middle point protrudes past the endpoints) leaves the closing
+    # chord cutting across it, so the assembled ring self-intersects even with
+    # an optimal tour. This is what a phase region touching the c=1 corner does
+    # on the opposite side (#253). The reconstruction must uncross the ring
+    # itself -- returning a valid polygon that keeps every border point --
+    # rather than leaning on make()'s make_valid repair (which warns and clips
+    # the protrusion off).
+    seg0 = np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 0.0]])  # apex [1, 2] protrudes
+    seg1 = np.array([[2.0, 1.0], [0.0, 1.0]])
+    assert not shapely.Polygon(np.vstack([seg0, seg1])).is_valid  # naive ring crosses
+    result = _segment_tsp_polygon([seg0, seg1], lambda dm: [0, 1, 2, 3])
+    assert isinstance(result, shapely.Polygon)
+    assert result.is_valid
+    verts = {tuple(p) for p in np.array(result.exterior.coords)[:-1]}
+    assert {tuple(p) for p in np.vstack([seg0, seg1])} <= verts  # no point dropped
+
+
+# --- _segments_cross / _uncross_ring tests ---
+
+
+def test_segments_cross_proper_crossing():
+    a, b = np.array([0.0, 0.0]), np.array([2.0, 2.0])
+    c, d = np.array([0.0, 2.0]), np.array([2.0, 0.0])
+    assert _segments_cross(a, b, c, d)
+
+
+def test_segments_cross_disjoint():
+    a, b = np.array([0.0, 0.0]), np.array([1.0, 0.0])
+    c, d = np.array([0.0, 1.0]), np.array([1.0, 1.0])
+    assert not _segments_cross(a, b, c, d)
+
+
+def test_segments_cross_shared_endpoint_is_not_a_crossing():
+    a, b = np.array([0.0, 0.0]), np.array([1.0, 1.0])
+    c, d = np.array([0.0, 0.0]), np.array([1.0, -1.0])
+    assert not _segments_cross(a, b, c, d)
+
+
+def test_uncross_ring_repairs_bowtie():
+    # classic self-intersecting bow-tie; uncrossing yields a simple ring
+    bowtie = np.array([[0.0, 0.0], [1.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+    assert not shapely.Polygon(bowtie).is_valid
+    fixed = _uncross_ring(bowtie)
+    poly = shapely.Polygon(fixed)
+    assert poly.is_valid
+    # all four points survive (none dropped, unlike a hull/repair)
+    assert {tuple(p) for p in fixed} == {tuple(p) for p in bowtie}
+
+
+def test_uncross_ring_leaves_simple_ring_unchanged():
+    square = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    np.testing.assert_array_equal(_uncross_ring(square), square)


### PR DESCRIPTION
Closes #253.

A phase region touching the c=1 corner splits its boundary into separate segments, forcing a straight closing chord on the opposite side that cuts across a convex nose whose PCA-terminal point is not its geometric extreme — so the ring self-intersects even with an optimal tour. `_segment_tsp_polygon` now uncrosses the assembled ring (2-opt) when invalid, keeping every border point and returning a simple polygon so no make_valid repair/warning is needed. Non-segment poly methods unchanged.

Generated with [Claude Code](https://claude.ai/code)