### PR TITLE
refactor(calculate): drop dead min_c/max_c writes in calc_phase_diagram

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -244,8 +244,9 @@ def calc_phase_diagram(
     Args:
         phases (iterable of Phases)
         Ts (iterable of floats): sampling points in temperature
-        mu (iterable of floats): sampling points in chemical potential; if int
-            guess sampling points with guess_mu_range at max(Ts)
+        mu (iterable of floats): sampling points in chemical potential; if a
+            non-zero int, guess sampling points with guess_mu_range at max(Ts)
+            (pass ``mu=0.0`` for a fixed-mu temperature-only diagram)
         refine (bool): add additional sampling points at exact phase transitions
         keep_unstable (bool): only keep entries of stable phases, otherwise keep entries of all phases at all sampling points
 
@@ -258,18 +259,14 @@ def calc_phase_diagram(
         Ts = [Ts]
     phases = {p.name: p for p in phases}
     if isinstance(mu, numbers.Integral) and mu != 0:
-        # we would often pass mu=0 to calculate a fixed mu, temperature only diagram and it'd be a bit annoying to pass
-        # mu=0.0 all the time, so we special case as above
         try:
-            mu, min_c, max_c = guess_mu_range(phases.values(), max(Ts), int(mu))
+            mu, *_ = guess_mu_range(phases.values(), max(Ts), int(mu))
         except ValueError:
             if all(isinstance(p, AbstractLinePhase) for p in phases.values()):
                 raise ValueError(
                         "Cannot guess chemical potential range of line phases with all the same concentration!"
                 ) from None
             raise
-    elif refine:
-        min_c, max_c = None, None
 
     def get(s, T):
         phi = s.semigrand_potential(T, mu)


### PR DESCRIPTION
Refs #116.

`guess_mu_range` returns `(mu, c0, c1)`. In `calc_phase_diagram` the
`c0, c1` were unpacked into `min_c, max_c` but then overwritten
unconditionally by `pdf.c.min()` / `pdf.c.max()` inside `if refine:`
before being passed to `refine_phase_diagram`. When `refine=False`
they are not referenced at all. Both assignments are dead.

The `elif refine: min_c, max_c = None, None` branch was likewise dead —
the `if refine:` block always overwrites those names before use.

Changes:
- `mu, min_c, max_c = guess_mu_range(...)` → `mu, *_ = guess_mu_range(...)`
- Remove `elif refine: min_c, max_c = None, None`
- Remove the stale inline comment that restated what the docstring now says
- Expand the `mu` docstring entry to document the `!= 0` carve-out for
  fixed-mu temperature-only diagrams (`mu=0.0` bypasses `guess_mu_range`)

51 unit + 18 regression tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFj52iPawHwZywKydD9Eh5)_