### PR TITLE
test(refine): direct unit tests for _dominated

### DIFF
--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -692,40 +692,40 @@ def _dom_phases(*specs):
 
 
 def test_dominated_no_rivals_returns_false():
-    # Two phases coexist, the mapping carries only those two: nothing else can
-    # dominate. The generator is empty and any() returns False.
+    """Two phases coexist, the mapping carries only those two: nothing else
+    can dominate. The generator is empty and any() returns False."""
     phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0))
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
     assert _dominated(pt, phases) is False
 
 
 def test_dominated_rival_with_lower_phi_returns_true():
-    # phi_A = 0, phi_B = -mu = 0, phi_C = E_C - 0.5*mu = -0.1 at (T, mu=0).
-    # C is outside pt.phase_names() and strictly lower, so it dominates.
+    """phi_A = 0, phi_B = -mu = 0, phi_C = E_C - 0.5*mu = -0.1 at (T, mu=0).
+    C is outside pt.phase_names() and strictly lower, so it dominates."""
     phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, -0.1))
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
     assert _dominated(pt, phases) is True
 
 
 def test_dominated_rival_with_higher_phi_returns_false():
-    # phi_C = +0.5 > phi_A = phi_B = 0 at mu = 0: no dominator.
+    """phi_C = +0.5 > phi_A = phi_B = 0 at mu = 0: no dominator."""
     phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.5))
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
     assert _dominated(pt, phases) is False
 
 
 def test_dominated_rival_equal_phi_returns_false():
-    # phi_C == own_phi exactly: the comparison is strict "<", so a degenerate
-    # rival is not treated as dominating. At a true triple point we want this
-    # so the refined point survives instead of getting dropped.
+    """phi_C == own_phi exactly: the comparison is strict "<", so a
+    degenerate rival is not treated as dominating. At a true triple point
+    we want this so the refined point survives instead of getting dropped."""
     phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.0))
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
     assert _dominated(pt, phases) is False
 
 
 def test_dominated_skips_phases_in_own_set():
-    # Triple-point candidate. D would dominate but it is *in* `own`, so the
-    # `if p.name not in own` filter excludes it and no rival remains.
+    """Triple-point candidate. D would dominate but it is *in* ``own``, so
+    the ``if p.name not in own`` filter excludes it and no rival remains."""
     phases = _dom_phases(
         ("A", 0.0, 0.0), ("B", 1.0, 0.0), ("D", 0.5, -1.0),
     )
@@ -734,7 +734,7 @@ def test_dominated_skips_phases_in_own_set():
 
 
 def test_dominated_triple_with_outside_dominator_returns_true():
-    # Three phases coexist; a fourth phase outside `own` dominates.
+    """Three phases coexist; a fourth phase outside ``own`` dominates."""
     phases = _dom_phases(
         ("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.0), ("X", 0.25, -0.5),
     )
@@ -743,7 +743,8 @@ def test_dominated_triple_with_outside_dominator_returns_true():
 
 
 def test_dominated_picks_any_lower_rival_among_many():
-    # Two outside rivals: one higher, one lower. The lower one alone is enough.
+    """Two outside rivals: one higher, one lower. The lower one alone is
+    enough to make the candidate dominated."""
     phases = _dom_phases(
         ("A", 0.0, 0.0), ("B", 1.0, 0.0),
         ("hi", 0.25, +0.5), ("lo", 0.75, -0.2),

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -19,6 +19,7 @@ from landau.refine import (
 from landau.refine import (
     _point_on_line,
     _simplex_straddles,
+    _dominated,
     _InterCandidate,
     _delaunay_simplices,
 )
@@ -672,3 +673,80 @@ def test_scan_refiner_splits_dominated_crossing_T_scan():
     assert len(by_T) == 2
     np.testing.assert_allclose(by_T.index, [490.0, 510.0], atol=SCAN_ATOL)
     assert by_T.tolist() == [("A", "B"), ("B", "C")]
+
+
+# -- _dominated ---------------------------------------------------------------
+#
+# `_dominated(pt, phases)` is the predicate every refiner's run() uses to drop
+# a refined transition whose phases are not globally stable at (pt.T, pt.mu):
+# True iff some phase outside pt.phase_names() has a strictly lower phi there.
+# The cases below cover each branch of that contract orthogonally: empty rival
+# set, lower / equal / higher rival, the strictness of "<", the size-3 own set,
+# and the own-set filter that hides supposedly-dominating coexisting phases.
+
+
+def _dom_phases(*specs):
+    """Build a name -> LinePhase mapping. Each spec is (name, c, E)."""
+    return {name: LinePhase(name=name, fixed_concentration=c, line_energy=E)
+            for name, c, E in specs}
+
+
+def test_dominated_no_rivals_returns_false():
+    # Two phases coexist, the mapping carries only those two: nothing else can
+    # dominate. The generator is empty and any() returns False.
+    phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0))
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is False
+
+
+def test_dominated_rival_with_lower_phi_returns_true():
+    # phi_A = 0, phi_B = -mu = 0, phi_C = E_C - 0.5*mu = -0.1 at (T, mu=0).
+    # C is outside pt.phase_names() and strictly lower, so it dominates.
+    phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, -0.1))
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is True
+
+
+def test_dominated_rival_with_higher_phi_returns_false():
+    # phi_C = +0.5 > phi_A = phi_B = 0 at mu = 0: no dominator.
+    phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.5))
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is False
+
+
+def test_dominated_rival_equal_phi_returns_false():
+    # phi_C == own_phi exactly: the comparison is strict "<", so a degenerate
+    # rival is not treated as dominating. At a true triple point we want this
+    # so the refined point survives instead of getting dropped.
+    phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.0))
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is False
+
+
+def test_dominated_skips_phases_in_own_set():
+    # Triple-point candidate. D would dominate but it is *in* `own`, so the
+    # `if p.name not in own` filter excludes it and no rival remains.
+    phases = _dom_phases(
+        ("A", 0.0, 0.0), ("B", 1.0, 0.0), ("D", 0.5, -1.0),
+    )
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B", "D"))
+    assert _dominated(pt, phases) is False
+
+
+def test_dominated_triple_with_outside_dominator_returns_true():
+    # Three phases coexist; a fourth phase outside `own` dominates.
+    phases = _dom_phases(
+        ("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.0), ("X", 0.25, -0.5),
+    )
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B", "C"))
+    assert _dominated(pt, phases) is True
+
+
+def test_dominated_picks_any_lower_rival_among_many():
+    # Two outside rivals: one higher, one lower. The lower one alone is enough.
+    phases = _dom_phases(
+        ("A", 0.0, 0.0), ("B", 1.0, 0.0),
+        ("hi", 0.25, +0.5), ("lo", 0.75, -0.2),
+    )
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is True


### PR DESCRIPTION
Refs #116.

`_dominated(pt, phases)` is the predicate every refiner's `run()` uses to drop
a refined transition whose phases are not globally stable at `(pt.T, pt.mu)`:
True iff some phase outside `pt.phase_names()` has a strictly lower phi there.
The integration path is exercised by `test_scan_refiner_splits_dominated_crossing`
(narrow B window in mu / T), but the helper itself has no direct test, so a
regression in the filter would only surface as a downstream miscount.

Seven new cases in `tests/unit/test_refine.py`, each pinning one orthogonal
branch of the contract:

- no rivals: empty generator → False
- outside rival strictly below: True
- outside rival strictly above: False
- outside rival exactly equal: False (strict `<` lets a true triple point survive)
- size-3 candidate whose only would-be dominator is *in* its own set: False (the
  `p.name not in own` filter holds)
- size-3 candidate with a fourth phase outside that dominates: True
- two rivals (one higher, one lower): True (lower one alone is enough)

Fixture is a small `LinePhase` mapping built from `(name, c, E)` tuples, so each
test reads as one line of setup plus one assertion.

`pytest tests/unit/test_refine.py` — 34 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE8BDqF5RYseeVbsBUvfjE)_