### PR TITLE
docs(agents): note TemperatureDependentLinePhase/AsePhase, tighten benchmarks/ row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Cross-tool entry point for AI coding agents (Codex, Cursor, Aider, Claude, ...).
 
 ## TL;DR
 
-`landau.py` — thermodynamic equilibria and phase diagrams in the (semi-)grand ensemble. Pure Python, dataclass-heavy, plug-in strategies (`Phase`, `Interpolator`, `Refiner`, `AbstractPolyMethod`).
+`landau.py` — thermodynamic equilibria and phase diagrams in the (semi-)grand ensemble. Dataclass-heavy, plug-in strategies (`Phase`, `Interpolator`, `Refiner`, `AbstractPolyMethod`).
 
 ## Commands
 
@@ -26,14 +26,14 @@ Python `>=3.11,<3.14`. Extras: `test`, `constraints`, `fast-tsp`, `python-tsp`, 
 | Path | What's there |
 |------|--------------|
 | `landau/calculate.py` | `calc_phase_diagram`, `refine_phase_diagram`, `guess_mu_range`, `get_transitions`, clustering helpers |
-| `landau/phases/` | `Phase` ABC, `LinePhase`, `IdealSolution`, `RegularSolution`, `InterpolatingPhase`, `SlowInterpolatingPhase`, `FastInterpolatingPhase` (the default solution-phase choice; `SlowInterpolatingPhase` stays as the per-scalar `scipy.optimize.brute` reference oracle); `pointdefects.py`, `asewrapper.py` siblings |
+| `landau/phases/` | `Phase` ABC, `AbstractLinePhase`, `LinePhase`, `TemperatureDependentLinePhase` (alias `TemperatureDepandantLinePhase` kept for back-compat), `IdealSolution`, `RegularSolution`, `InterpolatingPhase`, `SlowInterpolatingPhase`, `FastInterpolatingPhase` (the default solution-phase choice; `SlowInterpolatingPhase` stays as the per-scalar `scipy.optimize.brute` reference oracle). Sibling modules: `pointdefects.py` (`AbstractPointDefect`, `ConstantPointDefect`, `PointDefectSublattice`, `LowTemperatureExpansionSublattice`, `PointDefectedPhase` — pre-split names re-exported through `phases/__init__.py` behind `@deprecate` shims for back-compat) and `asewrapper.py` (`AsePhase`). User-facing classes are re-exported from `landau/__init__.py` |
 | `landau/interpolate/` | `Interpolator` strategies: `PolyFit`, `SplineFit`, `SGTE`, `RedlichKister`, `StitchedFit`, `SoftplusFit`, `WhitneyTemperatureInterpolator` (the sklearn-style `WhitneyRBFInterpolator` it wraps is not re-exported). Central contract: `Interpolator.fit(x, y) → Interpolation`; `Interpolation.deriv() → Interpolation` returns `f'` (analytic for `PolyFit` / `SGTE` / `RedlichKister`, numerical-default for closure-wrapped fits) — `FastInterpolatingPhase` needs the analytic first derivative |
 | `landau/refine.py` | `Refiner` ABC + `ScanRefiner`, `DelaunayLineRefiner`, `DelaunayTripleRefiner`, `ClausiusClapeyronRefiner`, `MiscibilityGapRefiner` |
 | `landau/plot.py` | `plot_phase_diagram`, `plot_mu_phase_diagram`, 1d variants, `plot_excess_free_energy`, `get_polygons` |
 | `landau/poly.py` | Point-cloud → polygon: `Concave`, `Segments`, optional `PythonTsp` / `FastTsp` / segment variants |
 | `landau/resample.py` | `resample_borders`, `RandomlyShiftedPhase` — bootstrap-style border resampling |
 | `landau/features.py` | `Locus` enum (`INTERIOR`/`BOUNDARY`/`TRIPLE`); imported as `from landau.features import Locus` (not re-exported from package root) |
-| `benchmarks/` | Scripts backing any number cited in a PR body (working-style hard rule); committed alongside the PR that introduces the number |
+| `benchmarks/` | Scripts backing any number cited in a PR body (see Working style); committed alongside the PR that introduces the number |
 | `tests/unit/` | One subdirectory per module; filenames mirror what's under test |
 | `tests/regression/` | Bug pins — names contain issue numbers or descriptive labels |
 | `tests/integration/test_border_coverage.py` | Polygon-coverage smoke test across every `poly_method` × axis pair |


### PR DESCRIPTION
## Summary

Small AGENTS.md accuracy fix surfaced by an audit against `landau/__init__.py`.

- **`landau/phases/` row** — the user-facing class list omitted `AbstractLinePhase`, `TemperatureDependentLinePhase` (plus its `TemperatureDepandantLinePhase` back-compat alias), and `AsePhase`, all of which `landau/__init__.py` re-exports. A reader greppping AGENTS.md for those names would not find them. Also names the point-defect classes under `pointdefects.py` and notes the pre-split back-compat re-exports through `phases/__init__.py`, so an agent doesn't reinvent the deprecation layer.
- **`benchmarks/` row** — drop the parenthetical re-statement of the working-style rule; the rule is already in the Working Style section three lines below.
- **TL;DR** — drop "Pure Python" as orientation filler; "dataclass-heavy, plug-in strategies" carries the load.

CLAUDE.md (the deep reference) is unchanged.

## Test plan

- [ ] Docs-only change — no code touched, no tests needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWtn1ut4VYK1ssPnX4UrrV)_