### PR TITLE
ci(claude): select model from a spaced @claude [model] mention

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,9 +38,14 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
+          # The action does its own trigger detection: it only fires on '@claude'
+          # followed by whitespace, punctuation, or end-of-line, so a model is
+          # selected with a space -- '@claude [haiku|sonnet|opus]'. This step only
+          # maps that alias onto a --model arg; bare or unrecognised mentions fall
+          # back to sonnet. (A glued '@claude[model]' would not trigger the action.)
           body="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}${ISSUE_TITLE}"
           model=sonnet
-          if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
+          if [[ "$body" =~ @claude[[:space:]]*\[([a-zA-Z]+)\] ]]; then
             choice="${BASH_REMATCH[1],,}"
             case "$choice" in
               haiku|sonnet|opus)


### PR DESCRIPTION
A model-selecting mention like `@claude[sonnet]` never triggered a run — the job started but Claude stayed silent. Reproduced by the `@claude[sonnet]` comment on #277 (2026-06-30); a bare `@claude fix ci` on the same PR worked.

## Cause

`claude-code-action` does its own trigger detection with the regex `(^|\s)@claude([\s.,!?;:]|$)` (`src/github/validation/trigger.ts`). The character after `@claude` must be whitespace, `.,!?;:`, or end-of-line. A glued `@claude[sonnet]` puts `[` there, so the action does not recognize the mention and never runs — there is no config knob to make the trigger accept `[` (the phrase is regex-escaped). The job-level `if:` uses `contains(..., '@claude')`, which matches the substring regardless of suffix, so the job ran, resolved the model, and invoked the action, which then silently bailed. That split is why the bug was invisible at the workflow level.

## Fix

Select the model with a space: `@claude [haiku|sonnet|opus]`. That keeps `@claude` followed by whitespace, so the action's native trigger fires and the mention runs through normal tag mode (full context + threaded reply). The resolve step only maps the alias onto `--model`; the action owns triggering. The sole change over the prior fixed-model workflow is whitespace tolerance in the alias regex (`@claude\[…\]` → `@claude[[:space:]]*\[…\]`). Bare or unrecognised mentions fall back to sonnet.

The action has no built-in model-from-mention feature, so a resolve step is required regardless. (An earlier revision of this PR instead hand-rolled an explicit `prompt` to bypass the action's trigger and preserve the glued `@claude[sonnet]` syntax; dropped in favour of leaning on the action's own trigger, which keeps every mention on one tag-mode code path.)

## Verified

Ran the resolve-step shell locally:

| comment | `--model` |
| --- | --- |
| `@claude [sonnet] …` | sonnet |
| `@claude [opus] …` | opus |
| `@claude  [haiku]` | haiku |
| `@claude fix ci` | sonnet (default) |
| `@claude please help` | sonnet (no warning) |
| `@claude [gpt]` | sonnet (warns) |

Triggering: a bare `@claude fix ci` already triggered tag mode on #277; `@claude [sonnet]` shares the identical `@claude`-then-space prefix, so the action fires the same way. `yaml.safe_load` confirms the workflow parses and the action step has no `prompt` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)