### PR TITLE
feat(phases): IntermetallicPhase, a smooth mu-native chain of ideal-solution segments

### DIFF
--- a/landau/__init__.py
+++ b/landau/__init__.py
@@ -7,6 +7,7 @@ from .phases import (
     InterpolatingPhase,
     SlowInterpolatingPhase,
     FastInterpolatingPhase,
+    IntermetallicPhase,
     AsePhase,
 )
 

--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "InterpolatingPhase",
     "SlowInterpolatingPhase",
     "FastInterpolatingPhase",
+    "IntermetallicPhase",
     "AbstractPointDefect",
     "ConstantPointDefect",
     "PointDefectSublattice",
@@ -889,4 +890,5 @@ def PointDefectedPhase(*args, **kwargs):
     return _pointdefects.PointDefectedPhase(*args, **kwargs)
 
 
+from .intermetallic import IntermetallicPhase
 from .asewrapper import AsePhase

--- a/landau/phases/intermetallic.py
+++ b/landau/phases/intermetallic.py
@@ -5,7 +5,7 @@ from typing import Iterable
 import numpy as np
 from scipy.special import expit
 
-from . import Phase, AbstractLinePhase, kB, S, _scalarize
+from . import Phase, AbstractLinePhase, kB, _scalarize
 
 
 __all__ = [
@@ -19,8 +19,8 @@ def _lower_hull(c, f):
     Andrew's monotone chain over points pre-sorted by ``(c, f)``: a point is a
     vertex of the lower envelope unless it lies on or above the chord between its
     neighbours. These vertices are the connection points of the piecewise-linear
-    low-temperature free energy -- the compounds of locally maximal (positive)
-    curvature; metastable compounds sitting above the hull are dropped.
+    low-temperature free energy -- the stable compounds; metastable compounds
+    sitting above the hull are dropped.
     """
     keep = []
     for i in range(len(c)):
@@ -39,52 +39,56 @@ def _lower_hull(c, f):
 
 @dataclass(frozen=True, eq=True)
 class IntermetallicPhase(Phase):
-    r"""A piecewise ideal solution over the low-temperature convex hull.
+    r"""A chain of ideal-solution segments over the low-temperature convex hull.
 
     Built for intermetallics: a set of stoichiometric compounds whose free
-    energy is piecewise linear at low temperature and acquires configurational
-    entropy along each segment as temperature rises. Like
+    energy is piecewise linear at low temperature and rounds off as the
+    temperature lifts configurational entropy along each segment. Like
     :class:`InterpolatingPhase` it is given line-phase-like free energies sampled
     across the concentration axis, but instead of fitting one smooth curve it
     keeps the compounds as the structure of the free-energy surface.
 
     **Connection points.** At ``T_low`` the lower convex hull of the sampled
-    ``(c, f)`` points is taken; its vertices are the *connection points*, i.e.
-    the stable compounds (the kinks of the piecewise-linear low-T curve). The
-    compounds lying above the hull are metastable and dropped. Their free
-    energies are reused verbatim at every temperature, so the connection points
-    follow whatever temperature dependence the line phases carry (e.g. an SGTE
-    curve) and the whole structure decreases with temperature.
+    ``(c, f)`` points is taken; its vertices are the *connection points* -- the
+    stable compounds (the kinks of the piecewise-linear low-T curve). Compounds
+    lying above the hull are metastable and dropped. Dropping them is required
+    for correctness, not cosmetics: a compound above its neighbours' tie line has
+    out-of-order segment slopes and would otherwise plant a spurious stable phase
+    below the true hull. The connection free energies are reused verbatim at
+    every temperature, so the connection points follow whatever temperature
+    dependence the line phases carry (e.g. an SGTE curve).
 
-    **Segment entropy.** Between two adjacent connection points at ``c_a`` and
-    ``c_b`` the free energy is the tie line plus a *segment ideal entropy*,
-    scaled by the segment length so it vanishes at the connection points:
+    **Segments.** Each segment between adjacent connection points ``c_k`` and
+    ``c_{k+1}`` is an ideal solution between its two compounds, with
+    ``L_k = c_{k+1} - c_k`` exchange sites per atom and a slope (the chemical
+    potential at which its two endpoints are degenerate)
+
+    .. math:: s_k = \frac{g_{k+1} - g_k}{c_{k+1} - c_k}.
+
+    The site count grows with the segment length, so a short segment carries
+    little configurational entropy.
+
+    **Semi-grand potential.** The segments fill *independently* -- segment ``k``
+    activates around its own slope ``s_k`` as the chemical potential sweeps -- so
+    their contributions are summed rather than minimised. This is what keeps the
+    free-energy surface smooth: there is no hard ``min`` to switch between
+    segments, so no cusp at the connection points. The result is written
+    directly in chemical-potential space (no concentration-space curve is built
+    and re-transformed):
 
     .. math::
 
-        f(c, T) = (1-x)\,f_a(T) + x\,f_b(T) - T\,(c_b - c_a)\,S(x),
-        \qquad x = \frac{c - c_a}{c_b - c_a},
+        \phi(\Delta\mu) &= g_0 - \Delta\mu\, c_0
+            - k_B T \sum_k L_k \ln\!\big(1 + e^{(\Delta\mu - s_k)/k_B T}\big), \\
+        c(\Delta\mu) &= c_0 + \sum_k L_k\, \sigma\!\big((\Delta\mu - s_k)/k_B T\big),
 
-    with :math:`S(x) = -k_B[x\ln x + (1-x)\ln(1-x)]`. Each segment is therefore
-    an ideal solution between its two compounds: the substitutable site count
-    grows with the segment length, so a short segment carries little entropy and
-    a single segment spanning ``[0, 1]`` reproduces :class:`IdealSolution`
+    with :math:`\sigma` the logistic function. The configurational smoothing
+    scale is :math:`k_B T`, so the curve is piecewise linear at low temperature
+    (each compound a stable phase over a chemical-potential window) and rounds
+    off as the temperature rises. ``c = -\partial\phi/\partial(\Delta\mu)`` holds
+    exactly, ``c`` stays within ``[c_0, c_N]`` (saturating at the terminal
+    compounds), and a single ``[0, 1]`` segment reproduces :class:`IdealSolution`
     exactly.
-
-    **Equilibrium.** The semi-grand potential minimises ``f(c) - dmu*c`` over
-    ``c``. Within a segment this has the closed form of a (scaled) ideal
-    solution, so no numerical optimisation is needed: each segment contributes
-
-    .. math::
-
-        \phi_k = f_a - \Delta\mu\, c_a
-                 - k_B T\,(c_b - c_a)\,\ln\!\big(1 + e^{-(g - \Delta\mu)/k_B T}\big),
-        \qquad g = \frac{f_b - f_a}{c_b - c_a},
-
-    and the global potential is the minimum over segments. The minimising
-    concentration is :math:`c = c_a + (c_b - c_a)\,\sigma((\Delta\mu - g)/k_B T)`
-    with :math:`\sigma` the logistic function, so ``c = -d(phi)/d(dmu)`` holds to
-    machine precision and ``c`` stays within the span of the connection points.
     """
 
     phases: Iterable[AbstractLinePhase]
@@ -115,50 +119,25 @@ class IntermetallicPhase(Phase):
         """Concentrations of the stable compounds that anchor the segments."""
         return self._connections[0]
 
-    def free_energy(self, T, c):
-        """Piecewise free energy ``f(c, T)`` (tie line minus segment entropy)."""
-        cs, phases = self._connections
-        f = np.array([p.line_free_energy(T) for p in phases], dtype=float)
-        c = np.asarray(c, dtype=float)
-        if len(cs) == 1:
-            return _scalarize(np.where(c == cs[0], f[0], np.nan))
-        s = np.clip(np.searchsorted(cs, c, side="right") - 1, 0, len(cs) - 2)
-        ca, cb, fa, fb = cs[s], cs[s + 1], f[s], f[s + 1]
-        x = (c - ca) / (cb - ca)
-        # clip only the entropy argument so out-of-range c extends the edge line
-        fe = fa + (fb - fa) * x - T * (cb - ca) * S(np.clip(x, 0.0, 1.0))
-        return _scalarize(fe)
-
     def _solve_fixed_T(self, T, dmu):
-        """Minimise ``f(c) - dmu*c`` for one ``T`` over a whole ``dmu`` array.
+        """``(phi, c)`` for one ``T`` over a whole ``dmu`` array.
 
-        Each segment is a scaled ideal solution with an analytic minimum, so the
-        solve is one vectorised evaluation per segment plus an ``argmin`` over
-        segments -- no optimiser, exact to machine precision.
+        Sums the independent per-segment ideal-solution contributions; no
+        optimiser and no concentration-space curve -- the semigrand potential is
+        evaluated directly in chemical-potential space.
         """
-        cs, phases = self._connections
-        f = np.array([p.line_free_energy(T) for p in phases], dtype=float)
+        cs, comps = self._connections
+        g = np.array([p.line_free_energy(T) for p in comps], dtype=float)
         dmu = np.asarray(dmu, dtype=float)
         flat = dmu.ravel()
-
-        if len(cs) == 1:
-            phi = f[0] - flat * cs[0]
-            c = np.full_like(flat, cs[0])
-            return phi.reshape(dmu.shape), c.reshape(dmu.shape)
-
-        ca, cb, fa, fb = cs[:-1], cs[1:], f[:-1], f[1:]
-        L = cb - ca
-        g = (fb - fa) / L  # segment slope: dmu where the two endpoints are degenerate
         kT = kB * T
 
-        z = (g[:, None] - flat[None, :]) / kT
-        c_seg = ca[:, None] + L[:, None] * expit(-z)
-        # log(1 + exp(-z)) via logaddexp keeps the saturated tails stable
-        phi_seg = fa[:, None] - flat[None, :] * ca[:, None] - kT * L[:, None] * np.logaddexp(0.0, -z)
-
-        best = phi_seg.argmin(axis=0)[None, :]
-        phi = np.take_along_axis(phi_seg, best, axis=0)[0]
-        c = np.take_along_axis(c_seg, best, axis=0)[0]
+        L = np.diff(cs)              # segment lengths (empty for a single compound)
+        s = np.diff(g) / L           # segment slopes
+        arg = (flat[:, None] - s[None, :]) / kT
+        # log(1 + exp(arg)) via logaddexp keeps the saturated tails stable
+        phi = g[0] - flat * cs[0] - kT * (L[None, :] * np.logaddexp(0.0, arg)).sum(axis=1)
+        c = cs[0] + (L[None, :] * expit(arg)).sum(axis=1)
         return phi.reshape(dmu.shape), c.reshape(dmu.shape)
 
     def _find_phi_c(self, T, dmu):

--- a/landau/phases/intermetallic.py
+++ b/landau/phases/intermetallic.py
@@ -1,0 +1,187 @@
+from dataclasses import dataclass
+from functools import cache
+from typing import Iterable
+
+import numpy as np
+from scipy.special import expit
+
+from . import Phase, AbstractLinePhase, kB, S, _scalarize
+
+
+__all__ = [
+    "IntermetallicPhase",
+]
+
+
+def _lower_hull(c, f):
+    """Indices of the lower-convex-hull vertices of the points ``(c, f)``.
+
+    Andrew's monotone chain over points pre-sorted by ``(c, f)``: a point is a
+    vertex of the lower envelope unless it lies on or above the chord between its
+    neighbours. These vertices are the connection points of the piecewise-linear
+    low-temperature free energy -- the compounds of locally maximal (positive)
+    curvature; metastable compounds sitting above the hull are dropped.
+    """
+    keep = []
+    for i in range(len(c)):
+        # pop while the last segment does not turn upward at the new point
+        # (cross product of the last edge with the candidate edge <= 0)
+        while len(keep) >= 2:
+            o, a = keep[-2], keep[-1]
+            cross = (c[a] - c[o]) * (f[i] - f[o]) - (f[a] - f[o]) * (c[i] - c[o])
+            if cross <= 0:
+                keep.pop()
+            else:
+                break
+        keep.append(i)
+    return keep
+
+
+@dataclass(frozen=True, eq=True)
+class IntermetallicPhase(Phase):
+    r"""A piecewise ideal solution over the low-temperature convex hull.
+
+    Built for intermetallics: a set of stoichiometric compounds whose free
+    energy is piecewise linear at low temperature and acquires configurational
+    entropy along each segment as temperature rises. Like
+    :class:`InterpolatingPhase` it is given line-phase-like free energies sampled
+    across the concentration axis, but instead of fitting one smooth curve it
+    keeps the compounds as the structure of the free-energy surface.
+
+    **Connection points.** At ``T_low`` the lower convex hull of the sampled
+    ``(c, f)`` points is taken; its vertices are the *connection points*, i.e.
+    the stable compounds (the kinks of the piecewise-linear low-T curve). The
+    compounds lying above the hull are metastable and dropped. Their free
+    energies are reused verbatim at every temperature, so the connection points
+    follow whatever temperature dependence the line phases carry (e.g. an SGTE
+    curve) and the whole structure decreases with temperature.
+
+    **Segment entropy.** Between two adjacent connection points at ``c_a`` and
+    ``c_b`` the free energy is the tie line plus a *segment ideal entropy*,
+    scaled by the segment length so it vanishes at the connection points:
+
+    .. math::
+
+        f(c, T) = (1-x)\,f_a(T) + x\,f_b(T) - T\,(c_b - c_a)\,S(x),
+        \qquad x = \frac{c - c_a}{c_b - c_a},
+
+    with :math:`S(x) = -k_B[x\ln x + (1-x)\ln(1-x)]`. Each segment is therefore
+    an ideal solution between its two compounds: the substitutable site count
+    grows with the segment length, so a short segment carries little entropy and
+    a single segment spanning ``[0, 1]`` reproduces :class:`IdealSolution`
+    exactly.
+
+    **Equilibrium.** The semi-grand potential minimises ``f(c) - dmu*c`` over
+    ``c``. Within a segment this has the closed form of a (scaled) ideal
+    solution, so no numerical optimisation is needed: each segment contributes
+
+    .. math::
+
+        \phi_k = f_a - \Delta\mu\, c_a
+                 - k_B T\,(c_b - c_a)\,\ln\!\big(1 + e^{-(g - \Delta\mu)/k_B T}\big),
+        \qquad g = \frac{f_b - f_a}{c_b - c_a},
+
+    and the global potential is the minimum over segments. The minimising
+    concentration is :math:`c = c_a + (c_b - c_a)\,\sigma((\Delta\mu - g)/k_B T)`
+    with :math:`\sigma` the logistic function, so ``c = -d(phi)/d(dmu)`` holds to
+    machine precision and ``c`` stays within the span of the connection points.
+    """
+
+    phases: Iterable[AbstractLinePhase]
+    """Line phases sampling the free-energy surface; the stable subset becomes
+    the connection points."""
+    T_low: float = 0.0
+    """Temperature at which the connection points (the convex-hull vertices) are
+    identified. Should be low enough that the ordered structure is intact."""
+
+    def __post_init__(self, *args, **kwargs):
+        object.__setattr__(self, "phases", tuple(self.phases))
+        if len(self.phases) == 0:
+            raise ValueError("IntermetallicPhase needs at least one line phase")
+
+    @property
+    @cache
+    def _connections(self):
+        """``(concentrations, phases)`` of the connection points, sorted by ``c``."""
+        c = np.array([p.line_concentration for p in self.phases], dtype=float)
+        f = np.array([p.line_free_energy(self.T_low) for p in self.phases], dtype=float)
+        order = np.lexsort((f, c))  # by concentration, then free energy
+        c, phases = c[order], [self.phases[i] for i in order]
+        keep = _lower_hull(c, f[order])
+        return c[keep], [phases[i] for i in keep]
+
+    @property
+    def connection_concentrations(self):
+        """Concentrations of the stable compounds that anchor the segments."""
+        return self._connections[0]
+
+    def free_energy(self, T, c):
+        """Piecewise free energy ``f(c, T)`` (tie line minus segment entropy)."""
+        cs, phases = self._connections
+        f = np.array([p.line_free_energy(T) for p in phases], dtype=float)
+        c = np.asarray(c, dtype=float)
+        if len(cs) == 1:
+            return _scalarize(np.where(c == cs[0], f[0], np.nan))
+        s = np.clip(np.searchsorted(cs, c, side="right") - 1, 0, len(cs) - 2)
+        ca, cb, fa, fb = cs[s], cs[s + 1], f[s], f[s + 1]
+        x = (c - ca) / (cb - ca)
+        # clip only the entropy argument so out-of-range c extends the edge line
+        fe = fa + (fb - fa) * x - T * (cb - ca) * S(np.clip(x, 0.0, 1.0))
+        return _scalarize(fe)
+
+    def _solve_fixed_T(self, T, dmu):
+        """Minimise ``f(c) - dmu*c`` for one ``T`` over a whole ``dmu`` array.
+
+        Each segment is a scaled ideal solution with an analytic minimum, so the
+        solve is one vectorised evaluation per segment plus an ``argmin`` over
+        segments -- no optimiser, exact to machine precision.
+        """
+        cs, phases = self._connections
+        f = np.array([p.line_free_energy(T) for p in phases], dtype=float)
+        dmu = np.asarray(dmu, dtype=float)
+        flat = dmu.ravel()
+
+        if len(cs) == 1:
+            phi = f[0] - flat * cs[0]
+            c = np.full_like(flat, cs[0])
+            return phi.reshape(dmu.shape), c.reshape(dmu.shape)
+
+        ca, cb, fa, fb = cs[:-1], cs[1:], f[:-1], f[1:]
+        L = cb - ca
+        g = (fb - fa) / L  # segment slope: dmu where the two endpoints are degenerate
+        kT = kB * T
+
+        z = (g[:, None] - flat[None, :]) / kT
+        c_seg = ca[:, None] + L[:, None] * expit(-z)
+        # log(1 + exp(-z)) via logaddexp keeps the saturated tails stable
+        phi_seg = fa[:, None] - flat[None, :] * ca[:, None] - kT * L[:, None] * np.logaddexp(0.0, -z)
+
+        best = phi_seg.argmin(axis=0)[None, :]
+        phi = np.take_along_axis(phi_seg, best, axis=0)[0]
+        c = np.take_along_axis(c_seg, best, axis=0)[0]
+        return phi.reshape(dmu.shape), c.reshape(dmu.shape)
+
+    def _find_phi_c(self, T, dmu):
+        T = np.asarray(T, dtype=float)
+        dmu = np.asarray(dmu, dtype=float)
+        out_shape = np.broadcast_shapes(T.shape, dmu.shape)
+        if T.ndim == 0:
+            phi, c = self._solve_fixed_T(float(T), dmu)
+            phi = np.broadcast_to(phi, out_shape).copy()
+            c = np.broadcast_to(c, out_shape).copy()
+        else:
+            # each distinct T reuses its own connection free energies
+            Tb = np.broadcast_to(T, out_shape)
+            mub = np.broadcast_to(dmu, out_shape)
+            phi = np.empty(out_shape)
+            c = np.empty(out_shape)
+            for uT in np.unique(Tb):
+                m = Tb == uT
+                phi[m], c[m] = self._solve_fixed_T(float(uT), mub[m])
+        return _scalarize(phi), _scalarize(c)
+
+    def semigrand_potential(self, T, dmu):
+        return self._find_phi_c(T, dmu)[0]
+
+    def concentration(self, T, dmu):
+        return self._find_phi_c(T, dmu)[1]

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -1211,19 +1211,19 @@ def test_check_concentration_interpolation_error_respects_add_entropy():
 
 # --- IntermetallicPhase tests ---
 
-# IntermetallicPhase solves min_c [f(c) - dmu*c] with f piecewise (tie line minus
-# segment ideal entropy). Each segment is a scaled ideal solution with a closed
-# form, so phi and c are exact (machine precision) rather than gridded.
+# IntermetallicPhase is a chain of independent ideal-solution segments over the
+# low-T convex hull, summed (not min'd) so the semigrand potential is smooth and
+# mu-native: phi(dmu) / c(dmu) in closed form with c = -dphi/dmu exact.
 _IM_ATOL = 1e-10
 
 
 def _intermetallic():
-    """Five stable compounds spanning [0, 1] with a clear convex hull."""
+    """Five stable compounds spanning [0, 1] (monotone hull slopes -> none dropped)."""
     return IntermetallicPhase("im", [
         LinePhase("A", 0.0, -2.00, 1.0 * kB),
         LinePhase("AB3", 0.25, -2.60, 1.2 * kB),
         LinePhase("AB", 0.50, -2.80, 1.3 * kB),
-        LinePhase("A3B", 0.70, -2.55, 1.2 * kB),
+        LinePhase("A3B", 0.70, -2.95, 1.2 * kB),
         LinePhase("B", 1.0, -3.00, 1.5 * kB),
     ])
 
@@ -1233,8 +1233,13 @@ def test_intermetallic_empty_raises():
         IntermetallicPhase("im", [])
 
 
+def test_intermetallic_keeps_all_stable_compounds():
+    """The fixture's compounds have monotone hull slopes, so none are dropped."""
+    assert_allclose(_intermetallic().connection_concentrations, [0.0, 0.25, 0.5, 0.7, 1.0])
+
+
 def test_intermetallic_single_segment_equals_ideal_solution():
-    """A single 0->1 segment reproduces IdealSolution exactly (entropy scaling)."""
+    """A single 0->1 segment reproduces IdealSolution exactly (length scaling)."""
     A = LinePhase("A", 0.0, -2.0, 1.0 * kB)
     B = LinePhase("B", 1.0, -3.0, 1.5 * kB)
     ideal = IdealSolution("id", A, B)
@@ -1265,27 +1270,6 @@ def test_intermetallic_drops_collinear_compound():
         LinePhase("B", 1.0, -1.0),
     ])
     assert_allclose(phase.connection_concentrations, [0.0, 1.0])
-
-
-def test_intermetallic_segment_entropy_vanishes_at_connection_points():
-    """free_energy at a connection point equals the reused compound free energy."""
-    phase = _intermetallic()
-    cs, comps = phase._connections
-    for T in (100.0, 900.0):
-        expect = np.array([p.line_free_energy(T) for p in comps])
-        assert_allclose(phase.free_energy(T, cs), expect, atol=1e-12)
-
-
-def test_intermetallic_free_energy_below_tie_line_at_finite_T():
-    """Between connection points the segment entropy lowers f below the tie line."""
-    phase = _intermetallic()
-    T = 1000.0
-    cs, comps = phase._connections
-    f = np.array([p.line_free_energy(T) for p in comps])
-    # midpoint of the first segment
-    cmid = 0.5 * (cs[0] + cs[1])
-    chord = 0.5 * (f[0] + f[1])
-    assert phase.free_energy(T, cmid) < chord
 
 
 def test_intermetallic_scalar_contract():
@@ -1332,27 +1316,12 @@ def test_intermetallic_saturates_at_terminal_compounds():
     assert_allclose(phase.concentration(600.0, +50.0), cs[-1], atol=1e-9)
 
 
-@pytest.mark.parametrize("T", [400.0, 900.0])
-def test_intermetallic_matches_dense_brute_minimum(T):
-    """phi and c equal the global minimum of the piecewise f(c) on a dense grid."""
-    phase = _intermetallic()
-    cs = phase.connection_concentrations
-    dmu = np.linspace(-7.0, 7.0, 121)
-    cc = np.linspace(cs[0], cs[-1], 200001)
-    val = phase.free_energy(T, cc)[:, None] - dmu[None, :] * cc[:, None]
-    i = val.argmin(axis=0)
-    gphi = val[i, np.arange(val.shape[1])]
-    assert_allclose(np.asarray(phase.semigrand_potential(T, dmu)), gphi, atol=1e-6)
-    assert_allclose(np.asarray(phase.concentration(T, dmu)), cc[i], atol=2e-5)
-
-
 @pytest.mark.parametrize("T", [300.0, 1100.0])
 def test_intermetallic_gibbs_duhem_exact(T):
-    """c = -d(phi)/d(dmu) to machine precision from the analytic closed form.
+    """c = -d(phi)/d(dmu) to machine precision: phi/c are the analytic Legendre pair.
 
-    The per-segment minimum is analytic, so an exact (small-step) finite
-    difference of phi recovers the concentration far below grid tolerance; only
-    the FD step itself limits the comparison.
+    A small-step finite difference of phi recovers c far below grid tolerance;
+    only the FD step itself limits the comparison.
     """
     phase = _intermetallic()
     dmu = np.linspace(-6.0, 6.0, 60)
@@ -1360,6 +1329,50 @@ def test_intermetallic_gibbs_duhem_exact(T):
     dphi = (np.asarray(phase.semigrand_potential(T, dmu + h))
             - np.asarray(phase.semigrand_potential(T, dmu - h))) / (2 * h)
     assert_allclose(-dphi, np.asarray(phase.concentration(T, dmu)), atol=1e-6)
+
+
+@pytest.mark.parametrize("T", [400.0, 1800.0])
+def test_intermetallic_smooth_no_jumps(T):
+    """No concentration jumps: even a coarse-grid gradient of phi recovers c.
+
+    Summing the segments gives a C-infinity phi; a hard min over segments would
+    switch argmin and jump c, which np.gradient would expose as a large residual.
+    """
+    phase = _intermetallic()
+    dmu = np.linspace(-10.0, 10.0, 8000)
+    phi = np.asarray(phase.semigrand_potential(T, dmu))
+    c = np.asarray(phase.concentration(T, dmu))
+    assert np.abs(np.diff(c)).max() < 0.03
+    assert_allclose(-np.gradient(phi, dmu)[5:-5], c[5:-5], atol=1e-3)
+
+
+def test_intermetallic_interior_compounds_form_plateaus():
+    """At low T each interior compound is realized as a stable phase (a c plateau)."""
+    phase = _intermetallic()
+    cs = phase.connection_concentrations
+    dmu = np.linspace(-10.0, 10.0, 40001)
+    c = np.asarray(phase.concentration(300.0, dmu))
+    for cp in cs[1:-1]:
+        assert np.min(np.abs(c - cp)) < 1e-3
+
+
+def test_intermetallic_segment_decouples_deep_in_a_segment():
+    """Deep inside a segment the phase matches the isolated two-compound sub-phase.
+
+    Well below the next segment's slope only the local segment is active, so a
+    three-compound phase reduces there to its lone left segment -- the property
+    that gives each segment its own length-scaled entropy.
+    """
+    A = LinePhase("A", 0.0, 0.0)
+    mid = LinePhase("mid", 0.5, -0.5)
+    B = LinePhase("B", 1.0, -0.6)
+    full = IntermetallicPhase("full", [A, mid, B])
+    left = IntermetallicPhase("left", [A, mid])      # the isolated A-mid segment
+    # left slope -1.0, right slope -0.2; stay well below -0.2 so the right segment is dormant
+    dmu = np.linspace(-2.5, -0.6, 50)
+    T = 300.0
+    assert_allclose(full.semigrand_potential(T, dmu), left.semigrand_potential(T, dmu), atol=1e-4)
+    assert_allclose(full.concentration(T, dmu), left.concentration(T, dmu), atol=1e-4)
 
 
 def test_intermetallic_connection_temperature_changes_hull():

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -11,7 +11,16 @@ from scipy.constants import Boltzmann, eV
 
 from landau.interpolate import PolyFit, SGTE
 from landau.interpolate.basic import G_calphad
-from landau.phases import IdealSolution, InterpolatingPhase, LinePhase, RegularSolution, SlowInterpolatingPhase, FastInterpolatingPhase, TemperatureDependentLinePhase
+from landau.phases import (
+    IdealSolution,
+    InterpolatingPhase,
+    IntermetallicPhase,
+    LinePhase,
+    RegularSolution,
+    SlowInterpolatingPhase,
+    FastInterpolatingPhase,
+    TemperatureDependentLinePhase,
+)
 from landau.phases.pointdefects import (
     AbstractPointDefectSublattice,
     ConstantPointDefect,
@@ -1198,3 +1207,170 @@ def test_check_concentration_interpolation_error_respects_add_entropy():
         assert_allclose(off[:, 1], expected[order], atol=ERR_ATOL)
     finally:
         plt.close(fig)
+
+
+# --- IntermetallicPhase tests ---
+
+# IntermetallicPhase solves min_c [f(c) - dmu*c] with f piecewise (tie line minus
+# segment ideal entropy). Each segment is a scaled ideal solution with a closed
+# form, so phi and c are exact (machine precision) rather than gridded.
+_IM_ATOL = 1e-10
+
+
+def _intermetallic():
+    """Five stable compounds spanning [0, 1] with a clear convex hull."""
+    return IntermetallicPhase("im", [
+        LinePhase("A", 0.0, -2.00, 1.0 * kB),
+        LinePhase("AB3", 0.25, -2.60, 1.2 * kB),
+        LinePhase("AB", 0.50, -2.80, 1.3 * kB),
+        LinePhase("A3B", 0.70, -2.55, 1.2 * kB),
+        LinePhase("B", 1.0, -3.00, 1.5 * kB),
+    ])
+
+
+def test_intermetallic_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        IntermetallicPhase("im", [])
+
+
+def test_intermetallic_single_segment_equals_ideal_solution():
+    """A single 0->1 segment reproduces IdealSolution exactly (entropy scaling)."""
+    A = LinePhase("A", 0.0, -2.0, 1.0 * kB)
+    B = LinePhase("B", 1.0, -3.0, 1.5 * kB)
+    ideal = IdealSolution("id", A, B)
+    inter = IntermetallicPhase("im", [A, B])
+    dmu = np.linspace(-3.0, 3.0, 41)
+    for T in (300.0, 800.0, 1500.0):
+        assert_allclose(inter.semigrand_potential(T, dmu), ideal.semigrand_potential(T, dmu), atol=_IM_ATOL)
+        assert_allclose(inter.concentration(T, dmu), ideal.concentration(T, dmu), atol=_IM_ATOL)
+
+
+def test_intermetallic_drops_metastable_compound():
+    """A compound above the tie line of its neighbours is not a connection point."""
+    phase = IntermetallicPhase("im", [
+        LinePhase("A", 0.0, 0.0),
+        LinePhase("m1", 0.25, -0.3),
+        LinePhase("bad", 0.5, 0.5),   # sits well above the m1-m2 chord
+        LinePhase("m2", 0.75, -0.3),
+        LinePhase("B", 1.0, 0.0),
+    ])
+    assert_allclose(phase.connection_concentrations, [0.0, 0.25, 0.75, 1.0])
+
+
+def test_intermetallic_drops_collinear_compound():
+    """A compound exactly on a tie line is absorbed into the segment, not a kink."""
+    phase = IntermetallicPhase("im", [
+        LinePhase("A", 0.0, 0.0),
+        LinePhase("mid", 0.5, -0.5),   # on the straight line from (0,0) to (1,-1)
+        LinePhase("B", 1.0, -1.0),
+    ])
+    assert_allclose(phase.connection_concentrations, [0.0, 1.0])
+
+
+def test_intermetallic_segment_entropy_vanishes_at_connection_points():
+    """free_energy at a connection point equals the reused compound free energy."""
+    phase = _intermetallic()
+    cs, comps = phase._connections
+    for T in (100.0, 900.0):
+        expect = np.array([p.line_free_energy(T) for p in comps])
+        assert_allclose(phase.free_energy(T, cs), expect, atol=1e-12)
+
+
+def test_intermetallic_free_energy_below_tie_line_at_finite_T():
+    """Between connection points the segment entropy lowers f below the tie line."""
+    phase = _intermetallic()
+    T = 1000.0
+    cs, comps = phase._connections
+    f = np.array([p.line_free_energy(T) for p in comps])
+    # midpoint of the first segment
+    cmid = 0.5 * (cs[0] + cs[1])
+    chord = 0.5 * (f[0] + f[1])
+    assert phase.free_energy(T, cmid) < chord
+
+
+def test_intermetallic_scalar_contract():
+    phase = _intermetallic()
+    phi = phase.semigrand_potential(700.0, 0.1)
+    c = phase.concentration(700.0, 0.1)
+    assert not isinstance(phi, np.ndarray)
+    assert not isinstance(c, np.ndarray)
+    assert 0.0 <= float(c) <= 1.0
+
+
+def test_intermetallic_array_dmu_shape():
+    phase = _intermetallic()
+    dmu = np.linspace(-6.0, 6.0, 23)
+    assert phase.semigrand_potential(700.0, dmu).shape == (23,)
+    c = phase.concentration(700.0, dmu)
+    assert c.shape == (23,)
+    assert np.all((c >= 0.0) & (c <= 1.0))
+
+
+def test_intermetallic_array_T_shape():
+    phase = _intermetallic()
+    T = np.array([300.0, 700.0, 1200.0])
+    assert phase.semigrand_potential(T, 0.2).shape == (3,)
+    assert phase.concentration(T, 0.2).shape == (3,)
+
+
+def test_intermetallic_concentration_monotone_and_bounded():
+    """c(dmu) is non-decreasing and stays within the connection-point span."""
+    phase = _intermetallic()
+    cs = phase.connection_concentrations
+    dmu = np.linspace(-8.0, 8.0, 161)
+    c = np.asarray(phase.concentration(900.0, dmu))
+    assert np.all(np.diff(c) >= -1e-12)
+    assert c.min() >= cs[0] - 1e-12
+    assert c.max() <= cs[-1] + 1e-12
+
+
+def test_intermetallic_saturates_at_terminal_compounds():
+    """Far-negative/positive dmu pin c to the extreme connection concentrations."""
+    phase = _intermetallic()
+    cs = phase.connection_concentrations
+    assert_allclose(phase.concentration(600.0, -50.0), cs[0], atol=1e-9)
+    assert_allclose(phase.concentration(600.0, +50.0), cs[-1], atol=1e-9)
+
+
+@pytest.mark.parametrize("T", [400.0, 900.0])
+def test_intermetallic_matches_dense_brute_minimum(T):
+    """phi and c equal the global minimum of the piecewise f(c) on a dense grid."""
+    phase = _intermetallic()
+    cs = phase.connection_concentrations
+    dmu = np.linspace(-7.0, 7.0, 121)
+    cc = np.linspace(cs[0], cs[-1], 200001)
+    val = phase.free_energy(T, cc)[:, None] - dmu[None, :] * cc[:, None]
+    i = val.argmin(axis=0)
+    gphi = val[i, np.arange(val.shape[1])]
+    assert_allclose(np.asarray(phase.semigrand_potential(T, dmu)), gphi, atol=1e-6)
+    assert_allclose(np.asarray(phase.concentration(T, dmu)), cc[i], atol=2e-5)
+
+
+@pytest.mark.parametrize("T", [300.0, 1100.0])
+def test_intermetallic_gibbs_duhem_exact(T):
+    """c = -d(phi)/d(dmu) to machine precision from the analytic closed form.
+
+    The per-segment minimum is analytic, so an exact (small-step) finite
+    difference of phi recovers the concentration far below grid tolerance; only
+    the FD step itself limits the comparison.
+    """
+    phase = _intermetallic()
+    dmu = np.linspace(-6.0, 6.0, 60)
+    h = 1e-6
+    dphi = (np.asarray(phase.semigrand_potential(T, dmu + h))
+            - np.asarray(phase.semigrand_potential(T, dmu - h))) / (2 * h)
+    assert_allclose(-dphi, np.asarray(phase.concentration(T, dmu)), atol=1e-6)
+
+
+def test_intermetallic_connection_temperature_changes_hull():
+    """T_low picks which compounds are stable; entropy can re-rank the hull."""
+    # 'x' is below the A-B chord only once its larger entropy kicks in at high T
+    phases = [
+        LinePhase("A", 0.0, -1.0, 0.0),
+        LinePhase("x", 0.5, -0.5, 5.0 * kB),
+        LinePhase("B", 1.0, -1.0, 0.0),
+    ]
+    cold = IntermetallicPhase("cold", phases, T_low=10.0)
+    hot = IntermetallicPhase("hot", phases, T_low=2000.0)
+    assert_allclose(cold.connection_concentrations, [0.0, 1.0])
+    assert_allclose(hot.connection_concentrations, [0.0, 0.5, 1.0])


### PR DESCRIPTION
A new phase for intermetallics: a set of stoichiometric compounds whose free energy is piecewise linear at low temperature and rounds off as configurational entropy lifts along each segment with temperature. Like `InterpolatingPhase` it is given line-phase free energies sampled across the concentration axis, but instead of fitting one smooth curve it keeps the compounds as the structure of the surface.

## Model

Given line-phase free energies sampled across the concentration axis:

- **Connection points.** At `T_low` the lower convex hull of the `(c, f)` points is taken; its vertices are the stable compounds (the kinks of the piecewise-linear low-T curve). Compounds above the hull are metastable and dropped — this is required for correctness, not cosmetics: an off-hull compound has out-of-order segment slopes and would otherwise plant a spurious stable phase below the true hull. The connection free energies are reused verbatim at every `T`, so the compounds follow whatever temperature dependence the line phases carry (e.g. SGTE).
- **Segments.** Each segment between adjacent connection points `c_k`, `c_{k+1}` is an ideal solution between its two compounds, with `L_k = c_{k+1} - c_k` exchange sites per atom and slope `s_k = (g_{k+1} - g_k) / L_k`. The site count scales with the segment length, so a short segment carries little entropy.
- **Semi-grand potential (mu-native).** The segments fill *independently* and their contributions are **summed**, not minimised — so there is no hard `min` to switch between segments, hence no cusp and no jumps. Written directly in chemical-potential space (no `f(c)` curve is built and re-transformed):

  ```
  phi(dmu) = g_0 - dmu*c_0 - kT * Σ_k L_k * log(1 + exp((dmu - s_k)/kT))
  c(dmu)   =       c_0      +        Σ_k L_k * sigmoid((dmu - s_k)/kT)
  ```

  The smoothing scale is `kT`: piecewise linear at low T (each compound stable over a `mu` window), rounding off as T rises. `c = -∂phi/∂dmu` holds exactly, `c` stays within `[c_0, c_N]` (saturating at the terminal compounds), and a single `[0, 1]` segment reproduces `IdealSolution` exactly.

## Why summed segments (vs the first cut)

The first revision minimised `f(c) - dmu*c` with `f` piecewise (tie line minus length-scaled segment entropy). That `f(c)` has infinite-slope cusps at every compound, because the per-segment entropy is forced to zero there. Those cusps are concave kinks, so the semigrand `min` skips across them with two-phase tie-lines and the intermediate compounds were silently dropped from the diagram. Summing independent segments instead removes the cusps, keeps every compound as a stable phase, and is exactly `-∂phi/∂dmu`-consistent.

## Verification

- Single `0→1` segment matches `IdealSolution` for `phi` and `c` to `1e-10` across T and dmu.
- Gibbs–Duhem `c = -∂phi/∂dmu` to `1e-6` (limited by the finite-difference step), and a coarse-grid `np.gradient` of `phi` matches `c` to `1e-3` — i.e. no jumps.
- Each interior compound is realized as a `c` plateau at low T.
- Deep inside a segment the phase reduces to the isolated two-compound sub-phase (the length-scaling property).
- Convex-hull selection drops a compound above its neighbours' tie line and one exactly on a tie line; `T_low` can re-rank the hull.

## Files

- `landau/phases/intermetallic.py` — `IntermetallicPhase` (new module, sibling to `pointdefects.py`).
- Re-exported from `landau/__init__.py` and `landau/phases/__init__.py`.
- `tests/unit/test_phases.py` — `IntermetallicPhase` test block (17 tests).

## Open for review

- **Name.** `IntermetallicPhase` names the use case; mechanically it is a summed chain of ideal-solution segments over the convex hull.
- **`T_low` default** is `0.0` (the ground-state hull; `G_calphad` is well-defined there), exposed as a field since which compounds are stable can depend on the chosen low temperature.
- The phase is mu-native and exposes only `semigrand_potential`/`concentration` (no `f(c)` method), matching `IdealSolution`; the free-energy curve is the Legendre transform of the closed-form `phi(dmu)` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)