### PR TITLE
refactor(interpolate): simplify softplus surface fit internals

### DIFF
--- a/landau/interpolate/softplus.py
+++ b/landau/interpolate/softplus.py
@@ -1,6 +1,5 @@
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 import scipy
@@ -34,6 +33,82 @@ def _sigmoid(t):
     return out
 
 
+def _softplus_inv(a):
+    """Inverse of softplus: ``alpha`` such that ``softplus(alpha) = a`` (``a > 0``).
+
+    Uses ``alpha = a + log1p(-exp(-a))`` rather than ``log(expm1(a))`` so it stays
+    finite for large ``a`` (where ``softplus`` is ~identity) instead of
+    overflowing ``expm1``.
+    """
+    a = np.maximum(np.asarray(a, float), 1e-12)
+    return a + np.log1p(-np.exp(-a))
+
+
+# --------------------------------------------------------------------------- #
+# Fixed-T softplus model:  offset + sum_i a_i * softplus(b_i * (cn + c_i)).
+# The single shared evaluation used by SoftplusFit, the per-slice seed fit, and
+# the fitted surface slice -- value, c-derivative, and parameter Jacobian.
+# --------------------------------------------------------------------------- #
+def _terms(cn, a, b, c, offset):
+    """Evaluate the softplus model on the normalised grid ``cn``."""
+    out = np.full(np.shape(cn), offset, float)
+    for ai, bi, ci in zip(a, b, c):
+        out = out + ai * _softplus(bi * (cn + ci))
+    return out
+
+
+def _terms_dc(cn, a, b, c):
+    """``d/dcn`` of the softplus model (the offset drops out)."""
+    out = np.zeros(np.shape(cn), float)
+    for ai, bi, ci in zip(a, b, c):
+        out = out + ai * _sigmoid(bi * (cn + ci)) * bi
+    return out
+
+
+def _terms_jac(cn, a, b, c):
+    """Jacobian wrt the flat ``[a_i, b_i, c_i]*n + [offset]`` parameter vector.
+
+    For one term ``a*softplus(b*(cn+c))`` with ``t = b*(cn+c)``:
+    ``d/da = softplus(t)``, ``d/db = a*sigmoid(t)*(cn+c)``, ``d/dc = a*sigmoid(t)*b``;
+    the offset contributes a column of ones.
+    """
+    n = len(a)
+    J = np.empty((cn.size, 3 * n + 1))
+    for i in range(n):
+        u = cn + c[i]
+        t = b[i] * u
+        sig = _sigmoid(t)
+        J[:, 3 * i] = _softplus(t)
+        J[:, 3 * i + 1] = a[i] * sig * u
+        J[:, 3 * i + 2] = a[i] * sig * b[i]
+    J[:, -1] = 1.0
+    return J
+
+
+def _flat(a, b, c, offset):
+    """Pack per-term ``(a, b, c)`` plus the offset into ``[a_0,b_0,c_0, ..., offset]``."""
+    return np.concatenate([np.ravel(np.column_stack([a, b, c])), [offset]])
+
+
+def _split(p, n):
+    """Inverse of :func:`_flat`: the ``(a, b, c, offset)`` of a flat slice vector."""
+    return p[0:3 * n:3], p[1:3 * n:3], p[2:3 * n:3], p[-1]
+
+
+def _fit_softplus(cn, y, p0, bounds, *, loss="linear", f_scale=1.0, max_nfev, x_scale=1.0):
+    """Bounded trust-region least-squares fit of the softplus sum (:func:`_terms`) to
+    ``(cn, y)`` from seed ``p0`` (clipped into ``bounds``).  The single solver shared
+    by :meth:`SoftplusFit.fit` and the surface seed fit :func:`_fit_slice`; they
+    differ only in how they build the seed and bounds.  Returns the scipy result,
+    whose ``x`` is the flat ``[a, b, c]*n + [offset]`` vector."""
+    n = (len(p0) - 1) // 3
+    return least_squares(
+        lambda p: _terms(cn, *_split(p, n)) - y, np.clip(p0, *bounds),
+        jac=lambda p: _terms_jac(cn, *_split(p, n)[:3]),
+        bounds=bounds, loss=loss, f_scale=f_scale, max_nfev=max_nfev, x_scale=x_scale,
+    )
+
+
 @dataclass(frozen=True, eq=True)
 class SoftplusFit(ConcentrationInterpolator, TemperatureInterpolator):
     """
@@ -60,115 +135,40 @@ class SoftplusFit(ConcentrationInterpolator, TemperatureInterpolator):
     the full residual range, equivalent to ``loss='linear'``.  Has no effect
     when ``loss='linear'``."""
 
-    def _prepare(self, x, y):
-        """Set up normalization, model, Jacobian, bounds and initial guess.
+    def _seed(self, xn, y):
+        """Initial parameter vector ``p0`` and bounds ``(lo, hi)`` for the local fit.
 
-        Returns ``(xn, y, model, jac, p0, lb, ub, xm, xs)``.
+        ``a_guess`` is the full peak-to-peak range of ``y`` rather than
+        ``ptp/(2*n)``: amplitudes large enough to actually reach the data keep the
+        optimizer out of the wide near-constant basin that ``soft_l1`` opens up
+        around small ``a`` (PR #82).  The bound on ``a`` is open above, so
+        over-estimating is harmless — the optimizer trims it.
         """
-        x = np.asarray(x, float)
-        y = np.asarray(y, float)
-
-        xm = x.mean()
-        xs = x.std() if x.std() > 0 else 1.0
-        xn = (x - xm) / xs
-
         n = self.n_softplus
-
-        def model(xn_, p):
-            out = np.full_like(xn_, p[-1], dtype=float)
-            for i in range(n):
-                a = p[3 * i]
-                b = p[3 * i + 1]
-                c = p[3 * i + 2]
-                out = out + a * _softplus(b * (xn_ + c))
-            return out
-
-        # Analytical Jacobian of residuals w.r.t. parameters.
-        # For one term  a * softplus(b*(xn+c)), with t = b*(xn+c):
-        #   d/da = softplus(t)
-        #   d/db = a * sigmoid(t) * (xn + c)
-        #   d/dc = a * sigmoid(t) * b
-        # The vertical offset contributes a column of ones.
-        def jac(p):
-            J = np.empty((xn.size, 3 * n + 1), dtype=float)
-            for i in range(n):
-                a = p[3 * i]
-                b = p[3 * i + 1]
-                c = p[3 * i + 2]
-                u = xn + c
-                t = b * u
-                sig = _sigmoid(t)
-                J[:, 3 * i] = _softplus(t)
-                J[:, 3 * i + 1] = a * sig * u
-                J[:, 3 * i + 2] = a * sig * b
-            J[:, -1] = 1.0
-            return J
-
-        # Initial guess.  ``a_guess`` is set to the full peak-to-peak range of
-        # ``y`` rather than ``ptp/(2*n)``: starting with amplitudes that are
-        # large enough to actually reach the data prevents the optimizer from
-        # collapsing into the wide near-constant basin that ``soft_l1`` opens
-        # up around small ``a`` (see PR #82).  The bound on ``a`` is open
-        # above, so over-estimating is harmless — the optimizer trims it.
         ptp = float(np.ptp(y))
-        offset = float(np.median(y))
         a_guess = ptp if ptp > 0 else 1.0
-        p0 = []
-        for i in range(n):
-            frac = (i + 0.5) / n
-            knee = float(np.quantile(xn, frac))
-            b_guess = 3.0 if (i % 2 == 0) else -3.0
-            p0 += [a_guess, b_guess, -knee]
-        p0 += [offset]
-        p0 = np.array(p0, dtype=float)
-
-        lb, ub = [], []
-        for _ in range(n):
-            lb += [0.0, -20.0, -10.0]
-            ub += [np.inf, 20.0, 10.0]
-        lb += [-np.inf]
-        ub += [np.inf]
-        return xn, y, model, jac, p0, lb, ub, xm, xs
-
-    def _least_squares(self, xn, y, model, jac, p0, lb, ub):
-        def resid(p):
-            return model(xn, p) - y
-
-        return least_squares(
-            resid,
-            p0,
-            jac=jac,
-            bounds=(lb, ub),
-            loss=self.loss,
-            f_scale=self.f_scale,
-            max_nfev=self.max_nfev,
-        )
-
-    @staticmethod
-    def _make_predictor(model, popt, xm, xs):
-        def predictor(x_new):
-            x_new = np.asarray(x_new, float)
-            xn_new = (x_new - xm) / xs
-            return model(xn_new, popt)
-
-        return predictor
+        knees = [float(np.quantile(xn, (i + 0.5) / n)) for i in range(n)]
+        slopes = [3.0 if i % 2 == 0 else -3.0 for i in range(n)]
+        p0 = _flat([a_guess] * n, slopes, [-k for k in knees], float(np.median(y)))
+        lo = _flat(np.zeros(n), np.full(n, -20.0), np.full(n, -10.0), -np.inf)
+        hi = _flat(np.full(n, np.inf), np.full(n, 20.0), np.full(n, 10.0), np.inf)
+        return p0, lo, hi
 
     def fit(self, x, y) -> Interpolation:
         """Local nonlinear least-squares fit with analytical Jacobian."""
-        xn, y, model, jac, p0, lb, ub, xm, xs = self._prepare(x, y)
-        res = self._least_squares(xn, y, model, jac, p0, lb, ub)
-        return _CallableInterpolation(self._make_predictor(model, res.x, xm, xs))
+        x = np.asarray(x, float)
+        y = np.asarray(y, float)
+        shift = float(x.mean())
+        scale = float(x.std()) if x.std() > 0 else 1.0
+        xn = (x - shift) / scale
+        n = self.n_softplus
 
-
-def _softplus_inv(a):
-    """Inverse of softplus: ``alpha`` such that ``softplus(alpha) = a`` (``a > 0``).
-
-    Uses ``alpha = a + log1p(-exp(-a))`` rather than ``log(expm1(a))`` so it stays
-    finite for large ``a`` (where ``softplus`` is ~identity) instead of
-    overflowing ``expm1``.
-    """
-    a = np.maximum(np.asarray(a, float), 1e-12)
-    return a + np.log1p(-np.exp(-a))
+        p0, lo, hi = self._seed(xn, y)
+        popt = _fit_softplus(xn, y, p0, (lo, hi),
+                             loss=self.loss, f_scale=self.f_scale, max_nfev=self.max_nfev).x
+        return _CallableInterpolation(
+            lambda x_new: _terms((np.asarray(x_new, float) - shift) / scale, *_split(popt, n))
+        )
 
 
 def _standardize(x):
@@ -202,12 +202,8 @@ class _SoftplusSlice(Interpolation):
     cs: float
 
     def __call__(self, c):
-        c_arr = np.asarray(c, float)
-        cn = (c_arr - self.cm) / self.cs
-        out = np.full(c_arr.shape, self.offset, float)
-        for ai, bi, ci in zip(self.a, self.b, self.c):
-            out = out + ai * _softplus(bi * (cn + ci))
-        return _scalarize(out)
+        cn = (np.asarray(c, float) - self.cm) / self.cs
+        return _scalarize(_terms(cn, self.a, self.b, self.c, self.offset))
 
     def deriv(self) -> Interpolation:
         # d/dc [ a*softplus(b*(cn + c)) ] = a*sigmoid(b*(cn+c))*b * d(cn)/dc,
@@ -215,39 +211,10 @@ class _SoftplusSlice(Interpolation):
         a, b, c, cm, cs = self.a, self.b, self.c, self.cm, self.cs
 
         def dfdc(cc):
-            cc_arr = np.asarray(cc, float)
-            cn = (cc_arr - cm) / cs
-            out = np.zeros(cc_arr.shape, float)
-            for ai, bi, ci in zip(a, b, c):
-                out = out + ai * _sigmoid(bi * (cn + ci)) * bi / cs
-            return _scalarize(out)
+            cn = (np.asarray(cc, float) - cm) / cs
+            return _scalarize(_terms_dc(cn, a, b, c) / cs)
 
         return _CallableInterpolation(dfdc)
-
-
-_BMAX = 200.0
-"""Magnitude bound on the (normalised) slope during the per-slice seed fit.
-
-A redundant softplus term is unconstrained in a flat direction and would otherwise
-drift to infinity; the bound keeps every seed finite without touching the genuine
-sharpness range the data needs."""
-
-_SEED_MAX_NFEV = 300
-"""Iteration cap for the per-slice seed fits (:func:`_fit_slice`).
-
-The seed only has to start the coupled fit in the right basin, not converge
-deeply.  Past a few hundred iterations the extra polish does not improve the
-final coupled fit -- and on a sharp slice can mildly worsen it, by handing the
-coupled solve an extreme constant-in-T start it then has to spread back out --
-while a hard slice would otherwise grind a single seed all the way to
-``max_nfev``.  Capping the seed keeps it cheap without affecting (often slightly
-improving) the fitted surface."""
-
-_SEED_RACE_NFEV = 80
-"""Length of the short coupled polish each seed gets before the better one is
-kept and finished (see :meth:`SoftplusSurface2DInterpolator.fit`).  Long enough
-that the faster-converging seed is clearly ahead, short enough that the loser's
-polish is a small fraction of the winner's full solve."""
 
 
 def _scipy_at_least(major: int, minor: int) -> bool:
@@ -255,19 +222,6 @@ def _scipy_at_least(major: int, minor: int) -> bool:
         return tuple(int(p) for p in scipy.__version__.split(".")[:2]) >= (major, minor)
     except (ValueError, AttributeError):  # unexpected version string -> be conservative
         return False
-
-
-_LM_HAS_INTERNAL_SCALING = _scipy_at_least(1, 16)
-"""Whether ``scipy.optimize.least_squares(method='lm')`` applies MINPACK's
-internal variable scaling.
-
-scipy 1.16 (gh-22790, fixing gh-19459) corrected ``lm`` to default to MINPACK's
-``mode=1`` internal scaling, as plain ``leastsq`` always did; before 1.16 ``lm``
-silently disabled it (``mode=2`` with an all-ones ``diag``) and converged poorly
-on a badly scaled Jacobian -- such as the stiff sharp-knee fit here.  When the
-fix is present the coupled solve uses ``lm`` (no per-iteration SVD, so faster);
-otherwise it uses the trust-region solver with an explicit ``x_scale='jac'``,
-which is robust on every supported scipy but does an SVD each step."""
 
 
 def _knee_position(cn, H):
@@ -304,54 +258,73 @@ def _smoothv_seed(cn, H, n, bb=12.0):
     a = [max(sR / bb, 1e-6), max(sL / bb, 1e-6)] + [1e-4] * (n - 2)
     b = [bb, -bb] + [bb] * (n - 2)
     c = [-c0] * n
-    return np.concatenate([np.ravel(np.column_stack([a, b, c])), [float(np.median(H))]])
+    return _flat(a, b, c, float(np.median(H)))
 
 
-def _slice_model(p, cn, n):
-    a, b, c, off = p[0:3 * n:3], p[1:3 * n:3], p[2:3 * n:3], p[-1]
-    out = np.full(cn.shape, off, float)
-    for ai, bi, ci in zip(a, b, c):
-        out = out + ai * _softplus(bi * (cn + ci))
-    return out
-
-
-def _slice_jac(p, cn, n):
-    a, b, c = p[0:3 * n:3], p[1:3 * n:3], p[2:3 * n:3]
-    J = np.empty((cn.size, 3 * n + 1))
-    for i in range(n):
-        u = cn + c[i]
-        t = b[i] * u
-        sig = _sigmoid(t)
-        J[:, 3 * i] = _softplus(t)
-        J[:, 3 * i + 1] = a[i] * sig * u
-        J[:, 3 * i + 2] = a[i] * sig * b[i]
-    J[:, -1] = 1.0
-    return J
-
-
-def _fit_slice(cn, H, n, max_nfev):
+def _fit_slice(cn, H, n, max_nfev, bmax=200.0):
     """Robust single-slice fit: data-driven smooth-V seed, then a bounded,
-    graduated-sharpness trust-region polish (``x_scale='jac'``).  Returns the
-    per-term ``(a, b, c)`` arrays and the offset.  Used only to seed the coupled
-    surface fit, so two slices (coldest, central) are enough regardless of how
-    many temperatures are sampled."""
+    graduated-sharpness polish via :func:`_fit_softplus` (``x_scale='jac'``).
+    Returns the per-term ``(a, b, c)`` arrays and the offset.  Used only to seed the
+    coupled surface fit, so two slices (coldest, central) are enough regardless of
+    how many temperatures are sampled.
+
+    The convex-well-aware seed (:func:`_smoothv_seed`) and the data-driven knee
+    bounds are what distinguish this from the generic :meth:`SoftplusFit.fit`; both
+    share the same underlying solver.  ``bmax`` bounds the (normalised) slope: a
+    redundant softplus term is unconstrained in a flat direction and would otherwise
+    drift to infinity; the bound keeps every seed finite without touching the
+    sharpness range the data needs."""
     pad = 0.5 * (cn.max() - cn.min())
     klo, khi = -(cn.max() + pad), -(cn.min() - pad)
-    lo = np.array([v for _ in range(n) for v in (0.0, -_BMAX, klo)] + [-np.inf])
-    hi = np.array([v for _ in range(n) for v in (np.inf, _BMAX, khi)] + [np.inf])
-    p0 = np.clip(_smoothv_seed(cn, H, n), lo, hi)
+    bounds = (_flat(np.zeros(n), np.full(n, -bmax), np.full(n, klo), -np.inf),
+              _flat(np.full(n, np.inf), np.full(n, bmax), np.full(n, khi), np.inf))
+    seed = _smoothv_seed(cn, H, n)
+
     best = None
     for scale in (0.4, 1.0):  # graduated sharpness: blunt corners first, then full
-        p = p0.copy()
-        p[1:3 * n:3] = np.clip(p[1:3 * n:3] * scale, lo[1:3 * n:3], hi[1:3 * n:3])
-        res = least_squares(lambda q: _slice_model(q, cn, n) - H, p,
-                            jac=lambda q: _slice_jac(q, cn, n), bounds=(lo, hi),
-                            method="trf", x_scale="jac", max_nfev=max_nfev)
-        if best is None or res.cost < best.cost:
-            best = res
-        p0 = res.x  # warm-start the sharper stage
-    s = best.x
-    return s[0:3 * n:3], s[1:3 * n:3], s[2:3 * n:3], float(s[-1])
+        seed = seed.copy()
+        seed[1:3 * n:3] *= scale
+        res = _fit_softplus(cn, H, seed, bounds, max_nfev=max_nfev, x_scale="jac")
+        best = res if best is None or res.cost < best.cost else best
+        seed = res.x  # warm-start the sharper stage
+
+    a, b, c, off = _split(best.x, n)
+    return a, b, c, float(off)
+
+
+class _CachedResidual:
+    """Residual and Jacobian of one coupled surface solve, sharing a single
+    ``_model_and_jac`` pass per point.  ``least_squares`` calls ``fun(p)`` then
+    ``jac(p)`` at the same ``p`` each iteration, so the per-term
+    ``softplus``/``sigmoid`` (and the ridge toward the seed) are evaluated once.
+    The augmented system stacks a tiny ridge ``ridge*(p - seed)`` under the data
+    residual to pin flat directions; ``solve`` starts from the seed itself.
+    """
+
+    def __init__(self, model_and_jac, cn, vt, f, seed, ridge, eye, solver_kwargs):
+        self._model_and_jac = model_and_jac
+        self._cn, self._vt, self._f = cn, vt, f
+        self._seed, self._ridge, self._eye = seed, ridge, eye
+        self._kwargs = solver_kwargs
+        self._p = None
+
+    def _refresh(self, p):
+        if self._p is None or not np.array_equal(p, self._p):
+            model, J = self._model_and_jac(p, self._cn, self._vt)
+            self._p = p.copy()
+            self._res = np.concatenate([model - self._f, self._ridge * (p - self._seed)])
+            self._jac = np.vstack([J, self._eye])
+
+    def fun(self, p):
+        self._refresh(p)
+        return self._res
+
+    def jac(self, p):
+        self._refresh(p)
+        return self._jac
+
+    def solve(self, max_nfev):
+        return least_squares(self.fun, self._seed, jac=self.jac, max_nfev=max_nfev, **self._kwargs)
 
 
 class SoftplusFittedSurface(FittedSurface):
@@ -377,10 +350,9 @@ class SoftplusFittedSurface(FittedSurface):
         Wn = (1.0 / float(T) - self._wm) / self._ws
         pv = np.polynomial.polynomial.polyval
         a = _softplus(np.array([pv(Tn, row) for row in self._A]))  # non-negative amplitude
-        b = np.array([pv(Wn, row) for row in self._B]) 
+        b = np.array([pv(Wn, row) for row in self._B])             # slope: polynomial in 1/T
         c = np.array([pv(Tn, row) for row in self._C])
-        offset = float(pv(Tn, self._O))
-        return _SoftplusSlice(offset, a, b, c, self._cm, self._cs)
+        return _SoftplusSlice(float(pv(Tn, self._O)), a, b, c, self._cm, self._cs)
 
 
 @dataclass(frozen=True, eq=True)
@@ -421,7 +393,7 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
     many temperatures are sampled (hundreds in practice).
 
     **Solver.**  By default the coupled solve picks its least-squares method by
-    scipy version (see :data:`_LM_HAS_INTERNAL_SCALING`); set :attr:`method` to
+    scipy version (see :attr:`_LM_HAS_INTERNAL_SCALING`); set :attr:`method` to
     ``'lm'`` or ``'trf'`` to override.  scipy 1.16 switched the default variable
     scaling of ``least_squares(method='lm')`` to MINPACK's internal scaling
     (``mode=1``), matching what plain ``leastsq`` always did -- see gh-22790 and
@@ -467,9 +439,28 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
     """Least-squares solver for the coupled fit.  ``None`` (default) picks by
     scipy version: ``'lm'`` on scipy >= 1.16 (faster, no per-iteration SVD) and
     ``'trf'`` on older scipy, where ``'lm'`` lacks variable scaling and converges
-    poorly on stiff data (see :data:`_LM_HAS_INTERNAL_SCALING`).  Force ``'lm'``
+    poorly on stiff data (see :attr:`_LM_HAS_INTERNAL_SCALING`).  Force ``'lm'``
     or ``'trf'`` to override the default; ``'lm'`` requires ``loss='linear'`` and,
     on scipy < 1.16, still converges poorly on sharp-knee data."""
+
+    # --- internal solver tuning (not dataclass fields) ---
+    _SEED_MAX_NFEV: ClassVar[int] = 300
+    """Iteration cap for the per-slice seed fits (:func:`_fit_slice`).  The seed
+    only has to start the coupled fit in the right basin, not converge deeply; past
+    a few hundred iterations the extra polish does not improve (and on a sharp
+    slice can mildly worsen) the final coupled fit, while a hard slice would
+    otherwise grind a single seed all the way to ``max_nfev``."""
+    _SEED_RACE_NFEV: ClassVar[int] = 80
+    """Length of the short coupled polish each seed gets before the better one is
+    kept and finished (see :meth:`fit`).  Long enough that the faster-converging
+    seed is clearly ahead, short enough that the loser's polish is a small fraction
+    of the winner's full solve."""
+    _LM_HAS_INTERNAL_SCALING: ClassVar[bool] = _scipy_at_least(1, 16)
+    """Whether ``least_squares(method='lm')`` applies MINPACK's internal variable
+    scaling.  scipy 1.16 (gh-22790, fixing gh-19459) corrected ``lm`` to default to
+    MINPACK's ``mode=1`` scaling, as plain ``leastsq`` always did; before 1.16
+    ``lm`` silently disabled it (``mode=2``, all-ones ``diag``) and converged poorly
+    on a badly scaled Jacobian -- such as the stiff sharp-knee fit here."""
 
     def __post_init__(self):
         if self.method == "lm" and self.loss != "linear":
@@ -481,60 +472,23 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
     def _orders(self):
         return self.a_order + 1, self.b_order + 1, self.c_order + 1, self.offset_order + 1
 
+    @property
+    def _n_params(self):
+        na, nb, nc, no = self._orders
+        return self.n_softplus * (na + nb + nc) + no
+
     def _unpack(self, p):
         """Split the flat vector into A (n,na), B (n,nb), C (n,nc), O (no,).
 
         ``A`` holds the amplitude *pre-activation* polynomial coefficients:
         ``a_i(T) = softplus(polyval(Tn, A[i]))``.  ``B`` is in 1/T, the rest in T.
+        Terms are laid out contiguously ``[A_i | B_i | C_i]`` then the offset.
         """
         na, nb, nc, no = self._orders
         n = self.n_softplus
         per = na + nb + nc
-        A = np.empty((n, na))
-        B = np.empty((n, nb))
-        C = np.empty((n, nc))
-        for i in range(n):
-            base = i * per
-            A[i] = p[base:base + na]
-            B[i] = p[base + na:base + na + nb]
-            C[i] = p[base + na + nb:base + per]
-        O = p[n * per:]
-        return A, B, C, O
-
-    def _model_and_jac(self, p, cn, vt):
-        """Model values and analytic Jacobian ``d(model)/d(params)`` in one pass.
-
-        The coupled fit evaluates the residual and Jacobian at the same point on
-        every iteration, so the per-term ``softplus``/``sigmoid`` are computed
-        once here and reused for both the value and its derivatives rather than
-        twice by an evaluation that returns only one of them.  ``vt`` carries the
-        Vandermonde of normalised T for a/c/offset and of normalised 1/T for b.
-        """
-        na, nb, nc, no = self._orders
-        n = self.n_softplus
-        VTa, VWb, VTc, VTo = vt
-        A, B, C, O = self._unpack(p)
-        per = na + nb + nc
-        out = VTo @ O
-        J = np.empty((cn.size, n * per + no))
-        for i in range(n):
-            alpha = VTa @ A[i]
-            a = _softplus(alpha)        # amplitude link -> convexity; da/dalpha = sigmoid(alpha)
-            sig_a = _sigmoid(alpha)
-            b = VWb @ B[i]              # slope: polynomial in 1/T
-            cc = VTc @ C[i]
-            u = cn + cc
-            t = b * u
-            spt = _softplus(t)
-            sig = _sigmoid(t)
-            out = out + a * spt
-            base = i * per
-            # d/dA = d/da * da/dalpha * dalpha/dA = softplus(t) * sigmoid(alpha) * Tn^k
-            J[:, base:base + na] = (spt * sig_a)[:, None] * VTa
-            J[:, base + na:base + na + nb] = (a * sig * u)[:, None] * VWb
-            J[:, base + na + nb:base + per] = (a * sig * b)[:, None] * VTc
-        J[:, n * per:] = VTo
-        return out, J
+        terms = p[:n * per].reshape(n, per)
+        return terms[:, :na], terms[:, na:na + nb], terms[:, na + nb:], p[n * per:]
 
     def _const_init(self, a, b, c, off):
         """Coefficient vector for a constant-in-T surface from one slice's
@@ -543,30 +497,83 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
         since ``A`` parametrises ``alpha``, not ``a``."""
         na, nb, nc, no = self._orders
         n = self.n_softplus
-        per = na + nb + nc
-        p = np.zeros(n * per + no)
-        for i in range(n):
-            base = i * per
-            p[base] = _softplus_inv(a[i])
-            p[base + na] = b[i]
-            p[base + na + nb] = c[i]
-        p[n * per] = off
-        return p
+        terms = np.zeros((n, na + nb + nc))
+        terms[:, 0] = _softplus_inv(a)
+        terms[:, na] = b
+        terms[:, na + nb] = c
+        offset = np.zeros(no)
+        offset[0] = off
+        return np.concatenate([terms.ravel(), offset])
+
+    def _model_and_jac(self, p, cn, vt):
+        """Model values and analytic Jacobian ``d(model)/d(params)`` in one pass.
+
+        The coupled fit evaluates the residual and Jacobian at the same point on
+        every iteration, so the per-term ``softplus``/``sigmoid`` are computed
+        once here and reused for both the value and its derivatives.  ``vt`` is the
+        Vandermonde of normalised T for a/c/offset and of normalised 1/T for b;
+        the Jacobian columns follow the ``[A_i | B_i | C_i]`` term layout, offset last.
+        """
+        VTa, VWb, VTc, VTo = vt
+        A, B, C, O = self._unpack(p)
+        out = VTo @ O
+        blocks = []
+        for Ai, Bi, Ci in zip(A, B, C):
+            alpha = VTa @ Ai
+            a = _softplus(alpha)        # amplitude link -> convexity; da/dalpha = sigmoid(alpha)
+            b = VWb @ Bi                # slope: polynomial in 1/T
+            u = cn + VTc @ Ci
+            t = b * u
+            sig = _sigmoid(t)
+            spt = _softplus(t)
+            out = out + a * spt
+            blocks.append((spt * _sigmoid(alpha))[:, None] * VTa)  # d/dA via the link
+            blocks.append((a * sig * u)[:, None] * VWb)
+            blocks.append((a * sig * b)[:, None] * VTc)
+        blocks.append(VTo)
+        return out, np.hstack(blocks)
 
     def _solver_kwargs(self) -> dict:
         """``least_squares`` keyword arguments for the coupled solve.
 
         Uses ``method='lm'`` where scipy applies MINPACK's internal variable
-        scaling (:data:`_LM_HAS_INTERNAL_SCALING`) and the loss is linear,
+        scaling (:attr:`_LM_HAS_INTERNAL_SCALING`) and the loss is linear,
         otherwise the trust-region solver with ``x_scale='jac'``.  An explicit
         :attr:`method` overrides the version-based choice.
         """
         method = self.method
         if method is None:
-            method = "lm" if (_LM_HAS_INTERNAL_SCALING and self.loss == "linear") else "trf"
+            method = "lm" if (self._LM_HAS_INTERNAL_SCALING and self.loss == "linear") else "trf"
         if method == "lm":
             return dict(method="lm")  # __post_init__ guarantees loss == "linear"
         return dict(method="trf", loss=self.loss, f_scale=self.f_scale, x_scale="jac")
+
+    def _vandermonde(self, Tn, Wn):
+        """Vandermonde bases: normalised T for amplitude/knee/offset, 1/T for the slope."""
+        na, nb, nc, no = self._orders
+        return (
+            np.vander(Tn, na, increasing=True),
+            np.vander(Wn, nb, increasing=True),
+            np.vander(Tn, nc, increasing=True),
+            np.vander(Tn, no, increasing=True),
+        )
+
+    def _seed_starts(self, T, cn, f):
+        """Constant-in-T seed vectors from the coldest and central temperature slices.
+
+        Trying both guards against a bad basin: the central slice alone misplaces
+        the knee on a strongly T-sharpening well, while the cold slice alone misses
+        a second term that only the warm data resolves.  The per-slice fit is
+        capped (:attr:`_SEED_MAX_NFEV`), so seeding cost is independent of how many
+        temperatures are sampled.
+        """
+        uT = np.unique(T)
+        max_nfev = min(self.max_nfev, self._SEED_MAX_NFEV)
+        return [
+            self._const_init(*_fit_slice(cn[np.isclose(T, Tseed)], f[np.isclose(T, Tseed)],
+                                         self.n_softplus, max_nfev))
+            for Tseed in (uT[0], uT[len(uT) // 2])
+        ]
 
     def fit(self, T, c, f) -> SoftplusFittedSurface:
         T = np.asarray(T, float)
@@ -580,79 +587,26 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
         Tn, Tm, Ts = _standardize(T)        # amplitude / knee / offset polynomials are in T
         Wn, wm, ws = _standardize(1.0 / T)  # slope polynomial is in 1/T
         cn, cm, cs = _standardize(c)
-        na, nb, nc, no = self._orders
-        vt = (
-            np.vander(Tn, na, increasing=True),
-            np.vander(Wn, nb, increasing=True),   # slope basis is 1/T
-            np.vander(Tn, nc, increasing=True),
-            np.vander(Tn, no, increasing=True),
-        )
+        vt = self._vandermonde(Tn, Wn)
 
-        # Seed from the coldest (sharpest) and central slices.  Trying both guards
-        # against a bad basin (the central slice alone misplaces the knee on a
-        # strongly T-sharpening well; the cold slice alone misses a second term
-        # that only the warm data resolves).  Rather than run both coupled fits to
-        # completion and keep the cheaper -- the worse seed reaches the same (or a
-        # higher-cost) minimum, so finishing it was wasted work -- race them: give
-        # each a short polish, keep whichever is converging better, and only finish
-        # that one.  Which seed converges fastest is *not* the one with the lower
-        # cost at the constant-in-T start (a sharp well's cold seed starts further
-        # off yet relaxes far quicker than the central seed has to sharpen), so the
-        # short race is what tells them apart.
-        #
-        # Solver: on scipy >= 1.16 the unbounded solve uses Levenberg-Marquardt
-        # (``method='lm'``), whose MINPACK step has no per-iteration SVD and --
-        # since gh-22790 -- applies internal variable scaling, so it copes with
-        # the badly conditioned sharp-knee Jacobian and is faster than the SVD
-        # trust region.  On older scipy ``lm`` lacks that scaling and converges
-        # poorly here, so the solve falls back to the trust-region solver with an
-        # explicit ``x_scale='jac'`` (see ``_LM_HAS_INTERNAL_SCALING``).  ``lm``
-        # only supports the linear loss, so a robust loss always takes ``trf``.
-        # Either way a tiny ridge toward the seed pins flat directions; the weight
-        # is negligible against the data residual, so it does not bias an active
-        # term.
-        uT = np.unique(T)
-        n = self.n_softplus
         ridge = 1e-7 * (float(np.abs(f).max()) or 1.0)
-        eye = ridge * np.eye(self.n_softplus * (na + nb + nc) + no)
-        seed_nfev = min(self.max_nfev, _SEED_MAX_NFEV)
-        seeds = []
-        for Tseed in (uT[0], uT[len(uT) // 2]):
-            m = np.isclose(T, Tseed)
-            a0, b0, c0, off0 = _fit_slice(cn[m], f[m], n, seed_nfev)
-            seeds.append(self._const_init(a0, b0, c0, off0))
+        eye = ridge * np.eye(self._n_params)
+        kwargs = self._solver_kwargs()
 
-        def coupled(seed, x0, max_nfev):
-            # Residual and Jacobian share one ``_model_and_jac`` pass per point via
-            # a one-slot cache: ``least_squares`` calls ``fun(p)`` then ``jac(p)``
-            # at the same ``p`` each iteration, so the transcendentals (and the
-            # ridge toward ``seed``) are evaluated once.
-            cache = {}
+        def coupled(seed):
+            return _CachedResidual(self._model_and_jac, cn, vt, f, seed, ridge, eye, kwargs)
 
-            def evaluate(p):
-                if cache.get("p") is None or not np.array_equal(p, cache["p"]):
-                    model, J = self._model_and_jac(p, cn, vt)
-                    cache["p"] = p.copy()
-                    cache["res"] = np.concatenate([model - f, ridge * (p - seed)])
-                    cache["jac"] = np.vstack([J, eye])
-                return cache
-
-            return least_squares(
-                lambda p: evaluate(p)["res"], x0, jac=lambda p: evaluate(p)["jac"],
-                max_nfev=max_nfev, **self._solver_kwargs(),
-            )
-
-        race_nfev = min(self.max_nfev, _SEED_RACE_NFEV)
-        trials = [(seed, coupled(seed, seed, race_nfev)) for seed in seeds]
+        # Race the two seeds: a short polish each, finish only the better one.  The
+        # faster-converging seed is *not* the one with the lower constant-in-T start
+        # cost (a sharp well's cold seed starts further off yet relaxes far quicker
+        # than the central seed has to sharpen), so the short race is what tells them
+        # apart.  Restart the winner from its seed -- not the drifted trial point --
+        # so structureless data can't wander down a flat valley to a degenerate
+        # huge-amplitude basin; if the short polish already converged it *is* the answer.
+        race_nfev = min(self.max_nfev, self._SEED_RACE_NFEV)
+        trials = [(seed, coupled(seed).solve(race_nfev)) for seed in self._seed_starts(T, cn, f)]
         seed, trial = min(trials, key=lambda st: st[1].cost)
-        # Finish the winning seed with a full solve *from its constant-in-T start*,
-        # not from the drifted trial point: restarting from the seed re-treads the
-        # same bounded trajectory a single-seed fit takes, so structureless data
-        # (pure noise) can't wander down a flat valley to a degenerate
-        # huge-amplitude basin the way continuing from the trial point can.  If the
-        # short polish already converged (an easy in-family surface needs only a
-        # few dozen steps) the trial *is* the answer.
-        res = trial if trial.status > 0 else coupled(seed, seed, self.max_nfev)
+        res = trial if trial.status > 0 else coupled(seed).solve(self.max_nfev)
 
         A, B, C, O = self._unpack(res.x)
         return SoftplusFittedSurface(A, B, C, O, Tm, Ts, wm, ws, cm, cs)


### PR DESCRIPTION
Internal refactor of `landau/interpolate/softplus.py` — no behaviour change. Parameter layout, solver selection, and numerics are unchanged.

## Shared softplus-term math
The "sum of softplus terms" loop and its analytic Jacobian appeared in four places (`SoftplusFit` model/jac, `_SoftplusSlice.__call__`/`deriv`, `_slice_model`/`_slice_jac`). Collapsed into three module-level helpers on the normalised grid:
- `_terms(cn, a, b, c, offset)` — the fixed-T model value
- `_terms_dc(cn, a, b, c)` — its c-derivative
- `_terms_jac(cn, a, b, c)` — its parameter Jacobian

plus `_flat`/`_split` for the flat `[a,b,c]*n + [offset]` pack/unpack (also used to build the bound vectors).

## One 1-D fit solver
`SoftplusFit.fit` and the surface seed fit `_fit_slice` both fit a sum of softpluses to 1-D data and each carried their own `least_squares` wiring. They now route through a single `_fit_softplus(cn, y, p0, bounds, …)` solver and differ only in policy: `_fit_slice` keeps its convex-well-aware `_smoothv_seed` and data-driven knee bounds; `SoftplusFit` keeps its generic quantile seed. `_slice_model`/`_slice_jac` are gone (folded into the shared solver).

## Flatter surface fit
- The nested `coupled` → `evaluate` → cache-dict closures in `SoftplusSurface2DInterpolator.fit` become a flat `_CachedResidual` class exposing `fun`/`jac`/`solve` (same one-pass-per-point caching of the shared model/Jacobian evaluation).
- Vandermonde construction and the cold/central seed build move out of `fit` into `_vandermonde` and `_seed_starts`, so `fit` reads as orchestration.
- `_unpack` / `_const_init` / `_model_and_jac` drop the per-term `base = i*per` index arithmetic: `_unpack` reshapes to `(n, per)` and column-slices; `_model_and_jac` accumulates per-term Jacobian column blocks and `hstack`es them. The interleaved `[A_i | B_i | C_i] … O` layout is preserved, so the solver sees the identical problem.

## Constants scoped
The four floating module-level constants are gone: the seed-fit iteration caps and the scipy-version `lm`-scaling flag (`_SEED_MAX_NFEV` / `_SEED_RACE_NFEV` / `_LM_HAS_INTERNAL_SCALING`) become `ClassVar`s on the interpolator, and the slope bound becomes a `bmax=` default on `_fit_slice`.

## Verification
- `tests/unit/test_softplus.py` + `tests/unit/interpolate/test_softplus_surface.py`: all pass (incl. machine-precision in-family recovery and the `b ∝ 1/T` slope test).
- Full `tests/unit` + `tests/regression`: 549 passed, 7 skipped.
- `benchmarks/bench_softplus_surface_fit.py` (`legacy_fit` baseline unchanged) reproduces in-family nRMSE ~1e-10 against the refactored `fit`; `bench_softplus_surface_minima.py`'s `_fit_slice` call and interleaved-layout assumptions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)