### PR TITLE
feat(refine): add dc_max concentration-drift floor to CC tracers

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,7 +38,8 @@ python benchmarks/cc_sampling_density.py [--plot out.png]
 ```
 
 Isolates the `ClausiusClapeyronRefiner` sampling-density regime that the
-`dc_max` floor targets: a coexistence boundary that is flat in `mu`
+`dc_max` cap targets: a coexistence boundary that is flat in `mu`
 (`dmu/dT -> 0`, where `_dT_adapt` saturates at `dT_max`) but whose plotted
 concentration still sweeps.  Reports the point count and worst per-step
-concentration jump with the cap off vs on (`--plot` writes the c-T scatter).
+concentration jump for the old defaults (`dT_max=50`, no drift cap) vs the
+new defaults (`dT_max=5`, `dc_max=0.01`); `--plot` writes the c-T scatter.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,3 +30,15 @@ Compares `FastInterpolatingPhase` against `SlowInterpolatingPhase` on a
 reporting wall-time, speedup, and each solver's error against a dense-grid
 true minimum.  Fast is ~2 orders of magnitude faster and at least as
 accurate (the brute reference's coarse 20-point grid can miss deep wells).
+
+## `cc_sampling_density.py`
+
+```bash
+python benchmarks/cc_sampling_density.py [--plot out.png]
+```
+
+Isolates the `ClausiusClapeyronRefiner` sampling-density regime that the
+`dc_max` floor targets: a coexistence boundary that is flat in `mu`
+(`dmu/dT -> 0`, where `_dT_adapt` saturates at `dT_max`) but whose plotted
+concentration still sweeps.  Reports the point count and worst per-step
+concentration jump with the cap off vs on (`--plot` writes the c-T scatter).

--- a/benchmarks/cc_sampling_density.py
+++ b/benchmarks/cc_sampling_density.py
@@ -1,0 +1,106 @@
+"""Sampling density of ``ClausiusClapeyronRefiner`` on a flat-in-mu boundary.
+
+The predictor-corrector step size ``_dT_adapt`` bounds the *mu* drift per
+step (``half_width / |dmu/dT|``, clamped to ``[dT_min, dT_max]``). That keeps
+the corrector bracket valid but ties the T-sampling density to the
+coexistence slope: a boundary that is nearly flat in mu (equal phase
+entropies, so ``dmu/dT -> 0`` by Clausius-Clapeyron ``dmu/dT = -ds/dc``)
+always saturates at ``dT_max`` and is sampled coarsely -- even where its
+concentration sweeps a lot, which is what actually gets plotted in the c-T
+diagram. This is the asymmetry behind a densely-sampled solid/liquid line
+next to a coarsely-sampled intermetallic.
+
+``dc_max`` adds a concentration-drift floor: the step also shrinks so the
+plotted ``c`` moves at most ``dc_max`` per step. A straight constant-c
+boundary keeps ``dc/dT ~ 0`` and the cap never engages, so nothing is
+over-sampled.
+
+This driver isolates the regime with a toy phase whose composition drifts
+linearly with T at fixed mu, so the boundary is exactly flat in mu while c
+sweeps. Run with ``python benchmarks/cc_sampling_density.py`` from the repo
+root; pass ``--plot out.png`` to also write the c-T scatter.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+import numpy as np
+
+from landau.phases import Phase
+from landau.refine import ClausiusClapeyronRefiner, _InterCandidate
+
+
+@dataclass(frozen=True)
+class DriftLinePhase(Phase):
+    """``phi(T, mu) = e - mu * c(T)`` with ``c(T) = c0 + slope*(T - T0)``.
+
+    Then ``c = -dphi/dmu = c(T)`` exactly: a line-like phase whose plotted
+    composition drifts with T at fixed mu.
+    """
+
+    e: float = 0.0
+    c0: float = 0.5
+    slope: float = 0.0
+    T0: float = 300.0
+
+    def _c(self, T):
+        return self.c0 + self.slope * (np.asarray(T, float) - self.T0)
+
+    def semigrand_potential(self, T, mu):
+        return self.e - np.asarray(mu, float) * self._c(T)
+
+    def concentration(self, T, mu):
+        return self._c(T) + 0.0 * np.asarray(mu, float)
+
+
+def trace(dc_max: float):
+    # Equal e -> coexistence at mu = 0 for every T (flat boundary); P's
+    # composition sweeps 0.8 -> 0.1 over the sampled T range.
+    P = DriftLinePhase(name="P", e=-2.0, c0=0.8, slope=-0.7 / 1100.0)
+    Q = DriftLinePhase(name="Q", e=-2.0, c0=0.05, slope=0.0)
+    cand = _InterCandidate(
+        phase1="P", phase2="Q", T_seed=850.0,
+        mu_bracket=(-0.05, 0.05), T_bracket=(800.0, 900.0),
+        T_min=300.0, T_max=1400.0,
+        proj_p1=(800.0, -0.1), proj_p2=(900.0, 0.1),
+    )
+    pts = ClausiusClapeyronRefiner(dc_max=dc_max).solve(cand, {"P": P, "Q": Q})
+    pts = sorted(pts, key=lambda p: p.T)
+    T = np.array([p.T for p in pts])
+    c = np.array([float(P.concentration(p.T, p.mu)) for p in pts])
+    mu = np.array([p.mu for p in pts])
+    return T, c, mu
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plot", default=None, help="write a c-T scatter PNG here")
+    args = ap.parse_args()
+
+    runs = [("mu-drift only (dc_max=inf)", 1e9), ("dc_max=0.02", 0.02)]
+    series = []
+    for label, dc_max in runs:
+        T, c, mu = trace(dc_max)
+        max_dc = float(np.abs(np.diff(c)).max()) if len(c) > 1 else 0.0
+        print(f"{label:>26}: n={len(T):3d}  max|dc/step|={max_dc:.4f}  "
+              f"|mu|max={np.abs(mu).max():.2e}")
+        series.append((label, T, c))
+
+    if args.plot:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(figsize=(6, 5))
+        for (label, T, c), color in zip(series, ["tab:red", "tab:green"]):
+            ax.plot(c, T, "o-", ms=4, color=color, label=f"{label} (n={len(T)})")
+        ax.set_xlabel("c"); ax.set_ylabel("T")
+        ax.set_title("CC sampling density on a flat-mu, c-sweeping boundary")
+        ax.legend()
+        fig.savefig(args.plot, dpi=120, bbox_inches="tight")
+        print(f"wrote {args.plot}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cc_sampling_density.py
+++ b/benchmarks/cc_sampling_density.py
@@ -54,19 +54,20 @@ class DriftLinePhase(Phase):
         return self._c(T) + 0.0 * np.asarray(mu, float)
 
 
-def trace(dc_max: float):
+def trace(dT_max: float, dc_max: float):
     # Equal e -> coexistence at mu = 0 for every T (flat boundary); P's
-    # composition sweeps 0.8 -> 0.1 over the sampled T range.
-    P = DriftLinePhase(name="P", e=-2.0, c0=0.8, slope=-0.7 / 1100.0)
+    # composition sweeps 0.8 -> 0.2 over the sampled T window, fast enough
+    # that the dc_max cap binds below dT_min in the new-defaults run.
+    P = DriftLinePhase(name="P", e=-2.0, c0=0.8, slope=-0.6 / 300.0, T0=700.0)
     Q = DriftLinePhase(name="Q", e=-2.0, c0=0.05, slope=0.0)
     cand = _InterCandidate(
         phase1="P", phase2="Q", T_seed=850.0,
         mu_bracket=(-0.05, 0.05), T_bracket=(800.0, 900.0),
-        T_min=300.0, T_max=1400.0,
+        T_min=700.0, T_max=1000.0,
         proj_p1=(800.0, -0.1), proj_p2=(900.0, 0.1),
     )
-    pts = ClausiusClapeyronRefiner(dc_max=dc_max).solve(cand, {"P": P, "Q": Q})
-    pts = sorted(pts, key=lambda p: p.T)
+    refiner = ClausiusClapeyronRefiner(dT_max=dT_max, dc_max=dc_max)
+    pts = sorted(refiner.solve(cand, {"P": P, "Q": Q}), key=lambda p: p.T)
     T = np.array([p.T for p in pts])
     c = np.array([float(P.concentration(p.T, p.mu)) for p in pts])
     mu = np.array([p.mu for p in pts])
@@ -78,12 +79,15 @@ def main() -> None:
     ap.add_argument("--plot", default=None, help="write a c-T scatter PNG here")
     args = ap.parse_args()
 
-    runs = [("mu-drift only (dc_max=inf)", 1e9), ("dc_max=0.02", 0.02)]
+    runs = [
+        ("old defaults (dT_max=50, no dc cap)", 50.0, 1e9),
+        ("new defaults (dT_max=5, dc_max=0.01)", 5.0, 0.01),
+    ]
     series = []
-    for label, dc_max in runs:
-        T, c, mu = trace(dc_max)
+    for label, dT_max, dc_max in runs:
+        T, c, mu = trace(dT_max, dc_max)
         max_dc = float(np.abs(np.diff(c)).max()) if len(c) > 1 else 0.0
-        print(f"{label:>26}: n={len(T):3d}  max|dc/step|={max_dc:.4f}  "
+        print(f"{label:>38}: n={len(T):3d}  max|dc/step|={max_dc:.4f}  "
               f"|mu|max={np.abs(mu).max():.2e}")
         series.append((label, T, c))
 
@@ -95,7 +99,8 @@ def main() -> None:
         fig, ax = plt.subplots(figsize=(6, 5))
         for (label, T, c), color in zip(series, ["tab:red", "tab:green"]):
             ax.plot(c, T, "o-", ms=4, color=color, label=f"{label} (n={len(T)})")
-        ax.set_xlabel("c"); ax.set_ylabel("T")
+        ax.set_xlabel("c")
+        ax.set_ylabel("T")
         ax.set_title("CC sampling density on a flat-mu, c-sweeping boundary")
         ax.legend()
         fig.savefig(args.plot, dpi=120, bbox_inches="tight")

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -658,13 +658,24 @@ class _CCBase(Refiner):
     max_steps : int
         Hard cap on steps per trace direction, just in case the
         adaptive logic somehow fails to terminate.
+    dc_max : float
+        Maximum concentration drift allowed per step. ``_dT_adapt``
+        bounds the *mu* drift, which keeps the corrector bracket valid
+        but leaves the T-sampling density proportional to ``dmu/dT``: a
+        boundary that is nearly flat in mu (``dmu/dT -> 0``, so the step
+        saturates at ``dT_max``) but curves in c gets sampled coarsely.
+        Capping the per-step concentration drift gives the trace a
+        density floor tied to the curve that is actually plotted; a
+        straight constant-c boundary keeps ``dc/dT ~ 0`` and the cap
+        never engages, so nothing is over-sampled.
     """
 
     def __init__(self, dT_max: float = 50.0, dT_min: float = 1.0,
-                 max_steps: int = 500):
+                 max_steps: int = 500, dc_max: float = 0.02):
         self.dT_max = dT_max
         self.dT_min = dT_min
         self.max_steps = max_steps
+        self.dc_max = dc_max
 
     # -- subclass hooks -----------------------------------------------------
 
@@ -784,9 +795,22 @@ class _CCBase(Refiner):
         slope = max(abs(dmu_dT), 1e-9)
         return half_width / slope
 
+    def _emitted_concentrations(self, pt, phases) -> tuple[float, ...]:
+        """Concentrations plotted by one emitted point, for the ``dc_max``
+        density floor in :meth:`_trace`.
+
+        A :class:`RefinedMiscibilityGap` plots its two pre-computed branch
+        concentrations; a :class:`RefinedPoint` plots one branch per
+        coexisting phase at ``(T, mu)``. Generic over both so the base
+        trace loop needs no per-subclass hook.
+        """
+        if isinstance(pt, RefinedMiscibilityGap):
+            return (pt.c_left, pt.c_right)
+        return tuple(float(phases[n].concentration(pt.T, pt.mu)) for n in pt.phases)
+
     # -- shared trace skeleton ---------------------------------------------
 
-    def _trace(self, cand, phases, T0, mu0, half_width, T_target, sign):
+    def _trace(self, cand, phases, T0, mu0, seed_c, half_width, T_target, sign):
         """Walk from the seed ``(T0, mu0)`` toward ``T_target``.
 
         On each step the next mu* is given by :meth:`_predict_mu` and
@@ -814,6 +838,10 @@ class _CCBase(Refiner):
             All known phases.
         T0, mu0 : float
             Seed location.
+        seed_c : tuple[float, ...]
+            Concentrations plotted at the seed, used to prime the
+            ``dc_max`` density floor from the very first step so the
+            curve resolution isn't lost on the bootstrap step.
         half_width : float
             Half-width of the seed simplex's mu bracket; sets the
             scale of subsequent isothermal brackets and the on-line
@@ -844,9 +872,14 @@ class _CCBase(Refiner):
             # benign: leave the seed-only point alone, let the
             # straddle dedup downstream decide whether to absorb it.
             return
-        yield self._emit(cand, T_b, step)
+        pt = self._emit(cand, T_b, step)
+        yield pt
         mu_star = step.mu_star
         dmu_dT = (mu_star - mu0) / dT_boot
+        c_b = self._emitted_concentrations(pt, phases)
+        dc_dT = max((abs(a - b) for a, b in zip(c_b, seed_c)),
+                    default=0.0) / abs(dT_boot)
+        c_prev = c_b
         T = T_b
 
         for _ in range(self.max_steps):
@@ -857,6 +890,13 @@ class _CCBase(Refiner):
 
             # Adaptive temperature step, clipped to [dT_min, dT_max].
             dT_adapt = self._dT_adapt(step, dmu_dT, half_width)
+            # Concentration-drift density floor: keep |dc| per step under
+            # dc_max using the drift observed over the previous step. On a
+            # flat-in-mu but curved-in-c boundary _dT_adapt saturates at
+            # dT_max and this is what keeps the c-T curve resolved; on a
+            # straight constant-c boundary dc_dT stays ~0 and it's a no-op.
+            if dc_dT > 0:
+                dT_adapt = min(dT_adapt, self.dc_max / dc_dT)
             dT_adapt = min(self.dT_max, max(self.dT_min, dT_adapt))
             dT = sign * dT_adapt
             # Don't step past the walk boundary; clip dT instead.
@@ -881,7 +921,12 @@ class _CCBase(Refiner):
                 return
             dmu_dT = (step.mu_star - mu_star) / dT
             T, mu_star = T_next, step.mu_star
-            yield self._emit(cand, T, step)
+            pt = self._emit(cand, T, step)
+            yield pt
+            c_now = self._emitted_concentrations(pt, phases)
+            dc_dT = max((abs(a - b) for a, b in zip(c_now, c_prev)),
+                        default=0.0) / abs(dT)
+            c_prev = c_now
             # If we've walked back onto an already-traced segment of
             # the same coexistence line, stop instead of duplicating it.
             if _point_on_line(T, mu_star, cand.existing, tol_mu=half_width):
@@ -894,10 +939,12 @@ class _CCBase(Refiner):
         T0, step0 = seed
         mu_lo, mu_hi = cand.mu_bracket
         half_width = (mu_hi - mu_lo) / 2.0
-        out = [self._emit(cand, T0, step0)]
-        out.extend(self._trace(cand, phases, T0, step0.mu_star,
+        seed_pt = self._emit(cand, T0, step0)
+        seed_c = self._emitted_concentrations(seed_pt, phases)
+        out = [seed_pt]
+        out.extend(self._trace(cand, phases, T0, step0.mu_star, seed_c,
                                half_width, cand.T_max, +1))
-        out.extend(self._trace(cand, phases, T0, step0.mu_star,
+        out.extend(self._trace(cand, phases, T0, step0.mu_star, seed_c,
                                half_width, cand.T_min, -1))
         return out
 
@@ -1109,9 +1156,11 @@ class MiscibilityGapRefiner(_CCBase):
     label = "miscibility-gap"
 
     def __init__(self, dT_max: float = 50.0, dT_min: float = 1.0,
-                 max_steps: int = 500, c_jump_min: float = 0.3,
+                 max_steps: int = 500, dc_max: float = 0.02,
+                 c_jump_min: float = 0.3,
                  gap_close: float = 1e-3, gap_share_min: float = 0.1):
-        super().__init__(dT_max=dT_max, dT_min=dT_min, max_steps=max_steps)
+        super().__init__(dT_max=dT_max, dT_min=dT_min, max_steps=max_steps,
+                         dc_max=dc_max)
         self.c_jump_min = c_jump_min
         self.gap_close = gap_close
         self.gap_share_min = gap_share_min

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -667,11 +667,13 @@ class _CCBase(Refiner):
         Capping the per-step concentration drift gives the trace a
         density floor tied to the curve that is actually plotted; a
         straight constant-c boundary keeps ``dc/dT ~ 0`` and the cap
-        never engages, so nothing is over-sampled.
+        never engages, so nothing is over-sampled. The cap is applied
+        after the ``[dT_min, dT_max]`` clamp, so ``dT_min`` yields when
+        it would otherwise block the drift target.
     """
 
-    def __init__(self, dT_max: float = 50.0, dT_min: float = 1.0,
-                 max_steps: int = 500, dc_max: float = 0.02):
+    def __init__(self, dT_max: float = 5.0, dT_min: float = 1.0,
+                 max_steps: int = 500, dc_max: float = 0.01):
         self.dT_max = dT_max
         self.dT_min = dT_min
         self.max_steps = max_steps
@@ -860,10 +862,25 @@ class _CCBase(Refiner):
         dT_boot = sign * min(self.dT_min, abs(T_target - T0))
         if dT_boot == 0:
             return
-        T_b = T0 + dT_boot
-        try:
+
+        def boot(dT):
+            # One bootstrap refinement at T0 + dT; returns (step, pt, drift).
             step = self._refine_step(
-                cand, phases, T_b, mu0 - half_width, mu0 + half_width)
+                cand, phases, T0 + dT, mu0 - half_width, mu0 + half_width)
+            pt = self._emit(cand, T0 + dT, step)
+            c = self._emitted_concentrations(pt, phases)
+            drift = max((abs(a - b) for a, b in zip(c, seed_c)), default=0.0)
+            return step, pt, c, drift
+
+        try:
+            step, pt, c_b, drift = boot(dT_boot)
+            # The bootstrap is a fixed dT_min kick, so it can overshoot
+            # dc_max where dT_min would otherwise block the drift target,
+            # so dT_min yields: re-solve once at the concentration-capped
+            # step (drift is ~linear in dT locally).
+            if drift > self.dc_max:
+                dT_boot *= self.dc_max / drift
+                step, pt, c_b, drift = boot(dT_boot)
         except ValueError:
             # Bootstrap step failed. Exercised mainly when the seed
             # already sits at the gap's closure (refine raises
@@ -872,13 +889,11 @@ class _CCBase(Refiner):
             # benign: leave the seed-only point alone, let the
             # straddle dedup downstream decide whether to absorb it.
             return
-        pt = self._emit(cand, T_b, step)
+        T_b = T0 + dT_boot
         yield pt
         mu_star = step.mu_star
         dmu_dT = (mu_star - mu0) / dT_boot
-        c_b = self._emitted_concentrations(pt, phases)
-        dc_dT = max((abs(a - b) for a, b in zip(c_b, seed_c)),
-                    default=0.0) / abs(dT_boot)
+        dc_dT = drift / abs(dT_boot)
         c_prev = c_b
         T = T_b
 
@@ -888,16 +903,19 @@ class _CCBase(Refiner):
             if sign * (T_target - T) <= 1e-12:
                 return
 
-            # Adaptive temperature step, clipped to [dT_min, dT_max].
+            # Adaptive temperature step from the mu-drift heuristic,
+            # clipped to [dT_min, dT_max].
             dT_adapt = self._dT_adapt(step, dmu_dT, half_width)
-            # Concentration-drift density floor: keep |dc| per step under
-            # dc_max using the drift observed over the previous step. On a
-            # flat-in-mu but curved-in-c boundary _dT_adapt saturates at
-            # dT_max and this is what keeps the c-T curve resolved; on a
-            # straight constant-c boundary dc_dT stays ~0 and it's a no-op.
-            if dc_dT > 0:
-                dT_adapt = min(dT_adapt, self.dc_max / dc_dT)
             dT_adapt = min(self.dT_max, max(self.dT_min, dT_adapt))
+            # Concentration-drift cap: keep |dc| per step under dc_max using
+            # the drift observed over the previous step. On a flat-in-mu but
+            # curved-in-c boundary the mu-drift step saturates at dT_max and
+            # this is what keeps the c-T curve resolved; on a straight
+            # constant-c boundary dc_dT stays ~0 and it's a no-op. Applied
+            # after the [dT_min, dT_max] clamp so dT_min yields to it — a
+            # tiny absolute floor keeps the walk progressing.
+            if dc_dT > 0:
+                dT_adapt = max(min(dT_adapt, self.dc_max / dc_dT), 1e-3)
             dT = sign * dT_adapt
             # Don't step past the walk boundary; clip dT instead.
             if sign * (T + dT - T_target) > 0:
@@ -1155,8 +1173,8 @@ class MiscibilityGapRefiner(_CCBase):
 
     label = "miscibility-gap"
 
-    def __init__(self, dT_max: float = 50.0, dT_min: float = 1.0,
-                 max_steps: int = 500, dc_max: float = 0.02,
+    def __init__(self, dT_max: float = 5.0, dT_min: float = 1.0,
+                 max_steps: int = 500, dc_max: float = 0.01,
                  c_jump_min: float = 0.3,
                  gap_close: float = 1e-3, gap_share_min: float = 0.1):
         super().__init__(dT_max=dT_max, dT_min=dT_min, max_steps=max_steps,

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -1,10 +1,12 @@
 """Unit tests for refiners in landau.refine."""
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from landau.features import Locus
-from landau.phases import LinePhase, TemperatureDependentLinePhase
+from landau.phases import LinePhase, Phase, TemperatureDependentLinePhase
 from landau.interpolate import SGTE
 from landau.interpolate.basic import G_calphad
 from landau.refine import (
@@ -140,6 +142,89 @@ def test_clausius_clapeyron_refiner_respects_dT_min(two_phase_system):
 
 def test_clausius_clapeyron_refiner_label():
     assert ClausiusClapeyronRefiner.label == "clausius-clapeyron"
+
+
+# -- dc_max concentration-drift density floor --------------------------------
+
+_DC_MAX = 0.02
+
+
+@dataclass(frozen=True)
+class _DriftLinePhase(Phase):
+    """Line-like phase whose plotted composition drifts linearly with T.
+
+    ``phi(T, mu) = e - mu * c(T)`` so ``c = -dphi/dmu = c(T)`` exactly and
+    sweeps with T at fixed mu.  Two of these with equal ``e`` coexist at
+    ``mu = 0`` for every T — a boundary that is exactly flat in mu — which
+    isolates the ``dc_max`` density floor: ``_dT_adapt`` saturates at
+    ``dT_max`` because ``dmu/dT = 0``, yet ``c`` still moves, so only the
+    concentration cap limits the step.
+    """
+
+    e: float = 0.0
+    c0: float = 0.5
+    slope: float = 0.0
+    T0: float = 300.0
+
+    def _c(self, T):
+        return self.c0 + self.slope * (np.asarray(T, float) - self.T0)
+
+    def semigrand_potential(self, T, mu):
+        return self.e - np.asarray(mu, float) * self._c(T)
+
+    def concentration(self, T, mu):
+        return self._c(T) + 0.0 * np.asarray(mu, float)
+
+
+def _drift_candidate():
+    return _InterCandidate(
+        phase1="P", phase2="Q", T_seed=850.0,
+        mu_bracket=(-0.05, 0.05), T_bracket=(800.0, 900.0),
+        T_min=300.0, T_max=1400.0,
+        proj_p1=(800.0, -0.1), proj_p2=(900.0, 0.1),
+    )
+
+
+def _solve_drift(dc_max, p_slope):
+    P = _DriftLinePhase(name="P", e=-2.0, c0=0.8, slope=p_slope)
+    Q = _DriftLinePhase(name="Q", e=-2.0, c0=0.05, slope=0.0)
+    pts = ClausiusClapeyronRefiner(dc_max=dc_max).solve(
+        _drift_candidate(), {"P": P, "Q": Q})
+    return P, sorted(pts, key=lambda p: p.T)
+
+
+def test_cc_refiner_dc_max_bounds_concentration_drift():
+    """On a boundary flat in mu but sweeping in c, dc_max caps every
+    per-step concentration jump so the plotted curve stays resolved."""
+    P, pts = _solve_drift(_DC_MAX, p_slope=-0.7 / 1100.0)
+    # Regime check: the located boundary is exactly flat in mu, so the
+    # mu-drift step heuristic alone would saturate at dT_max.
+    assert max(abs(p.mu) for p in pts) < 1e-9
+    # The trace spans the full sampled T range in both directions.
+    Ts = np.array([p.T for p in pts])
+    assert Ts.min() < 320.0 and Ts.max() > 1380.0
+    # Every consecutive step keeps the plotted concentration drift under
+    # the cap (priming from the seed leaves no coarse bootstrap step).
+    cs = np.array([float(P.concentration(p.T, p.mu)) for p in pts])
+    assert np.abs(np.diff(cs)).max() <= _DC_MAX + 1e-9
+
+
+def test_cc_refiner_dc_max_densifies_curved_boundary():
+    """Tightening dc_max adds samples on a curved-in-c boundary that the
+    mu-drift heuristic alone leaves coarse."""
+    _, loose = _solve_drift(1e9, p_slope=-0.7 / 1100.0)
+    _, tight = _solve_drift(_DC_MAX, p_slope=-0.7 / 1100.0)
+    assert len(tight) > len(loose)
+
+
+def test_cc_refiner_dc_max_noop_on_constant_c_boundary():
+    """A boundary straight in c (dc/dT ~ 0) must not be over-sampled:
+    dc_max never engages, so the point count is identical whether the cap
+    is tight or effectively off."""
+    _, tight = _solve_drift(1e-4, p_slope=0.0)
+    _, loose = _solve_drift(1e9, p_slope=0.0)
+    assert len(loose) > 3  # genuinely traced, not just the seed
+    assert len(tight) == len(loose)
 
 
 def test_simplex_straddles_segment_crossing():

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -121,10 +121,13 @@ def test_clausius_clapeyron_refiner_skips_straddling_simplices(two_phase_system)
     # The grid does have many two-phase simplices for the same pair...
     pairs = [frozenset((c.phase1, c.phase2)) for c in cands]
     assert pairs.count(frozenset(("A", "B"))) > 1
-    # ...but run() should skip retraces and emit roughly one line's worth.
+    # ...but run() should skip retraces and emit roughly one line's worth:
+    # the point count tracks a single T-sweep (span / dT_max), not ~one
+    # full trace per straddling simplex stacked on the same line.
     out = refiner.run(df, mapping)
     n_points = out.groupby(["T", "mu"]).ngroups
-    assert n_points < 4 * len(cands)
+    T_span = df["T"].max() - df["T"].min()
+    assert n_points < 3 * T_span / refiner.dT_max
 
 
 def test_clausius_clapeyron_refiner_respects_dT_min(two_phase_system):
@@ -144,9 +147,13 @@ def test_clausius_clapeyron_refiner_label():
     assert ClausiusClapeyronRefiner.label == "clausius-clapeyron"
 
 
-# -- dc_max concentration-drift density floor --------------------------------
+# -- dc_max concentration-drift cap ------------------------------------------
 
-_DC_MAX = 0.02
+# Physical drift slope: c sweeps ~0.8 -> 0.1 across the sampled T range.
+_DRIFT_SLOPE = -0.7 / 1100.0
+# Tight enough that the cap binds below the default dT_min = 1.0 K, so the
+# "dT_min yields to dc_max" path is exercised.
+_DC_TIGHT = 5e-4
 
 
 @dataclass(frozen=True)
@@ -176,44 +183,49 @@ class _DriftLinePhase(Phase):
         return self._c(T) + 0.0 * np.asarray(mu, float)
 
 
-def _drift_candidate():
+def _drift_candidate(T_min=300.0, T_max=1400.0):
+    T_seed = (T_min + T_max) / 2.0
     return _InterCandidate(
-        phase1="P", phase2="Q", T_seed=850.0,
-        mu_bracket=(-0.05, 0.05), T_bracket=(800.0, 900.0),
-        T_min=300.0, T_max=1400.0,
-        proj_p1=(800.0, -0.1), proj_p2=(900.0, 0.1),
+        phase1="P", phase2="Q", T_seed=T_seed,
+        mu_bracket=(-0.05, 0.05), T_bracket=(T_seed - 50.0, T_seed + 50.0),
+        T_min=T_min, T_max=T_max,
+        proj_p1=(T_seed - 50.0, -0.1), proj_p2=(T_seed + 50.0, 0.1),
     )
 
 
-def _solve_drift(dc_max, p_slope):
+def _solve_drift(dc_max, p_slope, T_min=300.0, T_max=1400.0):
     P = _DriftLinePhase(name="P", e=-2.0, c0=0.8, slope=p_slope)
     Q = _DriftLinePhase(name="Q", e=-2.0, c0=0.05, slope=0.0)
     pts = ClausiusClapeyronRefiner(dc_max=dc_max).solve(
-        _drift_candidate(), {"P": P, "Q": Q})
+        _drift_candidate(T_min, T_max), {"P": P, "Q": Q})
     return P, sorted(pts, key=lambda p: p.T)
 
 
 def test_cc_refiner_dc_max_bounds_concentration_drift():
     """On a boundary flat in mu but sweeping in c, dc_max caps every
-    per-step concentration jump so the plotted curve stays resolved."""
-    P, pts = _solve_drift(_DC_MAX, p_slope=-0.7 / 1100.0)
+    per-step concentration jump, and dT_min yields so the cap holds."""
+    # A short T window keeps c physical while dc_max binds below dT_min.
+    P, pts = _solve_drift(_DC_TIGHT, p_slope=_DRIFT_SLOPE, T_min=800.0, T_max=900.0)
     # Regime check: the located boundary is exactly flat in mu, so the
     # mu-drift step heuristic alone would saturate at dT_max.
     assert max(abs(p.mu) for p in pts) < 1e-9
-    # The trace spans the full sampled T range in both directions.
+    # The fine stepping does not truncate the walk: it spans the window
+    # in both directions.
     Ts = np.array([p.T for p in pts])
-    assert Ts.min() < 320.0 and Ts.max() > 1380.0
+    assert Ts.min() < 805.0 and Ts.max() > 895.0
     # Every consecutive step keeps the plotted concentration drift under
     # the cap (priming from the seed leaves no coarse bootstrap step).
     cs = np.array([float(P.concentration(p.T, p.mu)) for p in pts])
-    assert np.abs(np.diff(cs)).max() <= _DC_MAX + 1e-9
+    assert np.abs(np.diff(cs)).max() <= _DC_TIGHT + 1e-9
+    # dT_min (default 1.0 K) gives way to the drift target: steps go finer.
+    assert np.diff(Ts).min() < 1.0
 
 
 def test_cc_refiner_dc_max_densifies_curved_boundary():
     """Tightening dc_max adds samples on a curved-in-c boundary that the
     mu-drift heuristic alone leaves coarse."""
-    _, loose = _solve_drift(1e9, p_slope=-0.7 / 1100.0)
-    _, tight = _solve_drift(_DC_MAX, p_slope=-0.7 / 1100.0)
+    _, loose = _solve_drift(1e9, p_slope=_DRIFT_SLOPE, T_min=800.0, T_max=900.0)
+    _, tight = _solve_drift(_DC_TIGHT, p_slope=_DRIFT_SLOPE, T_min=800.0, T_max=900.0)
     assert len(tight) > len(loose)
 
 


### PR DESCRIPTION
## Problem

`ClausiusClapeyronRefiner` samples the solid/liquid line much more finely than an intermetallic boundary in the same diagram (the attached report figure).

The step size comes from `_CCBase._dT_adapt`, which bounds the **mu** drift per step: `half_width / |dmu/dT|`, clamped to `[dT_min, dT_max]`. That keeps the corrector bracket valid, but it ties the T-sampling density to the coexistence slope. By Clausius-Clapeyron, `dmu/dT = -Δs/Δc`, so a boundary between phases of near-equal entropy is flat in mu (`dmu/dT → 0`); the step then always saturates at `dT_max` and the boundary is sampled coarsely — even where its concentration sweeps a lot, which is exactly what the c-T diagram plots.

Instrumenting a reproduction (terminal + intermetallic + ideal-solution liquid, 40×60 grid) confirms it: ~50% of CC steps have `|dmu/dT| < 1e-6` and step at the full `dT_max`, while the sloped liquid line takes small steps and is dense.

## Change

Add a `dc_max` concentration-drift cap shared by both `_CCBase` tracers (`ClausiusClapeyronRefiner`, `MiscibilityGapRefiner`), and tighten the step bounds:

- **Defaults `dT_max = 5 K`, `dc_max = 0.01` (1% drift per step)** (were 50 K / no cap).
- The step shrinks so the plotted concentration moves at most `dc_max` per step, using the drift observed over the previous step and primed from the seed so no coarse bootstrap step slips through.
- The cap is applied **after** the `[dT_min, dT_max]` clamp, so `dT_min` yields when it would otherwise block the drift target. The bootstrap `dT_min` kick is re-solved once at the concentration-capped step for the same reason, so the 1% bound holds from the first step. A tiny absolute floor keeps the walk progressing.
- A straight constant-c boundary keeps `dc/dT ≈ 0`, so the cap never engages and nothing is over-sampled. Existing diagrams are unchanged in shape; the full suite (and the testplot render) pass.

`_emitted_concentrations` reads the plotted concentrations generically off either emitted type (`RefinedPoint` → one branch per coexisting phase, `RefinedMiscibilityGap` → its two stored branches), so the base trace loop needs no per-subclass hook.

## Tests

`tests/unit/test_refine.py` uses a toy phase whose composition drifts with T at fixed mu, so the located boundary is exactly flat in mu (`|mu| < 1e-9`) while c sweeps — isolating the regime the cap targets:

- `test_cc_refiner_dc_max_bounds_concentration_drift` — on a short T window where the cap binds below `dT_min`, every consecutive step bounds the per-step concentration jump to `dc_max`, `dT_min` yields (sub-1 K steps), and the walk isn't truncated.
- `test_cc_refiner_dc_max_densifies_curved_boundary` — tightening `dc_max` adds samples the mu-drift heuristic alone leaves coarse.
- `test_cc_refiner_dc_max_noop_on_constant_c_boundary` — a constant-c boundary gets the same point count cap-on vs cap-off.

The straddle-dedup test's point-count bound is rescaled to the finer default density.

`benchmarks/cc_sampling_density.py` reproduces the old-vs-new-defaults contrast on a flat-mu, c-sweeping boundary: 9 points / 10% worst-step drift → 63 points / exactly 1%.

Full suite: 560 passed, 1 xfailed.