### PR TITLE
ci: gate test workflows on source/test/workflow changes

### DIFF
--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -21,7 +21,7 @@ jobs:
               - 'landau/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/test-minimum-deps.yml'
 
   test-minimum-deps:
     needs: changes

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -7,16 +7,41 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'landau/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   test-minimum-deps:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip notice
+        if: needs.changes.outputs.run != 'true'
+        run: echo "No source, test, or workflow changes; skipping."
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run == 'true'
         with:
           # setuptools-scm derives the version from git history.
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+        if: needs.changes.outputs.run == 'true'
       - run: uv venv
+        if: needs.changes.outputs.run == 'true'
       # --resolution lowest-direct pins every direct dependency to the lowest
       # version its bound allows, exercising the floors declared in pyproject.
       - run: uv pip install --resolution lowest-direct -e ".[test,constraints,fast-tsp,python-tsp]"
+        if: needs.changes.outputs.run == 'true'
       - run: uv run --no-sync pytest
+        if: needs.changes.outputs.run == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,24 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'landau/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   build:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -15,17 +32,24 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Skip notice
+      if: needs.changes.outputs.run != 'true'
+      run: echo "No source, test, or workflow changes; skipping."
     - uses: actions/checkout@v5
+      if: needs.changes.outputs.run == 'true'
     - name: Set up Python ${{ matrix.python-version }}
+      if: needs.changes.outputs.run == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Setup
+      if: needs.changes.outputs.run == 'true'
       shell: bash -l {0}
       run: |
         pip install -e .[test,constraints,fast-tsp,python-tsp]
     - name: run tests
+      if: needs.changes.outputs.run == 'true'
       shell: bash -l {0}
       env:
         HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-py${{ matrix.python-version }}
@@ -33,7 +57,7 @@ jobs:
       run: |
         pytest
     - name: Upload Hypothesis example database
-      if: always()
+      if: needs.changes.outputs.run == 'true' && always()
       uses: actions/upload-artifact@v4
       with:
         name: hypothesis-example-db-py${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
               - 'landau/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/tests.yml'
 
   build:
     needs: changes


### PR DESCRIPTION
Add a `changes` gate job (`dorny/paths-filter`) to `tests.yml` and `test-minimum-deps.yml` so the test jobs only do work when relevant files change.

Each workflow's filter matches:
- the source dir (`landau/**`)
- `tests/**`
- `pyproject.toml`
- its own workflow file (e.g. `tests.yml` gates on `.github/workflows/tests.yml`)

So editing one workflow re-runs only that workflow, not the others. Steps are gated per-step (`if: needs.changes.outputs.run == 'true'`) with a "Skip notice" step, matching the pattern already used in `pmrv/fleche`, so the jobs still report green when skipped and remain valid as required status checks. A push/PR that only touches docs, notebooks, etc. no longer spins up the full Python matrix or the minimum-deps run.