### PR TITLE
feat(calculate): accept explicit refiner list in calc_phase_diagram

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -235,7 +235,7 @@ def calc_phase_diagram(
     phases: Iterable[Phase],
     Ts: Iterable[float] | float,
     mu: Iterable[float] | float | int,
-    refine: bool = True,
+    refine: bool | Sequence[Refiner] = True,
     keep_unstable: bool = False,
 ):
     """
@@ -247,7 +247,11 @@ def calc_phase_diagram(
         mu (iterable of floats): sampling points in chemical potential; if a
             non-zero int, guess sampling points with guess_mu_range at max(Ts)
             (pass ``mu=0.0`` for a fixed-mu temperature-only diagram)
-        refine (bool): add additional sampling points at exact phase transitions
+        refine (bool or sequence of :class:`~landau.refine.Refiner`): add
+            additional sampling points at exact phase transitions. ``True``
+            picks defaults based on which of ``T``/``mu`` are sampled, ``False``
+            skips refinement, and an explicit sequence of
+            :class:`~landau.refine.Refiner` instances applies just those.
         keep_unstable (bool): only keep entries of stable phases, otherwise keep entries of all phases at all sampling points
 
     Returns:
@@ -277,10 +281,11 @@ def calc_phase_diagram(
     pdf["stable"] = False
     pdf.loc[pdf.groupby(["T", "mu"], group_keys=False).phi.idxmin(), "stable"] = True
     pdf["locus"] = Locus.INTERIOR
-    if refine:
+    if refine is not False:
+        refiners = None if isinstance(refine, bool) else refine
         min_c = pdf.c.min()
         max_c = pdf.c.max()
-        pdf = refine_phase_diagram(pdf, phases, min_c=min_c, max_c=max_c)
+        pdf = refine_phase_diagram(pdf, phases, min_c=min_c, max_c=max_c, refiners=refiners)
     pdf["f"] = pdf.phi + pdf.mu * pdf.c
     pdf["f_excess"] = _apply_series(
         pdf.groupby("T", group_keys=False), _f_excess_tangent_chord, "f_excess"

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -535,6 +535,30 @@ def test_calc_phase_diagram_refined_locus(triple_point_phases):
     assert (df.loc[edges, "locus"] == Locus.INTERIOR).all()
 
 
+def test_calc_phase_diagram_refine_explicit_list(triple_point_phases):
+    """An explicit refiner list is applied instead of the defaults."""
+    from landau.refine import DelaunayLineRefiner
+    # DelaunayLineRefiner is opt-in (not in the 2-D defaults) and emits no
+    # triple points, so the explicit list is distinguishable from the default
+    # set which does produce Locus.TRIPLE rows.
+    df = calc_phase_diagram(triple_point_phases, Ts=np.linspace(220, 480, 12),
+                            mu=np.linspace(-0.05, 0.55, 15),
+                            refine=[DelaunayLineRefiner()], keep_unstable=True)
+    refined = df["refined"].fillna("no") != "no"
+    assert refined.any()
+    assert (df["locus"] == Locus.BOUNDARY).any()
+    assert not (df["locus"] == Locus.TRIPLE).any()
+
+
+def test_calc_phase_diagram_refine_empty_list_skips(triple_point_phases):
+    """An explicit empty refiner list refines nothing, like refine=False."""
+    df = calc_phase_diagram(triple_point_phases, Ts=np.linspace(220, 480, 12),
+                            mu=np.linspace(-0.05, 0.55, 15),
+                            refine=[], keep_unstable=True)
+    assert (df["refined"].fillna("no") == "no").all()
+    assert (df["locus"] == Locus.INTERIOR).all()
+
+
 def test_calc_phase_diagram_locus_triple(triple_point_phases):
     df = calc_phase_diagram(triple_point_phases, Ts=np.linspace(220, 480, 12),
                             mu=np.linspace(-0.05, 0.55, 15))


### PR DESCRIPTION
`calc_phase_diagram`'s `refine` argument now accepts a sequence of `Refiner` instances in addition to the bool, mirroring how `plot_phase_diagram` accepts an explicit `poly_method` instead of letting it auto-resolve.

`refine_phase_diagram` already took a `refiners` sequence; this threads it through the public entry point:

- `refine=True` (default) — pick defaults via `default_refiners` based on which of `T`/`mu` are sampled (unchanged).
- `refine=False` — skip refinement (unchanged).
- `refine=[...]` — apply exactly the given refiners; an empty list refines nothing.

The `if refine:` gate became `if refine is not False:` so a non-default sequence (including `[]`) still enters the refine path, with `refiners=None` only for the `True` bool.

Tests in `tests/unit/test_calculate.py`: an explicit `[DelaunayLineRefiner()]` (opt-in, emits no triple points) produces `BOUNDARY` rows but no `TRIPLE` rows, distinguishing it from the 2-D default set; an explicit `[]` leaves every row `INTERIOR` like `refine=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jf7gj2N5Z9FvJxkukjFC1

---
_Generated by [Claude Code](https://claude.ai/code/session_012jf7gj2N5Z9FvJxkukjFC1)_