### PR TITLE
feat(refine): add dc_min concentration-drift floor; kwarg-only CC ctors

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -673,9 +673,12 @@ class _CCBase(Refiner):
         steep in mu (``_dT_adapt`` shrinks the step toward ``dT_min``) but
         nearly flat in c, where ``dc_max`` never engages and the curve
         gets over-sampled. The step grows so the plotted concentration
-        moves at least ``dc_min``, but never past ``dT_max``. Disabled by
-        default (``0.0``); set it below ``dc_max`` to thin redundant
-        points without losing resolution.
+        moves at least ``dc_min``, but never past ``dT_max``. The ``max``
+        bounds take precedence over the ``min`` bounds: the floor is
+        applied before the ``dc_max`` cap, so a ``dc_min`` set at or above
+        ``dc_max`` yields to it and the per-step drift never exceeds
+        ``dc_max``. Disabled by default (``0.0``); set it below ``dc_max``
+        to thin redundant points without losing resolution.
     max_steps : int
         Hard cap on steps per trace direction, just in case the
         adaptive logic somehow fails to terminate.
@@ -918,23 +921,23 @@ class _CCBase(Refiner):
             # clipped to [dT_min, dT_max].
             dT_adapt = self._dT_adapt(step, dmu_dT, half_width)
             dT_adapt = min(self.dT_max, max(self.dT_min, dT_adapt))
+            # Concentration-drift floor (density ceiling): grow the step so
+            # |dc| per step reaches dc_min where it would otherwise over-sample
+            # a steep-in-mu, flat-in-c boundary. Capped at dT_max. Off when
+            # dc_min == 0. Applied before the dc_max cap below so the max
+            # parameters take precedence over the min ones.
+            if dc_dT > 0 and self.dc_min > 0:
+                dT_adapt = min(max(dT_adapt, self.dc_min / dc_dT), self.dT_max)
             # Concentration-drift cap: keep |dc| per step under dc_max using
             # the drift observed over the previous step. On a flat-in-mu but
             # curved-in-c boundary the mu-drift step saturates at dT_max and
             # this is what keeps the c-T curve resolved; on a straight
             # constant-c boundary dc_dT stays ~0 and it's a no-op. Applied
-            # after the [dT_min, dT_max] clamp so dT_min yields to it — a
-            # tiny absolute floor keeps the walk progressing.
+            # last — after the [dT_min, dT_max] clamp and the dc_min floor —
+            # so dT_min and dc_min both yield to it (max wins). A tiny
+            # absolute floor keeps the walk progressing.
             if dc_dT > 0:
                 dT_adapt = max(min(dT_adapt, self.dc_max / dc_dT), 1e-3)
-                # Concentration-drift floor (density ceiling): grow the step
-                # so |dc| per step reaches dc_min where it would otherwise
-                # over-sample a steep-in-mu, flat-in-c boundary. Capped at
-                # dT_max so the floor never oversteps the hard step bound.
-                # Off when dc_min == 0; kept below dc_max so it can't fight
-                # the cap above.
-                if self.dc_min > 0:
-                    dT_adapt = min(max(dT_adapt, self.dc_min / dc_dT), self.dT_max)
             dT = sign * dT_adapt
             # Don't step past the walk boundary; clip dT instead.
             if sign * (T + dT - T_target) > 0:

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -655,9 +655,6 @@ class _CCBase(Refiner):
     dT_min : float
         Minimum allowed temperature step (K) and the bootstrap step
         right after the seed.
-    max_steps : int
-        Hard cap on steps per trace direction, just in case the
-        adaptive logic somehow fails to terminate.
     dc_max : float
         Maximum concentration drift allowed per step. ``_dT_adapt``
         bounds the *mu* drift, which keeps the corrector bracket valid
@@ -670,14 +667,28 @@ class _CCBase(Refiner):
         never engages, so nothing is over-sampled. The cap is applied
         after the ``[dT_min, dT_max]`` clamp, so ``dT_min`` yields when
         it would otherwise block the drift target.
+    dc_min : float
+        Minimum concentration drift required per step, the complement of
+        ``dc_max``: a density *ceiling* that coarsens a boundary which is
+        steep in mu (``_dT_adapt`` shrinks the step toward ``dT_min``) but
+        nearly flat in c, where ``dc_max`` never engages and the curve
+        gets over-sampled. The step grows so the plotted concentration
+        moves at least ``dc_min``, but never past ``dT_max``. Disabled by
+        default (``0.0``); set it below ``dc_max`` to thin redundant
+        points without losing resolution.
+    max_steps : int
+        Hard cap on steps per trace direction, just in case the
+        adaptive logic somehow fails to terminate.
     """
 
-    def __init__(self, dT_max: float = 5.0, dT_min: float = 1.0,
-                 max_steps: int = 500, dc_max: float = 0.01):
+    def __init__(self, *, dT_max: float = 5.0, dT_min: float = 1.0,
+                 dc_max: float = 0.01, dc_min: float = 0.0,
+                 max_steps: int = 500):
         self.dT_max = dT_max
         self.dT_min = dT_min
-        self.max_steps = max_steps
         self.dc_max = dc_max
+        self.dc_min = dc_min
+        self.max_steps = max_steps
 
     # -- subclass hooks -----------------------------------------------------
 
@@ -798,8 +809,8 @@ class _CCBase(Refiner):
         return half_width / slope
 
     def _emitted_concentrations(self, pt, phases) -> tuple[float, ...]:
-        """Concentrations plotted by one emitted point, for the ``dc_max``
-        density floor in :meth:`_trace`.
+        """Concentrations plotted by one emitted point, for the
+        ``dc_max``/``dc_min`` density caps in :meth:`_trace`.
 
         A :class:`RefinedMiscibilityGap` plots its two pre-computed branch
         concentrations; a :class:`RefinedPoint` plots one branch per
@@ -916,6 +927,14 @@ class _CCBase(Refiner):
             # tiny absolute floor keeps the walk progressing.
             if dc_dT > 0:
                 dT_adapt = max(min(dT_adapt, self.dc_max / dc_dT), 1e-3)
+                # Concentration-drift floor (density ceiling): grow the step
+                # so |dc| per step reaches dc_min where it would otherwise
+                # over-sample a steep-in-mu, flat-in-c boundary. Capped at
+                # dT_max so the floor never oversteps the hard step bound.
+                # Off when dc_min == 0; kept below dc_max so it can't fight
+                # the cap above.
+                if self.dc_min > 0:
+                    dT_adapt = min(max(dT_adapt, self.dc_min / dc_dT), self.dT_max)
             dT = sign * dT_adapt
             # Don't step past the walk boundary; clip dT instead.
             if sign * (T + dT - T_target) > 0:
@@ -1045,6 +1064,8 @@ class ClausiusClapeyronRefiner(_CCBase):
     dT_min : float
         Minimum temperature step / bootstrap step (K). See
         :class:`_CCBase`.
+    dc_max, dc_min : float
+        Per-step concentration-drift cap / floor. See :class:`_CCBase`.
     max_steps : int
         Hard cap on steps per trace direction. See :class:`_CCBase`.
     """
@@ -1158,7 +1179,7 @@ class MiscibilityGapRefiner(_CCBase):
 
     Parameters
     ----------
-    dT_max, dT_min, max_steps :
+    dT_max, dT_min, dc_max, dc_min, max_steps :
         See :class:`_CCBase`.
     c_jump_min : float
         Minimum c-spread of a simplex's vertices for it to be seeded.
@@ -1173,12 +1194,12 @@ class MiscibilityGapRefiner(_CCBase):
 
     label = "miscibility-gap"
 
-    def __init__(self, dT_max: float = 5.0, dT_min: float = 1.0,
-                 max_steps: int = 500, dc_max: float = 0.01,
-                 c_jump_min: float = 0.3,
+    def __init__(self, *, dT_max: float = 5.0, dT_min: float = 1.0,
+                 dc_max: float = 0.01, dc_min: float = 0.0,
+                 max_steps: int = 500, c_jump_min: float = 0.3,
                  gap_close: float = 1e-3, gap_share_min: float = 0.1):
-        super().__init__(dT_max=dT_max, dT_min=dT_min, max_steps=max_steps,
-                         dc_max=dc_max)
+        super().__init__(dT_max=dT_max, dT_min=dT_min, dc_max=dc_max,
+                         dc_min=dc_min, max_steps=max_steps)
         self.c_jump_min = c_jump_min
         self.gap_close = gap_close
         self.gap_share_min = gap_share_min

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -322,6 +322,36 @@ def test_cc_refiner_dc_min_noop_when_drift_already_met():
     assert len(on) == len(off)
 
 
+def _solve_steep_caps(dc_max, dc_min, cslope):
+    A = _SteepMuFlatCPhase(name="A", a=1.0, k=0.0, c0=0.5, cslope=cslope)
+    B = _SteepMuFlatCPhase(name="B", a=0.0, k=0.025, c0=0.2, cslope=0.0)
+    pts = ClausiusClapeyronRefiner(dc_max=dc_max, dc_min=dc_min).solve(
+        _steep_candidate(), {"A": A, "B": B})
+    return A, sorted(pts, key=lambda p: p.T)
+
+
+def test_cc_refiner_dc_max_takes_precedence_over_dc_min():
+    """The max bound wins: a dc_min set above dc_max still cannot drive a step
+    past the dc_max cap, so the per-step drift is pinned at dc_max."""
+    # dc_min = 0.05 alone wants dT = 0.05 / 4e-3 = 12.5 K (clamped to dT_max),
+    # but dc_max = 0.01 caps the drift at dT = 0.01 / 4e-3 = 2.5 K.
+    A, pts = _solve_steep_caps(dc_max=0.01, dc_min=0.05, cslope=4e-3)
+    assert len(pts) > 4
+    cs = np.array([float(A.concentration(p.T, p.mu)) for p in pts])
+    assert np.abs(np.diff(cs)).max() == pytest.approx(0.01, abs=1e-9)
+
+
+def test_cc_refiner_dT_max_bounds_dc_min_floor():
+    """The dc_min floor never oversteps dT_max even when the drift target
+    would call for a larger step."""
+    # dc_min = 0.05 wants dT = 50 K with cslope = 1e-3; dc_max = 1.0 is slack,
+    # so only dT_max = 5 K bounds the step.
+    _, pts = _solve_steep_caps(dc_max=1.0, dc_min=0.05, cslope=1e-3)
+    assert len(pts) > 4
+    Ts = np.sort([p.T for p in pts])
+    assert np.diff(Ts).max() == pytest.approx(5.0, abs=1e-9)
+
+
 def test_simplex_straddles_segment_crossing():
     """A simplex with no traced vertex inside still gets skipped if a
     segment of the traced line crosses its bounding box."""

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -239,6 +239,89 @@ def test_cc_refiner_dc_max_noop_on_constant_c_boundary():
     assert len(tight) == len(loose)
 
 
+# -- dc_min concentration-drift floor ----------------------------------------
+
+
+@dataclass(frozen=True)
+class _SteepMuFlatCPhase(Phase):
+    """Toy phase with decoupled boundary slope and plotted concentration.
+
+    ``phi(T, mu) = -mu * a - k * (T - T0)`` so a coexistence pair with
+    different ``a`` locates ``mu* = -(k1 - k2)/(a1 - a2) * (T - T0)`` — a
+    boundary whose mu-slope is set by ``k`` alone. ``concentration`` is
+    defined independently as a near-flat ``c0 + cslope * (T - T0)``; the toy
+    need not satisfy ``c = -dphi/dmu``, so the boundary can be steep in mu
+    (``_dT_adapt`` pins the step at ``dT_min``) while c barely drifts —
+    exactly the regime the ``dc_min`` density ceiling targets.
+    """
+
+    a: float = 0.0
+    k: float = 0.0
+    c0: float = 0.5
+    cslope: float = 0.0
+    T0: float = 850.0
+
+    def semigrand_potential(self, T, mu):
+        return -np.asarray(mu, float) * self.a - self.k * (np.asarray(T, float) - self.T0)
+
+    def concentration(self, T, mu):
+        return self.c0 + self.cslope * (np.asarray(T, float) - self.T0) + 0.0 * np.asarray(mu, float)
+
+
+def _steep_candidate(T_min=840.0, T_max=860.0, T_c=850.0):
+    return _InterCandidate(
+        phase1="A", phase2="B", T_seed=T_c,
+        mu_bracket=(-0.05, 0.05), T_bracket=(T_c - 5.0, T_c + 5.0),
+        T_min=T_min, T_max=T_max,
+        proj_p1=(T_c, -0.1), proj_p2=(T_c, 0.1),
+    )
+
+
+def _solve_steep(dc_min, cslope=1e-3, K=0.025):
+    # mu* = K * (T - 850); |dmu/dT| = K, so _dT_adapt = half_width / K = 2 K,
+    # finer than dT_max = 5 K (the boundary is over-sampled) yet the dT_min
+    # bootstrap shift K * 1 = 0.025 stays inside the half-width bracket.
+    A = _SteepMuFlatCPhase(name="A", a=1.0, k=0.0, c0=0.5, cslope=cslope)
+    B = _SteepMuFlatCPhase(name="B", a=0.0, k=K, c0=0.2, cslope=0.0)
+    pts = ClausiusClapeyronRefiner(dc_min=dc_min).solve(
+        _steep_candidate(), {"A": A, "B": B})
+    return A, sorted(pts, key=lambda p: p.T)
+
+
+def test_cc_refiner_dc_min_floors_concentration_drift():
+    """On a steep-in-mu, flat-in-c boundary the floor grows each steady step
+    until the plotted concentration drifts exactly dc_min (capped at dT_max)."""
+    A, pts = _solve_steep(dc_min=4e-3)
+    assert len(pts) > 4  # genuinely traced
+    order = np.argsort([p.T for p in pts])
+    Ts = np.array([p.T for p in pts])[order]
+    cs = np.array([float(A.concentration(p.T, p.mu)) for p in pts])[order]
+    # Steady steps sit on the floor: dT = dc_min / cslope = 4 K, dc = dc_min.
+    # Nothing drifts more (dc_max is slack, dT_max = 5 K is not reached); the
+    # bootstrap and the truncated end steps drift less.
+    assert np.abs(np.diff(cs)).max() == pytest.approx(4e-3, abs=1e-9)
+    assert np.diff(Ts).max() == pytest.approx(4.0, abs=1e-9)
+
+
+def test_cc_refiner_dc_min_thins_oversampled_boundary():
+    """Without the floor the over-sampled steep-in-mu boundary steps at the
+    bare _dT_adapt size; the floor coarsens it to fewer points."""
+    _, dense = _solve_steep(dc_min=0.0)
+    _, thin = _solve_steep(dc_min=4e-3)
+    # Regime check: with the floor off every step is the 2 K _dT_adapt size.
+    assert np.diff(sorted(p.T for p in dense)).max() == pytest.approx(2.0, abs=1e-9)
+    assert len(thin) < len(dense)
+
+
+def test_cc_refiner_dc_min_noop_when_drift_already_met():
+    """A boundary whose bare step already drifts past dc_min never engages the
+    floor: identical point count whether it is set or off."""
+    _, off = _solve_steep(dc_min=0.0, cslope=3e-3)
+    _, on = _solve_steep(dc_min=4e-3, cslope=3e-3)
+    assert len(off) > 4  # genuinely traced
+    assert len(on) == len(off)
+
+
 def test_simplex_straddles_segment_crossing():
     """A simplex with no traced vertex inside still gets skipped if a
     segment of the traced line crosses its bounding box."""


### PR DESCRIPTION
## Change

Follow-up to #308, which added a `dc_max` concentration-drift cap (a density *floor*) to the `_CCBase` tracers. This adds the complement, `dc_min`, plus a small constructor cleanup.

- **`dc_min` density ceiling.** Where a coexistence boundary is steep in mu — so `_dT_adapt` shrinks the step toward `dT_min` — but nearly flat in c, `dc_max` never engages and the curve is over-sampled with redundant points. `dc_min` grows the step so the plotted concentration moves at least `dc_min` per step, capped at `dT_max`. Shared by `ClausiusClapeyronRefiner` and `MiscibilityGapRefiner` via `_CCBase`, reading the plotted concentrations through the existing `_emitted_concentrations` hook.
- **`max` bounds take precedence over `min` bounds.** The `dc_min` floor is applied before the `dc_max` cap in the trace loop, so `dc_max` always wins: a `dc_min` set at or above `dc_max` yields and the per-step drift never exceeds `dc_max`. `dT_max` likewise bounds the floor.
- **Disabled by default (`0.0`)**, so it is a no-op unless set and existing diagram shapes are unchanged.
- **Keyword-only constructors, reordered args.** `_CCBase.__init__` and `MiscibilityGapRefiner.__init__` are now keyword-only (`*`), with the dc caps grouped and the `max_steps` hard cap moved last: `dT_max, dT_min, dc_max, dc_min, max_steps`. Every existing caller (tests, `benchmarks/cc_sampling_density.py`) already passes by keyword, so nothing breaks.

## Tests

`tests/unit/test_refine.py` adds a toy `_SteepMuFlatCPhase` whose boundary mu-slope (set by `semigrand_potential`) and plotted concentration (set independently by `concentration`) are decoupled, isolating the steep-in-mu / flat-in-c regime the floor targets:

- `test_cc_refiner_dc_min_floors_concentration_drift` — each steady step's plotted drift is pinned to exactly `dc_min` (`dT = dc_min / cslope`), nothing drifts more, asserted at `atol=1e-9`.
- `test_cc_refiner_dc_min_thins_oversampled_boundary` — turning the floor on coarsens an over-sampled boundary to fewer points.
- `test_cc_refiner_dc_min_noop_when_drift_already_met` — a boundary whose bare step already drifts past `dc_min` gets the identical point count whether the floor is set or off.
- `test_cc_refiner_dc_max_takes_precedence_over_dc_min` — with `dc_min` set 5× larger than `dc_max`, the per-step drift is still capped at `dc_max`.
- `test_cc_refiner_dT_max_bounds_dc_min_floor` — the floor never oversteps `dT_max` when the drift target would call for a larger step.

Full suite: 567 passed, 1 xfailed.