### PR TITLE
feat(interpolate): add monotone_slope to SoftplusSurface2DInterpolator

### DIFF
--- a/benchmarks/bench_monotone_slope.py
+++ b/benchmarks/bench_monotone_slope.py
@@ -1,0 +1,124 @@
+"""Cost and guarantee of ``SoftplusSurface2DInterpolator(monotone_slope=True)``.
+
+The free slope ``b_i(T)`` is a free polynomial in 1/T and can reverse direction
+(sharpen, then soften again as it cools) -- unphysical for a convex well.
+``monotone_slope=True`` reparametrises it through the same non-negative softplus
+link the amplitude already uses,
+
+    b_i(T) = s_i * [ softplus(B_i0) + sum_{k>=1} softplus(B_ik) * w^k ],
+    w = max((1/T) - min_train(1/T), 0),
+
+so ``|b_i(T)|`` is non-increasing in T by construction at every temperature.
+Softplus (not sigmoid) is the link: it is unbounded above and keeps the coupled
+solve unconstrained, so the default ``lm`` fast path is retained and the slope is
+free to grow at the cold end.
+
+This benchmark fits the public class both ways on three representative surfaces and
+reports, per surface:
+
+* fit wall-time (best of 3) and its ratio -- the convergence cost of the link;
+* worst-over-T RMSE normalised by the well depth -- the accuracy cost;
+* ``max_T d|b|/dT`` over a wide sweep incl. extrapolation -- positive for the free
+  fit when the well's sharpening is non-monotone, ~0 (the guarantee) for monotone.
+
+Run with ``python benchmarks/bench_monotone_slope.py`` from the repo root
+(``[test]`` extras).
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from landau.interpolate import SoftplusSurface2DInterpolator
+from landau.interpolate.softplus import _softplus
+
+
+# --------------------------------------------------------------------------- #
+# representative surfaces (entropy-removed free energy H(T, c))
+# --------------------------------------------------------------------------- #
+def in_family(T, c, c0=0.36):
+    """In-family softplus V, sharpness b(T) = 4 + 30/T (monotone in 1/T)."""
+    b = 4.0 + 30.0 * (1000.0 / np.asarray(T, float))
+    u = np.asarray(c, float) - c0
+    return -0.2 + 0.05 * _softplus(b * u) + 0.03 * _softplus(-b * u)
+
+
+def sharp_v(T, c, c0=0.36):
+    """Asymmetric hard V, branch slopes ~ 1/T (monotone sharpening, worst case)."""
+    T, u = np.asarray(T, float), np.asarray(c, float) - c0
+    sL, sR = 0.03 + 0.22 * (1000.0 / T), 0.01 + 0.09 * (1000.0 / T)
+    return np.where(u < 0, sL * (-u), sR * u)
+
+
+def humped_b(T, c, c0=0.36):
+    """In-family V whose sharpness is *humped* in 1/T -- a deliberately
+    non-monotone truth, where the constraint genuinely binds."""
+    w = 1000.0 / np.asarray(T, float)
+    b = np.maximum(6.0 + 25.0 * w - 6.0 * w ** 2, 1.0)
+    u = np.asarray(c, float) - c0
+    return -0.2 + 0.05 * _softplus(b * u) + 0.03 * _softplus(-b * u)
+
+
+CASES = {"in_family": in_family, "sharp_v": sharp_v, "humped_b": humped_b}
+NT, NC, TLO, THI, CLO, CHI = 80, 13, 250.0, 1500.0, 0.30, 0.45
+
+
+def grid():
+    Tg, cg = np.linspace(TLO, THI, NT), np.linspace(CLO, CHI, NC)
+    return np.repeat(Tg, NC), np.tile(cg, NT), Tg, cg
+
+
+def nrmse(surface, H, Tg, cg):
+    worst = 0.0
+    for Tq in Tg:
+        truth = H(Tq, cg)
+        depth = max(float(truth.max() - truth.min()), 1e-12)
+        pred = np.asarray(surface.slice_at(Tq)(cg))
+        worst = max(worst, np.sqrt(np.mean((pred - truth) ** 2)) / depth)
+    return worst
+
+
+def max_slope_increase(surface, Tlo, Thi):
+    """Largest forward step of ``|b_i(T)|`` as T rises (over all terms), on a wide
+    sweep including extrapolation.  > 0 means the sharpness reverses somewhere."""
+    Ts = np.linspace(Tlo, Thi, 300)
+    babs = np.array([np.abs(surface.slice_at(float(t)).b) for t in Ts])
+    return float(np.diff(babs, axis=0).max())
+
+
+def best_time(fn, reps=3):
+    best, out = np.inf, None
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        out = fn()
+        best = min(best, time.perf_counter() - t0)
+    return best, out
+
+
+def main() -> None:
+    print(f"grid: {NT} temperatures x {NC} concentrations, T in [{TLO:.0f}, {THI:.0f}]")
+    print("slope sweep for d|b|/dT spans [50, 5000] K (heavy extrapolation)\n")
+    header = (f"{'surface':11s} {'mode':9s} {'fit [ms]':>9s} {'ratio':>6s} "
+              f"{'nrmse':>10s} {'max d|b|/dT':>12s}")
+    print(header)
+    print("-" * len(header))
+    for name, H in CASES.items():
+        T, c, Tg, cg = grid()
+        f = H(T, c)
+        rows = {}
+        for mode in (False, True):
+            itp = SoftplusSurface2DInterpolator(n_softplus=2, monotone_slope=mode)
+            t, surface = best_time(lambda itp=itp: itp.fit(T, c, f))
+            rows[mode] = (t, nrmse(surface, H, Tg, cg), max_slope_increase(surface, 50.0, 5000.0))
+        t_free = rows[False][0]
+        for mode, label in ((False, "free"), (True, "monotone")):
+            t, e, mono = rows[mode]
+            ratio = t / t_free
+            print(f"{name:11s} {label:9s} {t*1e3:9.0f} {ratio:5.2f}x "
+                  f"{e:10.2e} {mono:+12.2e}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/landau/interpolate/softplus.py
+++ b/landau/interpolate/softplus.py
@@ -338,19 +338,37 @@ class SoftplusFittedSurface(FittedSurface):
     at T to produce a :class:`_SoftplusSlice` with an analytic c-derivative; the
     amplitude passes through the softplus link ``a_i(T) = softplus(polyval(Tn,
     A[i]))`` so it is non-negative and the slice is convex in c.
+
+    Under :attr:`SoftplusSurface2DInterpolator.monotone_slope`, ``B`` holds the
+    *pre-link* slope coefficients instead: the slope is
+    ``b_i(T) = signs[i] * sum_k softplus(B[i,k]) * w^k`` with
+    ``w = max(Wn - wmin, 0)``, so ``|b_i(T)|`` is non-increasing in T.  ``signs``
+    and ``wmin`` are stored for :meth:`slice_at`; both are unused for the default
+    free polynomial slope.
     """
 
-    def __init__(self, A, B, C, O, Tm, Ts, wm, ws, cm, cs):
+    def __init__(self, A, B, C, O, Tm, Ts, wm, ws, cm, cs,
+                 monotone_slope=False, signs=None, wmin=0.0):
         self._A, self._B, self._C, self._O = A, B, C, O
         self._Tm, self._Ts, self._wm, self._ws = Tm, Ts, wm, ws
         self._cm, self._cs = cm, cs
+        self._monotone_slope = monotone_slope
+        self._signs = signs        # fixed per-term branch sign (monotone_slope only)
+        self._wmin = wmin          # training min of normalised 1/T (the w=0 anchor)
 
     def slice_at(self, T: float) -> _SoftplusSlice:
         Tn = (float(T) - self._Tm) / self._Ts
         Wn = (1.0 / float(T) - self._wm) / self._ws
         pv = np.polynomial.polynomial.polyval
         a = _softplus(np.array([pv(Tn, row) for row in self._A]))  # non-negative amplitude
-        b = np.array([pv(Wn, row) for row in self._B])             # slope: polynomial in 1/T
+        if self._monotone_slope:
+            # |b| = sum_k softplus(B_k) w^k, w = max(Wn - wmin, 0); sign fixed per term.
+            # Clamping at 0 holds |b| flat for T hotter than training, keeping it
+            # monotone (and positive) under extrapolation past the hot end.
+            w = max(Wn - self._wmin, 0.0)
+            b = np.array([s * pv(w, _softplus(row)) for s, row in zip(self._signs, self._B)])
+        else:
+            b = np.array([pv(Wn, row) for row in self._B])         # slope: polynomial in 1/T
         c = np.array([pv(Tn, row) for row in self._C])
         return _SoftplusSlice(float(pv(Tn, self._O)), a, b, c, self._cm, self._cs)
 
@@ -369,7 +387,9 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
     **slope ``b_i`` is a polynomial in normalised 1/T** -- the well sharpens as the
     temperature drops, so its inverse-temperature dependence is far better
     approximated by a low-order polynomial in 1/T than in T (a polynomial in T
-    cannot track the strong sharpening at the cold end over a wide range).
+    cannot track the strong sharpening at the cold end over a wide range).  Set
+    :attr:`monotone_slope` to additionally constrain ``|b_i(T)|`` to never reverse
+    -- a physically convex well only ever sharpens as it cools.
 
     **Convexity.** The amplitudes are reparametrised through a non-negative link,
     ``a_i(T) = softplus(alpha_i(T))`` with ``alpha_i(T)`` the fitted polynomial,
@@ -457,6 +477,27 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
     poorly on stiff data (see :attr:`_LM_HAS_INTERNAL_SCALING`).  Force ``'lm'``
     or ``'trf'`` to override the default; ``'lm'`` requires ``loss='linear'`` and,
     on scipy < 1.16, still converges poorly on sharp-knee data."""
+    monotone_slope: bool = False
+    """Constrain every term's slope magnitude ``|b_i(T)|`` to be non-increasing in
+    ``T`` -- a convex well only ever sharpens as it cools, so the fitted sharpness
+    should never reverse.  When ``True`` the slope is reparametrised as
+
+        ``b_i(T) = s_i * [ softplus(B_i0) + sum_{k>=1} softplus(B_ik) * w^k ]``,
+        ``w = max((1/T) - min_train(1/T), 0)``,
+
+    with the branch sign ``s_i`` fixed from the per-slice seed.  Each
+    ``softplus(B_ik) >= 0`` and ``w^k`` is non-decreasing in ``1/T``, so ``|b_i|`` is
+    non-decreasing in ``1/T`` (= non-increasing in ``T``) by construction at *every*
+    temperature, training and extrapolated -- the ``max(., 0)`` holds the magnitude
+    flat for ``T`` hotter than the training range rather than letting an even-power
+    term turn it back up.  Softplus (not sigmoid) is the positivity link: it is
+    unbounded above and keeps the solve unconstrained, so the default ``lm`` fast
+    path is retained and the slope is free to grow at the cold end (a bounded
+    sigmoid link caps the slope and converges worse on sharp wells).  The branch
+    sign ``s_i`` is frozen from the per-slice seed and *not* refined by the coupled
+    solve -- reliable for the intended convex-V wells (the opposite-slope seed
+    yields ``[+, -]``), but a near-degenerate seed slice could lock in a wrong
+    sign.  The default ``False`` leaves ``b_i(T)`` a free polynomial in ``1/T``."""
 
     # --- internal solver tuning (not dataclass fields) ---
     _SEED_MAX_NFEV: ClassVar[int] = 300
@@ -519,61 +560,98 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
         terms = p[:n * per].reshape(n, per)
         return terms[:, :na], terms[:, na:na + nb], terms[:, na + nb:], p[n * per:]
 
-    def _const_init(self, a, b, c, off):
+    def _bseed(self, b, b_basis):
+        """Seed the per-term b-block, returning an ``(n, nb)`` array.
+
+        Free slope: the order-0 coefficient is the slice slope ``b_i``, higher
+        orders zero.  Monotone slope: ``B_i0`` goes through the inverse softplus
+        link so the constant magnitude is ``|b_i|``, and the higher-order
+        increments are small but *active* (a non-dead gradient), scaled by the
+        basis column magnitudes so each contributes a few percent of ``|b_i|`` at
+        the cold end rather than being born saturated-off."""
+        na, nb, nc, no = self._orders
+        n = self.n_softplus
+        block = np.zeros((n, nb))
+        if not self.monotone_slope:
+            block[:, 0] = b
+            return block
+        mag = np.maximum(np.abs(b), 1e-6)
+        block[:, 0] = _softplus_inv(mag)
+        if nb > 1:
+            col = np.abs(b_basis).mean(axis=0) if b_basis is not None else np.ones(nb)
+            for k in range(1, nb):
+                block[:, k] = _softplus_inv(0.05 * mag / max(float(col[k]), 1e-12))
+        return block
+
+    def _const_init(self, a, b, c, off, b_basis=None):
         """Coefficient vector for a constant-in-T surface from one slice's
         ``(a, b, c, offset)`` -- order-0 terms set, higher orders zero.  The
         amplitude is mapped through the inverse link (``alpha0 = softplus_inv(a)``)
-        since ``A`` parametrises ``alpha``, not ``a``.  With :attr:`shared_knee`
-        the per-slice seed already has identical knees across terms
-        (:func:`_smoothv_seed`), so ``c[0]`` is the shared value."""
+        since ``A`` parametrises ``alpha``, not ``a``; the b-block is seeded by
+        :meth:`_bseed` (which applies the same inverse link under
+        :attr:`monotone_slope`, ``b_basis`` being its slope Vandermonde).  With
+        :attr:`shared_knee` the per-slice seed already has identical knees across
+        terms (:func:`_smoothv_seed`), so ``c[0]`` is the shared value."""
         na, nb, nc, no = self._orders
         n = self.n_softplus
         offset = np.zeros(no)
         offset[0] = off
+        bblock = self._bseed(b, b_basis)
         if self.shared_knee:
             terms = np.zeros((n, na + nb))
             terms[:, 0] = _softplus_inv(a)
-            terms[:, na] = b
+            terms[:, na:na + nb] = bblock
             c_shared = np.zeros(nc)
             c_shared[0] = c[0]
             return np.concatenate([terms.ravel(), c_shared, offset])
         terms = np.zeros((n, na + nb + nc))
         terms[:, 0] = _softplus_inv(a)
-        terms[:, na] = b
+        terms[:, na:na + nb] = bblock
         terms[:, na + nb] = c
         return np.concatenate([terms.ravel(), offset])
 
-    def _model_and_jac(self, p, cn, vt):
+    def _model_and_jac(self, p, cn, vt, signs=None):
         """Model values and analytic Jacobian ``d(model)/d(params)`` in one pass.
 
         The coupled fit evaluates the residual and Jacobian at the same point on
         every iteration, so the per-term ``softplus``/``sigmoid`` are computed
         once here and reused for both the value and its derivatives.  ``vt`` is the
-        Vandermonde of normalised T for a/c/offset and of normalised 1/T for b;
+        Vandermonde of normalised T for a/c/offset and, for b, of normalised 1/T
+        (free slope) or of the clamped shifted ``w >= 0`` (:attr:`monotone_slope`);
         the Jacobian columns follow the ``[A_i | B_i | C_i]`` term layout, offset
         last -- or, with :attr:`shared_knee`, ``[A_i | B_i]`` per term, one shared
         knee block, then offset, matching :meth:`_unpack`.  In the shared case
         every term evaluates the same knee polynomial (``C`` is already broadcast
         by :meth:`_unpack`), and by the chain rule the derivative wrt a shared
         coefficient is the *sum* of each term's contribution, so the per-term
-        knee blocks are accumulated rather than each appended separately.
+        knee blocks are accumulated rather than each appended separately.  Under
+        :attr:`monotone_slope` the slope passes through the same non-negative
+        softplus link as the amplitude (``signs`` carries the fixed branch sign
+        ``s_i``), so ``db/dB_ik = s_i * sigmoid(B_ik) * w^k``.
         """
         VTa, VWb, VTc, VTo = vt
         A, B, C, O = self._unpack(p)
         out = VTo @ O
         blocks = []
         dC_shared = np.zeros((cn.size, VTc.shape[1])) if self.shared_knee else None
-        for Ai, Bi, Ci in zip(A, B, C):
+        for i, (Ai, Bi, Ci) in enumerate(zip(A, B, C)):
             alpha = VTa @ Ai
             a = _softplus(alpha)        # amplitude link -> convexity; da/dalpha = sigmoid(alpha)
-            b = VWb @ Bi                # slope: polynomial in 1/T
+            if self.monotone_slope:
+                # |b| = sum_k softplus(B_k) w^k, monotone in w=1/T; db/dB_k = sigmoid(B_k) w^k
+                spB, sgB = _softplus(Bi), _sigmoid(Bi)
+                b = signs[i] * (VWb @ spB)
+                db = signs[i] * (VWb * sgB[None, :])
+            else:
+                b = VWb @ Bi            # slope: free polynomial in 1/T
+                db = VWb
             u = cn + VTc @ Ci
             t = b * u
             sig = _sigmoid(t)
             spt = _softplus(t)
             out = out + a * spt
             blocks.append((spt * _sigmoid(alpha))[:, None] * VTa)  # d/dA via the link
-            blocks.append((a * sig * u)[:, None] * VWb)
+            blocks.append((a * sig * u)[:, None] * db)
             dC = (a * sig * b)[:, None] * VTc
             if self.shared_knee:
                 dC_shared += dC
@@ -609,22 +687,27 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
             np.vander(Tn, no, increasing=True),
         )
 
-    def _seed_starts(self, T, cn, f):
-        """Constant-in-T seed vectors from the coldest and central temperature slices.
+    def _seed_starts(self, T, cn, f, b_basis=None):
+        """Constant-in-T ``(seed, signs)`` pairs from the coldest and central slices.
 
         Trying both guards against a bad basin: the central slice alone misplaces
         the knee on a strongly T-sharpening well, while the cold slice alone misses
         a second term that only the warm data resolves.  The per-slice fit is
         capped (:attr:`_SEED_MAX_NFEV`), so seeding cost is independent of how many
-        temperatures are sampled.
+        temperatures are sampled.  ``signs`` is the per-term branch sign of the
+        slice slopes, fixed for :attr:`monotone_slope` (unused otherwise);
+        ``b_basis`` is the slope Vandermonde, used to scale the seed increments.
         """
         uT = np.unique(T)
         max_nfev = min(self.max_nfev, self._SEED_MAX_NFEV)
-        return [
-            self._const_init(*_fit_slice(cn[np.isclose(T, Tseed)], f[np.isclose(T, Tseed)],
-                                         self.n_softplus, max_nfev))
-            for Tseed in (uT[0], uT[len(uT) // 2])
-        ]
+        starts = []
+        for Tseed in (uT[0], uT[len(uT) // 2]):
+            m = np.isclose(T, Tseed)
+            a0, b0, c0, off0 = _fit_slice(cn[m], f[m], self.n_softplus, max_nfev)
+            signs = np.sign(b0)
+            signs[signs == 0] = 1.0
+            starts.append((self._const_init(a0, b0, c0, off0, b_basis), signs))
+        return starts
 
     def fit(self, T, c, f) -> SoftplusFittedSurface:
         T = np.asarray(T, float)
@@ -638,14 +721,20 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
         Tn, Tm, Ts = _standardize(T)        # amplitude / knee / offset polynomials are in T
         Wn, wm, ws = _standardize(1.0 / T)  # slope polynomial is in 1/T
         cn, cm, cs = _standardize(c)
-        vt = self._vandermonde(Tn, Wn)
+        # monotone slope: fit b against the clamped shifted variable w = max(Wn - wmin, 0)
+        # (training min of 1/T maps to w=0), so |b| is non-decreasing in 1/T by construction.
+        wmin = float(Wn.min())
+        Wb = np.maximum(Wn - wmin, 0.0) if self.monotone_slope else Wn
+        vt = self._vandermonde(Tn, Wb)
 
         ridge = 1e-7 * (float(np.abs(f).max()) or 1.0)
         eye = ridge * np.eye(self._n_params)
         kwargs = self._solver_kwargs()
 
-        def coupled(seed):
-            return _CachedResidual(self._model_and_jac, cn, vt, f, seed, ridge, eye, kwargs)
+        def coupled(seed, signs):
+            mj = ((lambda p, cn_, vt_: self._model_and_jac(p, cn_, vt_, signs))
+                  if self.monotone_slope else self._model_and_jac)
+            return _CachedResidual(mj, cn, vt, f, seed, ridge, eye, kwargs)
 
         # Race the two seeds: a short polish each, finish only the better one.  The
         # faster-converging seed is *not* the one with the lower constant-in-T start
@@ -655,9 +744,11 @@ class SoftplusSurface2DInterpolator(SurfaceInterpolator):
         # so structureless data can't wander down a flat valley to a degenerate
         # huge-amplitude basin; if the short polish already converged it *is* the answer.
         race_nfev = min(self.max_nfev, self._SEED_RACE_NFEV)
-        trials = [(seed, coupled(seed).solve(race_nfev)) for seed in self._seed_starts(T, cn, f)]
-        seed, trial = min(trials, key=lambda st: st[1].cost)
-        res = trial if trial.status > 0 else coupled(seed).solve(self.max_nfev)
+        trials = [(seed, signs, coupled(seed, signs).solve(race_nfev))
+                  for seed, signs in self._seed_starts(T, cn, f, vt[1])]
+        seed, signs, trial = min(trials, key=lambda st: st[2].cost)
+        res = trial if trial.status > 0 else coupled(seed, signs).solve(self.max_nfev)
 
         A, B, C, O = self._unpack(res.x)
-        return SoftplusFittedSurface(A, B, C, O, Tm, Ts, wm, ws, cm, cs)
+        return SoftplusFittedSurface(A, B, C, O, Tm, Ts, wm, ws, cm, cs,
+                                     monotone_slope=self.monotone_slope, signs=signs, wmin=wmin)

--- a/tests/unit/interpolate/test_softplus_surface.py
+++ b/tests/unit/interpolate/test_softplus_surface.py
@@ -183,6 +183,136 @@ def test_shared_knee_reduces_parameter_count():
 
 
 # --------------------------------------------------------------------------- #
+# monotone_slope: |b_i(T)| never reverses (a convex well only sharpens as it cools)
+# --------------------------------------------------------------------------- #
+MONO_ATOL = 1e-9  # forward-difference slack for "|b| non-increasing in T"
+
+
+def _abs_slopes_over_T(surface, Ts):
+    """``|b_i(T)|`` for every term, stacked as ``(len(Ts), n_softplus)``."""
+    return np.array([np.abs(surface.slice_at(float(t)).b) for t in Ts])
+
+
+def test_monotone_slope_recovers_in_family_surface():
+    """``_v_slope_1overT`` sharpens monotonically (b = 4 + 30/T), so the monotone
+    parametrisation can still recover it tightly -- the constraint is consistent
+    with the data and costs no accuracy."""
+    Tg = np.linspace(200.0, 1000.0, 40)
+    cg = np.linspace(0.30, 0.45, 11)
+    T = np.repeat(Tg, len(cg))
+    c = np.tile(cg, len(Tg))
+    surface = SoftplusSurface2DInterpolator(n_softplus=2, monotone_slope=True).fit(
+        T, c, _v_slope_1overT(T, c))
+    for Tq in (Tg[0], Tg[len(Tg) // 2], Tg[-1]):
+        np.testing.assert_allclose(surface.slice_at(Tq)(cg), _v_slope_1overT(Tq, cg), atol=1e-6)
+
+
+def test_monotone_slope_is_monotone_far_outside_training_range():
+    """``|b_i(T)|`` is non-increasing in T at *every* term and temperature,
+    including heavy extrapolation on both sides of the (250, 1500) training range
+    -- the clamp ``w = max(Wn - wmin, 0)`` holds it flat past the hot end rather
+    than letting the even-power term turn it back up."""
+    c0 = 0.36
+    Tg = np.linspace(250.0, 1500.0, 50)
+    cg = np.linspace(0.30, 0.45, 13)
+    T = np.repeat(Tg, len(cg))
+    c = np.tile(cg, len(Tg))
+
+    def H(Tq, cq):
+        Tq, u = np.asarray(Tq, float), np.asarray(cq, float) - c0
+        sL, sR = 0.03 + 0.22 * (1000.0 / Tq), 0.01 + 0.09 * (1000.0 / Tq)
+        return np.where(u < 0, sL * (-u), sR * u)
+
+    surface = SoftplusSurface2DInterpolator(n_softplus=2, monotone_slope=True).fit(T, c, H(T, c))
+    Ts = np.linspace(50.0, 5000.0, 300)  # far below and above the training window
+    babs = _abs_slopes_over_T(surface, Ts)
+    assert np.diff(babs, axis=0).max() <= MONO_ATOL
+    # non-degenerate: a constant or b~0 fit would also be "monotone", so pin that
+    # this is a genuine sharpening fit -- recovers the data and spans a wide |b|.
+    assert babs.max() > 3.0 * babs[-1].max()  # cold slope >> flat hot-extrapolation floor
+    for Tq in (Tg[0], Tg[len(Tg) // 2], Tg[-1]):
+        depth = max(H(Tq, cg.max()), H(Tq, cg.min()))
+        pred = np.asarray(surface.slice_at(Tq)(cg))
+        assert np.sqrt(np.mean((pred - H(Tq, cg)) ** 2)) / depth < 1e-3
+
+
+def test_monotone_slope_constrains_a_non_monotone_truth():
+    """When the true sharpness is genuinely humped in 1/T, the free polynomial
+    slope reproduces the reversal while ``monotone_slope`` refuses it -- proof the
+    constraint binds rather than being vacuous."""
+    c0 = 0.36
+
+    def H(Tq, cq):
+        w = 1000.0 / np.asarray(Tq, float)
+        b = np.maximum(6.0 + 25.0 * w - 6.0 * w ** 2, 1.0)  # non-monotone in 1/T
+        u = np.asarray(cq, float) - c0
+        return -0.2 + 0.05 * _softplus(b * u) + 0.03 * _softplus(-b * u)
+
+    Tg = np.linspace(250.0, 1500.0, 40)
+    cg = np.linspace(0.30, 0.45, 13)
+    T = np.repeat(Tg, len(cg))
+    c = np.tile(cg, len(Tg))
+    free = SoftplusSurface2DInterpolator(n_softplus=2, monotone_slope=False).fit(T, c, H(T, c))
+    mono = SoftplusSurface2DInterpolator(n_softplus=2, monotone_slope=True).fit(T, c, H(T, c))
+
+    Ts = np.linspace(Tg[0], Tg[-1], 150)
+    free_b = _abs_slopes_over_T(free, Ts)
+    mono_b = _abs_slopes_over_T(mono, Ts)
+    assert np.diff(free_b, axis=0).max() > 1e-2            # free follows the reversal
+    assert np.diff(mono_b, axis=0).max() <= MONO_ATOL      # monotone refuses it
+
+
+def test_monotone_slope_keeps_slices_convex():
+    """The amplitude softplus link is untouched, so a monotone-slope fit on
+    arbitrary noisy data still yields non-negative amplitudes and convex slices
+    while honouring the slope constraint."""
+    rng = np.random.default_rng(0)
+    T, c, Tg, cg = _grid(nT=18, nc=9)
+    H = rng.normal(scale=0.05, size=c.shape)
+    surface = SoftplusSurface2DInterpolator(monotone_slope=True, max_nfev=300).fit(T, c, H)
+    for Tq in (Tg[0], Tg[len(Tg) // 2], Tg[-1]):
+        sl = surface.slice_at(Tq)
+        assert (sl.a >= 0).all()
+        assert _second_difference_min(sl, 0.2, 0.8) >= -CONVEX_ATOL
+    Ts = np.linspace(Tg[0], Tg[-1], 120)
+    assert np.diff(_abs_slopes_over_T(surface, Ts), axis=0).max() <= MONO_ATOL
+
+
+def test_monotone_slope_composes_with_shared_knee():
+    """``shared_knee`` and ``monotone_slope`` together: the b-block layout differs
+    under ``shared_knee``, so pin that the two compose -- an in-family V that
+    sharpens as 1/T (shared knee at c0) is still recovered and stays monotone."""
+    Tg = np.linspace(200.0, 1000.0, 40)
+    cg = np.linspace(0.30, 0.45, 11)
+    T = np.repeat(Tg, len(cg))
+    c = np.tile(cg, len(Tg))
+    surface = SoftplusSurface2DInterpolator(
+        n_softplus=2, shared_knee=True, monotone_slope=True).fit(T, c, _v_slope_1overT(T, c))
+    for Tq in (Tg[0], Tg[len(Tg) // 2], Tg[-1]):
+        np.testing.assert_allclose(surface.slice_at(Tq)(cg), _v_slope_1overT(Tq, cg), atol=RECOVER_ATOL)
+    Ts = np.linspace(50.0, 5000.0, 200)
+    assert np.diff(_abs_slopes_over_T(surface, Ts), axis=0).max() <= MONO_ATOL
+
+
+def test_monotone_slope_recovers_and_stays_monotone_with_three_terms():
+    """With ``n_softplus=3`` the extra term carries a fixed, seed-derived branch
+    sign the coupled solve cannot flip.  Pin that a third term neither breaks
+    recovery of the two-term in-family V nor introduces a non-monotone slope of
+    its own (every term's ``|b_i(T)|`` stays non-increasing)."""
+    Tg = np.linspace(200.0, 1000.0, 40)
+    cg = np.linspace(0.30, 0.45, 11)
+    T = np.repeat(Tg, len(cg))
+    c = np.tile(cg, len(Tg))
+    surface = SoftplusSurface2DInterpolator(n_softplus=3, monotone_slope=True).fit(
+        T, c, _v_slope_1overT(T, c))
+    for Tq in (Tg[0], Tg[-1]):
+        np.testing.assert_allclose(surface.slice_at(Tq)(cg), _v_slope_1overT(Tq, cg), atol=RECOVER_ATOL)
+    Ts = np.linspace(50.0, 5000.0, 200)
+    babs = _abs_slopes_over_T(surface, Ts)  # (M, 3): all three terms
+    assert np.diff(babs, axis=0).max() <= MONO_ATOL
+
+
+# --------------------------------------------------------------------------- #
 # convexity (the reason softplus is used over a polynomial amplitude)
 # --------------------------------------------------------------------------- #
 @settings(max_examples=15, deadline=None)
@@ -300,6 +430,7 @@ def test_interpolator_is_frozen_and_hashable():
     assert hash(a) == hash(b)
     assert len({a, b}) == 1
     assert SoftplusSurface2DInterpolator(b_order=3) != a
+    assert SoftplusSurface2DInterpolator(monotone_slope=True) != a
     with pytest.raises(Exception):
         a.n_softplus = 5
 
@@ -360,6 +491,30 @@ def test_surface_phase_solver_and_gibbs_duhem():
     assert (c >= crange[0] - 1e-6).all() and (c <= crange[1] + 1e-6).all()
 
     # c = -dphi/ddmu via the analytic slice derivative, at strictly interior c
+    h = 1e-4
+    cphi = -(phase.semigrand_potential(np.full_like(dmu, T), dmu + h)
+             - phase.semigrand_potential(np.full_like(dmu, T), dmu - h)) / (2 * h)
+    interior = (c > crange[0] + 1e-3) & (c < crange[1] - 1e-3)
+    assert interior.any()
+    np.testing.assert_allclose(c[interior], cphi[interior], atol=GIBBS_ATOL)
+
+
+def test_monotone_slope_surface_phase_gibbs_duhem():
+    """Under ``monotone_slope`` the monotone slice's analytic c-derivative still
+    feeds the parent phase's logit-Newton solver correctly, so ``c = -dphi/ddmu``
+    holds at interior c -- the reparametrised slope must not break the exact
+    stationary-point relation the free-slope path satisfies."""
+    lines, crange = _intermetallic_line_phases()
+    phase = Surface2DInterpolatingPhase(
+        "im", lines, concentration_range=crange, add_entropy=False,
+        surface_interpolator=SoftplusSurface2DInterpolator(monotone_slope=True))
+
+    T = 500.0
+    dmu = np.linspace(-0.2, 0.2, 41)
+    c = phase.concentration(np.full_like(dmu, T), dmu)
+    phi = phase.semigrand_potential(np.full_like(dmu, T), dmu)
+    assert np.isfinite(c).all() and np.isfinite(phi).all()
+
     h = 1e-4
     cphi = -(phase.semigrand_potential(np.full_like(dmu, T), dmu + h)
              - phase.semigrand_potential(np.full_like(dmu, T), dmu - h)) / (2 * h)


### PR DESCRIPTION
## What

Adds an opt-in `monotone_slope: bool = False` to `SoftplusSurface2DInterpolator`. When set, every term's slope magnitude `|b_i(T)|` is constrained to be non-increasing in `T`. The default is unchanged (`b_i(T)` stays a free polynomial in `1/T`).

## Why

A convex well only ever sharpens as it cools, so the fitted sharpness should never reverse. The free slope (a degree-`b_order` polynomial in `1/T`) has no such guarantee — it can sharpen and then soften again across the range. `benchmarks/bench_monotone_slope.py` includes a `humped_b` surface where the free fit reproduces exactly that reversal.

## How

The slope is reparametrised through the same non-negative softplus link the amplitude already uses (`a_i = softplus(α_i)`):

```
b_i(T) = s_i * [ softplus(B_i0) + sum_{k>=1} softplus(B_ik) * w^k ],
w = max((1/T) - min_train(1/T), 0)
```

with the branch sign `s_i` fixed from the per-slice seed. Each `softplus(B_ik) >= 0` and `w^k` is non-decreasing in `1/T`, so `|b_i|` is non-increasing in `T` by construction at every temperature. The `max(., 0)` clamp anchors the training minimum at `w = 0` and holds `|b|` flat for `T` hotter than the training range, so an even-power term cannot turn it back up (or flip its sign) under extrapolation.

`s_i` is frozen from the seed and not refined by the coupled solve — reliable for the intended convex-V wells (the opposite-slope seed yields `[+, -]`); a near-degenerate seed slice could in principle lock in a wrong sign.

### Softplus, not sigmoid, for the positivity link

Both keep `|b|` positive, but softplus is `(0, ∞)` while sigmoid is `(0, s)`. Sigmoid imposes a ceiling that caps the slope (which grows unboundedly at the cold end) and saturates at both tails; in a side comparison it converged worse on sharp wells and never tripped the convergence test on the sharpest case, burning the full iteration budget. Softplus is unbounded above and keeps the coupled solve unconstrained, so the default `lm` fast path is retained.

## Cost

`benchmarks/bench_monotone_slope.py` fits the public class both ways on three surfaces (fit wall-time, worst-over-T normalised RMSE, and `max_T d|b|/dT` over `[50, 5000] K`):

- `in_family` (monotone truth): ~1.5x fit time, recovers to ~1e-7 (vs ~1e-10 free), guarantee holds exactly (`+0.0`).
- `sharp_v` (sharp monotone truth): monotone is *faster* (~0.45x) and more accurate — the constraint regularizes the stiff sharp-knee fit.
- `humped_b` (non-monotone truth): free follows the reversal; monotone refuses it (higher RMSE, as expected when the data genuinely reverses).

## Tests

`tests/unit/interpolate/test_softplus_surface.py`:
- in-family recovery under the constraint (`atol=1e-6`);
- `|b_i(T)|` non-increasing across heavy extrapolation on both sides of the training range, with a recovery + wide-`|b|`-span check so a degenerate/constant fit cannot pass;
- the constraint binding on a non-monotone truth (free reverses, monotone does not);
- convexity and non-negative amplitudes preserved on noisy data;
- composition with `shared_knee=True` (recovery + monotonicity);
- `n_softplus=3` sign stability (extra term stays monotone, recovery holds);
- Gibbs-Duhem `c = -dphi/dmu` consistency under monotone mode via `Surface2DInterpolatingPhase`;
- `monotone_slope` participates in dataclass equality.

Full `tests/unit/interpolate` + `tests/unit/test_phases.py` suite passes (184 tests); existing `SoftplusSurface2DInterpolator` behaviour with the default `monotone_slope=False` is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1mZq2oTsLDfnecKvrnJQz