### PR TITLE
test(poly): direct unit tests for _to_mpl_polygon

### DIFF
--- a/tests/unit/test_poly.py
+++ b/tests/unit/test_poly.py
@@ -17,6 +17,7 @@ import pytest
 from matplotlib.patches import Polygon
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
+from unittest.mock import MagicMock
 
 # Check if optional dependencies are available
 try:
@@ -570,3 +571,37 @@ def test_segment_tsp_polygon_rotated_tour_cut_inside_segment():
     assert isinstance(result, shapely.Polygon)
     assert result.is_valid
     assert result.equals(shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]))
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        shapely.LineString([(0, 0), (1, 1)]),
+        shapely.MultiPolygon(
+            [
+                shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                shapely.Polygon([(2, 2), (3, 2), (3, 3), (2, 3)]),
+            ]
+        ),
+        shapely.Point(0, 0),
+        shapely.Polygon(),
+    ],
+    ids=["linestring", "multipolygon", "point", "empty_polygon"],
+)
+def test_to_mpl_polygon_non_polygon_returns_none(shape):
+    assert AbstractPolyMethod._to_mpl_polygon(shape) is None
+
+
+def test_to_mpl_polygon_degenerate_boundary_returns_none():
+    # A Polygon whose exterior ring has collapsed below 3 coordinates.
+    shape = MagicMock(spec=shapely.Polygon)
+    shape.is_empty = False
+    shape.exterior.coords = [(0.0, 0.0), (1.0, 0.0)]
+    assert AbstractPolyMethod._to_mpl_polygon(shape) is None
+
+
+def test_to_mpl_polygon_valid_polygon_round_trips_coords():
+    shape = shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    result = AbstractPolyMethod._to_mpl_polygon(shape)
+    assert isinstance(result, Polygon)
+    np.testing.assert_array_equal(result.get_xy(), np.asarray(shape.exterior.coords))


### PR DESCRIPTION
Closes #294.

`AbstractPolyMethod._to_mpl_polygon(shape)` (`landau/poly.py:145`) had no direct unit tests. Adds three cases covering its branches:

1. **non-`shapely.Polygon` input** — `LineString`, `MultiPolygon`, `Point`, and an empty `Polygon` all return `None`. Parametrized.
2. **`Polygon` with `<3` exterior coords** — returns `None`. A real `shapely.Polygon` can't be constructed with a degenerate exterior ring (the constructor requires a closed ring of at least 4 coordinates), so this uses `MagicMock(spec=shapely.Polygon)` with `is_empty=False` and a 2-point `exterior.coords` to exercise the branch directly.
3. **valid `Polygon`** — returns a `matplotlib.patches.Polygon` whose `get_xy()` equals `shape.exterior.coords`.

Added `AbstractPolyMethod` and `unittest.mock.MagicMock` to the `tests/unit/test_poly.py` imports; no production code changes.

`pytest tests/unit/test_poly.py` — 36 passed. `pytest tests/unit` — 350 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwtFyxhBZb2q983zBy3s8R)_