### PR TITLE
fix(phases): anchor check_concentration_interpolation plot_excess to line phases' own concentrations

### DIFF
--- a/landau/phases/__init__.py
+++ b/landau/phases/__init__.py
@@ -833,17 +833,26 @@ def check_concentration_interpolation(
     free_energy = phase.free_energy(T, x)
 
     if plot_excess:
-        p_min = min(phases, key=lambda p: p.fixed_concentration)
-        p_max = max(phases, key=lambda p: p.fixed_concentration)
+        # Anchor the chord to the line phases' own free energies at their own
+        # concentrations (c_lo, c_hi) -- not at the concentration_range bounds
+        # (cmin, cmax).  The two coincide only when concentration_range happens
+        # to match the underlying phases' span; concentration_range can be wider
+        # (e.g. maximum_extrapolation > 0) or narrower (an explicit range), and
+        # in either case the previous code used cmin/cmax as both the chord's
+        # x-anchors and the entropy-correction concentration, which is only
+        # correct when c_lo == cmin and c_hi == cmax.
+        p_min = min(phases, key=lambda p: p.line_concentration)
+        p_max = max(phases, key=lambda p: p.line_concentration)
+        c_lo, c_hi = p_min.line_concentration, p_max.line_concentration
         f_min = p_min.line_free_energy(T)
         f_max = p_max.line_free_energy(T)
 
         # line_free_energy doesn't automatically respect add_entropy, unlike free_energy
         if phase.add_entropy:
-            f_min -= T * S(cmin)
-            f_max -= T * S(cmax)
+            f_min -= T * S(c_lo)
+            f_max -= T * S(c_hi)
 
-        free_energy -= (((cmax-x)*f_min + (x-cmin)*f_max)/(cmax-cmin))
+        free_energy -= (((c_hi-x)*f_min + (x-c_lo)*f_max)/(c_hi-c_lo))
 
     plt.plot(x, free_energy, label=phase.name)
 
@@ -855,7 +864,7 @@ def check_concentration_interpolation(
             line_free_energy -= T * S(cline)
 
         if plot_excess:
-            line_free_energy -= (((cmax-cline)*f_min + (cline-cmin)*f_max)/(cmax-cmin))
+            line_free_energy -= (((c_hi-cline)*f_min + (cline-c_lo)*f_max)/(c_hi-c_lo))
 
         plt.scatter(cline, line_free_energy)
 

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -1198,3 +1198,38 @@ def test_check_concentration_interpolation_error_respects_add_entropy():
         assert_allclose(off[:, 1], expected[order], atol=ERR_ATOL)
     finally:
         plt.close(fig)
+
+
+@pytest.mark.parametrize("concentration_range", [(0.3, 0.7), (0.0, 1.0)])
+@pytest.mark.parametrize("add_entropy", [False, True])
+def test_check_concentration_interpolation_plot_excess_anchors_to_line_phases(
+    concentration_range, add_entropy
+):
+    """plot_excess subtracts the chord between the *line phases'* free energies at
+    their own (min/max) concentrations -- not at the concentration_range bounds.
+    The two coincide only when concentration_range matches the line phases' span;
+    here it doesn't, both narrower (0.3, 0.7) and wider (0.0, 1.0) than the
+    phases' [0.2, 0.8], so the extremal line phases must land exactly on zero in
+    both directions and under add_entropy (which exercises the S(c) correction
+    at the line phase's own concentration rather than the range bound)."""
+    cs = [0.2, 0.5, 0.8]
+    fe = [0.0, -0.3, 0.05]
+    lps = [LinePhase(n, c, f) for n, c, f in zip("ABC", cs, fe)]
+    phase = SlowInterpolatingPhase(
+        name="sol",
+        phases=lps,
+        concentration_range=concentration_range,
+        interpolator=PolyFit(2),
+        add_entropy=add_entropy,
+    )
+
+    fig, ax = plt.subplots()
+    try:
+        phase.check_concentration_interpolation(T=1000, plot_excess=True)
+        offsets = {tuple(c.get_offsets()[0]) for c in ax.collections}
+        anchors = {c for c in offsets if c[0] in (0.2, 0.8)}
+        assert len(anchors) == 2
+        for _, y in anchors:
+            assert abs(y) < ERR_ATOL
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
`check_concentration_interpolation(plot_excess=True)` subtracts the chord between the extremal line phases' free energies. It used the `concentration_range` bounds (`cmin`, `cmax`) both as the chord's x-anchors and as the entropy-correction concentration. Those only coincide with the line phases' own concentrations when `concentration_range` matches their span exactly.

With an explicit `concentration_range` narrower or wider than the underlying line phases (e.g. `maximum_extrapolation > 0`, or an explicit range), the chord no longer passed through the phases' actual free energies, and the entropy term used `S(cmin)/S(cmax)` instead of `S` at each line phase's own concentration — so the extremal line phases no longer landed on zero excess.

Anchor the chord to the min/max-concentration line phases' own `(c_lo, c_hi)` and apply the entropy correction at those concentrations instead.

## Tests

`tests/unit/test_phases.py`: `test_check_concentration_interpolation_plot_excess_anchors_to_line_phases`, parametrized over a narrower `(0.3, 0.7)` and wider `(0.0, 1.0)` `concentration_range` than the phases' `[0.2, 0.8]` span, and over `add_entropy` — asserts the two extremal line phases land on zero excess (`< ERR_ATOL`) in both directions and under the entropy correction.

- `pytest tests/unit/test_phases.py -k "plot_excess_anchors or check_concentration"` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9NeYq1J4wqpT9pYEGwiSU)_