### PR TITLE
Vectorized coarse-then-refine CC trace (parked, with timing analysis)

### DIFF
--- a/benchmarks/bench_cc_vectorized.py
+++ b/benchmarks/bench_cc_vectorized.py
@@ -1,0 +1,147 @@
+"""Where the ``ClausiusClapeyronRefiner`` trace spends its time.
+
+This driver backs the timing analysis on the vectorized coarse-then-refine CC
+trace (the ``_bisect_vectorized`` densification). It is a *diagnostic* record,
+not a win: on the phases currently in the library the vectorization does not
+speed the refiner up, and the numbers here say why. It becomes a win only for a
+phase whose ``semigrand_potential`` genuinely batches over an *array of
+distinct T* with non-trivial per-element cost.
+
+Three measurements, run from the repo root with
+``python benchmarks/bench_cc_vectorized.py``:
+
+1. **propose vs. trace (cheap phase).** On an ``IdealSolution`` solid/liquid
+   grid, ``propose`` (Delaunay + a ``df.iloc[simplex]`` per simplex) dominates;
+   the trace's ``semigrand_potential`` calls are a minority. Vectorizing the
+   trace cannot move a number the refiner is not spending time on.
+
+2. **eval attribution (expensive phase).** On a ``FastInterpolatingPhase`` pair
+   the expensive ``_solve_fixed_T`` calls are counted by refiner call site. They
+   land almost entirely in the *scalar* coarse walk / seed root-finding
+   (``<lambda>`` inside ``_refine_step``), not in the vectorized densification.
+
+3. **densification batching (vectorizing phase).** For ``IdealSolution`` —
+   which broadcasts ``semigrand_potential`` over ``T`` — the densification's
+   ``_bisect_vectorized`` calls carry many elements each, i.e. the batching the
+   design is built to exploit does happen; it just does not dominate runtime.
+"""
+from __future__ import annotations
+
+import time
+from collections import Counter
+import traceback
+
+import numpy as np
+from scipy.constants import Boltzmann, eV
+
+from landau.phases import LinePhase, IdealSolution, FastInterpolatingPhase
+from landau.interpolate import RedlichKister
+from landau.calculate import calc_phase_diagram, refine_phase_diagram
+from landau.refine import ClausiusClapeyronRefiner, _delaunay_simplices
+
+kB = Boltzmann / eV
+
+Ts = np.linspace(200, 1800, 25)
+mus = np.linspace(-0.3, 0.3, 21)
+
+
+def _best(fn, repeats=5):
+    best = np.inf
+    for _ in range(repeats):
+        t = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t)
+    return best
+
+
+def ideal_system():
+    solid = IdealSolution(
+        "solid", LinePhase("A", 0, -2.0, 1.0 * kB), LinePhase("B", 1, -3.0, 1.5 * kB))
+    liquid = IdealSolution(
+        "liquid", LinePhase("A(l)", 0, -1.9, 2.5 * kB), LinePhase("B(l)", 1, -2.9, 2.2 * kB))
+    return [solid, liquid], {"solid": solid, "liquid": liquid}
+
+
+def fast_system():
+    def mk(name, e, s):
+        cs = [0, 0.25, 0.5, 0.75, 1.0]
+        lps = [LinePhase(f"{name}{i}", c, e + 0.2 * c * (1 - c), s) for i, c in enumerate(cs)]
+        return FastInterpolatingPhase(
+            name=name, phases=lps, add_entropy=True, interpolator=RedlichKister(2))
+    a, b = mk("alpha", -2.0, 1.0 * kB), mk("beta", -1.9, 2.6 * kB)
+    return [a, b], {"alpha": a, "beta": b}
+
+
+def propose_vs_trace():
+    phases, mapping = ideal_system()
+    df = calc_phase_diagram(phases, Ts=Ts, mu=mus, refine=False, keep_unstable=False)
+    r = ClausiusClapeyronRefiner()
+    n_simplices = len(list(_delaunay_simplices(df)))
+    t_propose = _best(lambda: list(r.propose(df)))
+    t_run = _best(lambda: r.run(df, mapping))
+    print("[1] propose vs. trace (IdealSolution, cheap phi)")
+    print(f"    grid={len(df)} points, {n_simplices} simplices")
+    print(f"    propose(): {t_propose * 1e3:6.1f} ms   "
+          f"full run(): {t_run * 1e3:6.1f} ms   "
+          f"propose share: {t_propose / t_run:4.0%}")
+
+
+def eval_attribution():
+    phases, mapping = fast_system()
+    df = calc_phase_diagram(phases, Ts=Ts, mu=mus, refine=False, keep_unstable=False)
+    site = Counter()
+    orig = FastInterpolatingPhase._solve_fixed_T
+
+    def counted(self, T, dmu):
+        last = "?"
+        for fr in traceback.extract_stack():
+            if "refine.py" in fr.filename:
+                last = fr.name
+        site[last] += 1
+        return orig(self, T, dmu)
+
+    FastInterpolatingPhase._solve_fixed_T = counted
+    try:
+        out = refine_phase_diagram(df, mapping, refiners=[ClausiusClapeyronRefiner()])
+    finally:
+        FastInterpolatingPhase._solve_fixed_T = orig
+    cc = out[out["refined"] == "clausius-clapeyron"]
+    print("[2] expensive _solve_fixed_T evals by call site "
+          "(FastInterpolatingPhase)")
+    print(f"    output points={cc.groupby(['T', 'mu']).ngroups}   "
+          f"total evals={sum(site.values())}")
+    for name, n in site.most_common():
+        print(f"      {name:20} {n}")
+
+
+def densification_batching():
+    phases, mapping = ideal_system()
+    df = calc_phase_diagram(phases, Ts=Ts, mu=mus, refine=False, keep_unstable=False)
+    sizes = []
+    orig = IdealSolution.semigrand_potential
+
+    def counted(self, T, dmu):
+        sizes.append(int(np.size(np.broadcast_arrays(np.asarray(T), np.asarray(dmu))[0])))
+        return orig(self, T, dmu)
+
+    IdealSolution.semigrand_potential = counted
+    try:
+        refine_phase_diagram(df, mapping, refiners=[ClausiusClapeyronRefiner()])
+    finally:
+        IdealSolution.semigrand_potential = orig
+    arr = np.array(sizes)
+    print("[3] semigrand_potential call sizes (IdealSolution, vectorizes over T)")
+    print(f"    calls={arr.size}   scalar(1-elem)={int((arr == 1).sum())}   "
+          f"batched(>1)={int((arr > 1).sum())}   max batch={arr.max()}")
+
+
+def main() -> None:
+    propose_vs_trace()
+    print()
+    eval_attribution()
+    print()
+    densification_batching()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_cc_vectorized.py
+++ b/benchmarks/bench_cc_vectorized.py
@@ -22,9 +22,10 @@ branch (same machine).
    trace's ``semigrand_potential`` calls dominate.
 
 2. **eval attribution (expensive phase).** On a ``FastInterpolatingPhase`` pair
-   the expensive ``_solve_fixed_T`` calls are counted by refiner call site. They
-   land almost entirely in the *scalar* coarse walk / seed root-finding
-   (``<lambda>`` inside ``_refine_step``), not in the vectorized densification.
+   the expensive ``_solve_fixed_T`` calls are counted per refiner stage
+   (seed root-find / extent walk / densification). Runs on ``main`` too, where
+   the stages are ``_seed_step`` and ``_trace`` — comparing the two runs shows
+   where this branch spends evals the sequential tracer does not.
 
 3. **densification batching (vectorizing phase).** For ``IdealSolution`` —
    which broadcasts ``semigrand_potential`` over ``T`` — the densification's
@@ -110,13 +111,14 @@ def eval_attribution():
     df = calc_phase_diagram(phases, Ts=Ts, mu=mus, refine=False, keep_unstable=False)
     site = Counter()
     orig = FastInterpolatingPhase._solve_fixed_T
+    # attribute each eval to the innermost refiner stage on the stack; the
+    # last two names cover the sequential tracer on main so the measurement
+    # compares across checkouts
+    stages = ("_seed_step", "_coarse_walk", "_densify", "_trace")
 
     def counted(self, T, dmu):
-        last = "?"
-        for fr in traceback.extract_stack():
-            if "refine.py" in fr.filename:
-                last = fr.name
-        site[last] += 1
+        names = [fr.name for fr in traceback.extract_stack() if "refine.py" in fr.filename]
+        site[next((n for n in reversed(names) if n in stages), "?")] += 1
         return orig(self, T, dmu)
 
     FastInterpolatingPhase._solve_fixed_T = counted

--- a/benchmarks/bench_cc_vectorized.py
+++ b/benchmarks/bench_cc_vectorized.py
@@ -7,13 +7,19 @@ speed the refiner up, and the numbers here say why. It becomes a win only for a
 phase whose ``semigrand_potential`` genuinely batches over an *array of
 distinct T* with non-trivial per-element cost.
 
-Three measurements, run from the repo root with
-``python benchmarks/bench_cc_vectorized.py``:
+Four measurements, run from the repo root with
+``python benchmarks/bench_cc_vectorized.py``. The old-vs-new end-to-end table
+in the PR description is measurement 0 run once on ``main`` and once on this
+branch (same machine).
+
+0. **end-to-end.** Best-of-5 ``refine_phase_diagram`` with only the CC refiner,
+   on a cheap (``IdealSolution``) and an expensive (``FastInterpolatingPhase``)
+   two-phase system, with the emitted point count.
 
 1. **propose vs. trace (cheap phase).** On an ``IdealSolution`` solid/liquid
-   grid, ``propose`` (Delaunay + a ``df.iloc[simplex]`` per simplex) dominates;
-   the trace's ``semigrand_potential`` calls are a minority. Vectorizing the
-   trace cannot move a number the refiner is not spending time on.
+   grid, how the wall-clock splits between ``propose`` and the trace. Since
+   #335 (numpy-backed ``_Simplex``) ``propose`` is a few percent and the
+   trace's ``semigrand_potential`` calls dominate.
 
 2. **eval attribution (expensive phase).** On a ``FastInterpolatingPhase`` pair
    the expensive ``_solve_fixed_T`` calls are counted by refiner call site. They
@@ -70,6 +76,19 @@ def fast_system():
             name=name, phases=lps, add_entropy=True, interpolator=RedlichKister(2))
     a, b = mk("alpha", -2.0, 1.0 * kB), mk("beta", -1.9, 2.6 * kB)
     return [a, b], {"alpha": a, "beta": b}
+
+
+def end_to_end():
+    print("[0] end-to-end refine_phase_diagram, CC refiner only (best of 5)")
+    for label, system in [("IdealSolution", ideal_system),
+                          ("FastInterpolatingPhase", fast_system)]:
+        phases, mapping = system()
+        df = calc_phase_diagram(phases, Ts=Ts, mu=mus, refine=False, keep_unstable=False)
+        out = refine_phase_diagram(df, mapping, refiners=[ClausiusClapeyronRefiner()])
+        cc = out[out["refined"] == "clausius-clapeyron"]
+        t = _best(lambda: refine_phase_diagram(df, mapping, refiners=[ClausiusClapeyronRefiner()]))
+        print(f"    {label:22s} {t * 1e3:7.1f} ms   "
+              f"output points: {cc.groupby(['T', 'mu']).ngroups}")
 
 
 def propose_vs_trace():
@@ -136,6 +155,8 @@ def densification_batching():
 
 
 def main() -> None:
+    end_to_end()
+    print()
     propose_vs_trace()
     print()
     eval_attribution()

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -1100,6 +1100,75 @@ class _CCBase(Refiner):
 
 
 # -- Inter-phase coexistence --------------------------------------------------
+#
+# ClausiusClapeyronRefiner traces its coexistence line differently from the
+# shared _CCBase._trace used by MiscibilityGapRefiner: it walks a very coarse
+# grid to find the line's extent, then recursively halves every interval that
+# is still coarser than the dc_max resolution target, solving all of one
+# level's new midpoints in a single vectorized semigrand_potential pass. The
+# two helpers below are the vectorized primitives that makes that batching
+# possible.
+
+
+def _eval_over_arrays(fn, Ts, mus):
+    """Evaluate a vectorized phase method over paired ``(T, mu)`` arrays.
+
+    Most phases broadcast ``semigrand_potential`` / ``concentration`` over both
+    arguments, so a single call handles a whole array of temperatures. Some
+    phases (e.g. :class:`~landau.phases.RegularSolution`, which keys an internal
+    fit on a *scalar* ``T``) cannot take an array ``T`` and raise; fall back to
+    an elementwise loop for those so the vectorized tracer stays correct, just
+    without the speedup, on any phase.
+    """
+    Ts = np.asarray(Ts, dtype=float)
+    mus = np.asarray(mus, dtype=float)
+    try:
+        out = np.asarray(fn(Ts, mus), dtype=float)
+        if out.shape == Ts.shape:
+            return out
+    except Exception:
+        pass
+    return np.array(
+        [float(fn(float(t), float(m))) for t, m in zip(Ts.ravel(), mus.ravel())]
+    ).reshape(Ts.shape)
+
+
+def _bisect_vectorized(g, lo, hi, xtol=1e-10, max_iter=100, max_expand=40):
+    """Locate one sign-change root of ``g`` per element, all at once.
+
+    ``g`` maps a float array (shape of ``lo`` / ``hi``) to ``g(mu)`` for each
+    element; every bisection iteration is a single vectorized call, so N
+    coexistence chemical potentials at N temperatures cost one pass each rather
+    than N scalar root-finds. Elements whose bracket does not contain a sign
+    change — after a bounded symmetric expansion — come back ``NaN`` so the
+    caller can drop them (a midpoint where the coexistence line does not
+    actually pass).
+    """
+    lo = np.array(lo, dtype=float)
+    hi = np.array(hi, dtype=float)
+    glo = g(lo)
+    ghi = g(hi)
+    for _ in range(max_expand):
+        bad = (np.sign(glo) == np.sign(ghi)) & (glo != 0.0) & (ghi != 0.0)
+        if not bad.any():
+            break
+        width = hi - lo
+        lo = np.where(bad, lo - width, lo)
+        hi = np.where(bad, hi + width, hi)
+        glo = g(lo)
+        ghi = g(hi)
+    valid = np.sign(glo) != np.sign(ghi)
+    for _ in range(max_iter):
+        if np.all(hi - lo <= xtol):
+            break
+        mid = 0.5 * (lo + hi)
+        gm = g(mid)
+        left = np.sign(gm) == np.sign(glo)
+        lo = np.where(left, mid, lo)
+        glo = np.where(left, gm, glo)
+        hi = np.where(~left, mid, hi)
+        ghi = np.where(~left, gm, ghi)
+    return np.where(valid, 0.5 * (lo + hi), np.nan)
 
 
 @dataclass(frozen=True)
@@ -1124,28 +1193,174 @@ class _InterCandidate:
 
 
 class ClausiusClapeyronRefiner(_CCBase):
-    """Predictor-corrector tracer of two-phase coexistence lines.
+    """Coarse-then-refine tracer of two-phase coexistence lines.
 
-    For each two-phase Delaunay simplex, projects across the line
-    between the two phases' vertex centroids to land a seed point on
-    the boundary, then walks T in both directions via isothermal
-    root-finding on ``phi1 - phi2``. The default ``_dT_adapt`` keeps
-    each step's mu drift bounded by the seed bracket's half-width.
+    For each two-phase Delaunay simplex, projects across the line between the
+    two phases' vertex centroids to land a seed point on the boundary. Rather
+    than walking the whole line one adaptive step at a time (the shared
+    :meth:`_CCBase._trace` used by :class:`MiscibilityGapRefiner`), it:
+
+    1. **walks a very coarse grid** — fixed ``dT_max`` steps in both T
+       directions (:meth:`_coarse_walk`) — to find the line's extent as a
+       sparse ``(T, mu*)`` polyline, then
+    2. **recursively doubles the point density** (:meth:`_densify`): every round
+       bisects, in T, each interval still coarser than the ``dc_max`` resolution
+       target and locates *all* those midpoints' coexistence chemical potentials
+       in one vectorized :func:`_bisect_vectorized` pass over
+       ``semigrand_potential``.
+
+    Locating many boundary points per pass instead of one per
+    ``scipy.optimize.root_scalar`` call is the speedup; see
+    ``benchmarks/bench_cc_vectorized.py``.
 
     Parameters
     ----------
     dT_max : float
-        Maximum allowed temperature step (K). See :class:`_CCBase`.
+        Coarse-walk temperature step (K) and the coarsest final spacing —
+        intervals are never left wider than this. See :class:`_CCBase`.
     dT_min : float
-        Minimum temperature step / bootstrap step (K). See
+        See :class:`_CCBase`. **Inert for this refiner:** ``dc_max`` drives the
+        subdivision and overrides any T-step floor (as its cap did for the
+        sequential tracer), so the finest spacing is set by ``dc_max`` down to
+        an absolute ``_dT_floor``, not by ``dT_min``.
+    dc_max : float
+        Per-interval concentration-drift *resolution target*: an interval is
+        subdivided while the plotted concentration moves more than this across
+        it. This is the sole driver of refinement below ``dT_max``. See
         :class:`_CCBase`.
-    dc_max, dc_min : float
-        Per-step concentration-drift cap / floor. See :class:`_CCBase`.
+    dc_min : float
+        See :class:`_CCBase`. **Inert for this refiner:** its purpose — capping
+        the sampling density at the ``dT_max`` scale where c is flat — is met by
+        construction, because the coarse-first walk starts at ``dT_max`` and
+        only ever refines *finer* where ``dc_max`` demands.
     max_steps : int
-        Hard cap on steps per trace direction. See :class:`_CCBase`.
+        Hard cap on coarse-walk steps per direction. See :class:`_CCBase`.
+
+    Notes
+    -----
+    ``dT_min`` and ``dc_min`` stay accepted (both still live for
+    :class:`MiscibilityGapRefiner`, which shares :class:`_CCBase`) so the
+    constructor signature is unchanged, but neither affects this refiner's
+    sampling.
     """
 
     label = "clausius-clapeyron"
+
+    # The coarse walk lays down at most ~2*_n_coarse scalar root-finds across
+    # the whole T span; the vectorized densification does the rest. Its step is
+    # never finer than dT_max (that is the densification's job), so the coarse
+    # pass stays cheap regardless of the target resolution.
+    _n_coarse: ClassVar[int] = 8
+    # Absolute smallest interval the densification will bisect, so the recursion
+    # always terminates even when dc_max can never be met (matches the sequential
+    # tracer's 1e-3 absolute floor). _max_levels bounds the recursion depth.
+    _dT_floor: ClassVar[float] = 1e-3
+    _max_levels: ClassVar[int] = 60
+
+    def solve(self, cand, phases):
+        seed = self._seed_step(cand, phases)
+        if seed is None:
+            return []
+        T0, step0 = seed
+        mu0 = step0.mu_star
+        # Coarse-walk step: span/_n_coarse, but never finer than dT_max so the
+        # scalar pass never does the densification's work.
+        dT_coarse = max(self.dT_max,
+                        (cand.T_max - cand.T_min) / self._n_coarse)
+        coarse = (
+            self._coarse_walk(cand, phases, T0, mu0, cand.T_min, -1, dT_coarse)[::-1]
+            + [(T0, mu0)]
+            + self._coarse_walk(cand, phases, T0, mu0, cand.T_max, +1, dT_coarse)
+        )
+        pts = self._densify(cand, phases, coarse)
+        return [self._emit(cand, T, _StepResult(mu_star=mu)) for T, mu in pts]
+
+    def _coarse_walk(self, cand, phases, T0, mu0, T_target, sign, dT_coarse):
+        """Walk ``dT_coarse`` steps from the seed to a T bound.
+
+        A cheap scalar predictor-corrector (linear mu prediction, isothermal
+        :meth:`_refine_step` correction) that just needs to establish where the
+        coexistence line runs; :meth:`_densify` fills in the interior. Stops
+        when the corrector can no longer bracket a root (the line has ended) or
+        the bound is reached. Returns the walked ``(T, mu*)`` points in walk
+        order (excluding the seed).
+        """
+        half_width = (cand.mu_bracket[1] - cand.mu_bracket[0]) / 2.0
+        out: list[TMuPoint] = []
+        T, mu, slope = T0, mu0, 0.0
+        for _ in range(self.max_steps):
+            if sign * (T_target - T) <= 1e-12:
+                break
+            dT = sign * dT_coarse
+            if sign * (T + dT - T_target) > 0:
+                dT = T_target - T
+            T_next = T + dT
+            mu_pred = self._predict_mu(mu, slope, dT)
+            # A coarse step can move mu* well outside a fixed bracket, so widen
+            # it until the corrector brackets a root (up to a few doublings)
+            # before giving up and ending the trace.
+            bracket = max(half_width, abs(slope * dT) * 2.0)
+            step = None
+            for _ in range(12):
+                try:
+                    step = self._refine_step(
+                        cand, phases, T_next,
+                        mu_pred - bracket, mu_pred + bracket)
+                    break
+                except ValueError:
+                    bracket *= 2.0
+            if step is None:
+                break
+            slope = (step.mu_star - mu) / dT
+            T, mu = T_next, step.mu_star
+            out.append((T, mu))
+        return out
+
+    def _densify(self, cand, phases, coarse):
+        """Recursively halve every interval coarser than ``dT_max`` or ``dc_max``.
+
+        Each round recomputes the plotted concentration drift over every
+        adjacent interval of the current polyline, flags those wider than
+        ``dT_max`` or drifting more than ``dc_max`` (down to the absolute
+        ``_dT_floor``), bisects them in T, and solves all the new midpoints'
+        coexistence chemical potentials in one vectorized pass. Midpoints where
+        no coexistence root is bracketed come back ``NaN`` and are dropped.
+        Iterates until no interval needs splitting, so a boundary curved in c
+        gets dense sampling while one flat in c stays at the coarse ``dT_max``
+        spacing.
+        """
+        p1, p2 = phases[cand.phase1], phases[cand.phase2]
+        half_width = (cand.mu_bracket[1] - cand.mu_bracket[0]) / 2.0
+        pts = sorted(coarse)
+        for _ in range(self._max_levels):
+            Ts = np.array([t for t, _ in pts])
+            mus = np.array([m for _, m in pts])
+            cA = _eval_over_arrays(p1.concentration, Ts, mus)
+            cB = _eval_over_arrays(p2.concentration, Ts, mus)
+            dc = np.maximum(np.abs(np.diff(cA)), np.abs(np.diff(cB)))
+            dT = np.diff(Ts)
+            split = ((dc > self.dc_max) | (dT > self.dT_max)) & (dT > 2 * self._dT_floor)
+            if not split.any():
+                break
+            i = np.nonzero(split)[0]
+            Tm = 0.5 * (Ts[i] + Ts[i + 1])
+            lo = np.minimum(mus[i], mus[i + 1])
+            hi = np.maximum(mus[i], mus[i + 1])
+            # bracket each midpoint's mu* by the enclosing samples, padded so a
+            # boundary flat in mu (lo == hi) still straddles the root
+            pad = np.maximum(hi - lo, half_width)
+
+            def g(mu, Tm=Tm):
+                return (_eval_over_arrays(p1.semigrand_potential, Tm, mu)
+                        - _eval_over_arrays(p2.semigrand_potential, Tm, mu))
+
+            mu_mid = _bisect_vectorized(g, lo - pad, hi + pad)
+            new = [(float(t), float(m))
+                   for t, m in zip(Tm, mu_mid) if np.isfinite(m)]
+            if not new:
+                break
+            pts = sorted(pts + new)
+        return pts
 
     def propose(self, df: pd.DataFrame) -> Iterator[_InterCandidate]:
         T_min = float(df["T"].min())

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -1273,7 +1273,11 @@ class ClausiusClapeyronRefiner(_CCBase):
             + self._coarse_walk(cand, phases, T0, mu0, cand.T_max, +1, dT_coarse)
         )
         pts = self._densify(cand, phases, coarse)
-        return [self._emit(cand, T, _StepResult(mu_star=mu)) for T, mu in pts]
+        # Emit only globally stable points: the seed can project just past a
+        # triple point into a metastable sliver, and a densified midpoint can
+        # land in one even when its enclosing coarse points are stable.
+        emitted = (self._emit(cand, T, _StepResult(mu_star=mu)) for T, mu in pts)
+        return [pt for pt in emitted if not _dominated(pt, phases)]
 
     def _coarse_walk(self, cand, phases, T0, mu0, T_target, sign, dT_coarse):
         """Walk ``dT_coarse`` steps from the seed to a T bound.
@@ -1281,8 +1285,9 @@ class ClausiusClapeyronRefiner(_CCBase):
         A cheap scalar predictor-corrector (linear mu prediction, isothermal
         :meth:`_refine_step` correction) that just needs to establish where the
         coexistence line runs; :meth:`_densify` fills in the interior. Stops
-        when the corrector can no longer bracket a root (the line has ended) or
-        the bound is reached. Returns the walked ``(T, mu*)`` points in walk
+        when the corrector can no longer bracket a root (the line has ended),
+        the walked point is no longer globally stable (the pair's line has
+        crossed a triple point and gone metastable), or the bound is reached. Returns the walked ``(T, mu*)`` points in walk
         order (excluding the seed).
         """
         half_width = (cand.mu_bracket[1] - cand.mu_bracket[0]) / 2.0
@@ -1313,6 +1318,11 @@ class ClausiusClapeyronRefiner(_CCBase):
                 break
             slope = (step.mu_star - mu) / dT
             T, mu = T_next, step.mu_star
+            # Stop once the pair is no longer globally stable here — the
+            # extent search has crossed a triple point; densification only
+            # needs the stable span.
+            if _dominated(self._emit(cand, T, step), phases):
+                break
             out.append((T, mu))
         return out
 

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -27,6 +27,8 @@ from landau.refine import (
     _simplex_containment,
     _state_row,
     _Simplex,
+    _eval_over_arrays,
+    _bisect_vectorized,
 )
 
 
@@ -124,6 +126,131 @@ def test_clausius_clapeyron_refiner_traces_coexistence(two_phase_system):
         assert abs(phi_a - phi_b) < 1e-7
 
 
+# -- vectorized densification primitives -------------------------------------
+
+
+def test_bisect_vectorized_finds_all_roots_in_one_pass():
+    """Each element's sign-change root is located to tolerance simultaneously."""
+    roots = np.array([-0.3, 0.0, 0.7, 2.5])
+
+    def g(mu):
+        return mu - roots  # independent linear root per element
+
+    lo = roots - 1.0
+    hi = roots + 1.0
+    out = _bisect_vectorized(g, lo, hi)
+    np.testing.assert_allclose(out, roots, atol=1e-9)
+
+
+def test_bisect_vectorized_expands_bracket_for_root_outside():
+    """A root outside the initial bracket is recovered by the symmetric
+    expansion instead of being dropped."""
+    def g(mu):
+        return mu - np.array([5.0])  # root far outside [-1, 1]
+
+    out = _bisect_vectorized(g, np.array([-1.0]), np.array([1.0]))
+    np.testing.assert_allclose(out, [5.0], atol=1e-9)
+
+
+def test_bisect_vectorized_nan_when_no_sign_change():
+    """An element whose function never changes sign comes back NaN so the
+    caller can drop that midpoint."""
+    def g(mu):
+        # element 0 has a root at 0.5; element 1 is strictly positive
+        return np.array([mu[0] - 0.5, mu[1] ** 2 + 1.0])
+
+    out = _bisect_vectorized(g, np.array([0.0, -1.0]), np.array([1.0, 1.0]))
+    assert np.isclose(out[0], 0.5, atol=1e-9)
+    assert np.isnan(out[1])
+
+
+def test_eval_over_arrays_vectorized_phase_single_call():
+    """A phase that broadcasts over T is evaluated in one call."""
+    ph = LinePhase(name="A", fixed_concentration=0.3, line_energy=-1.0, line_entropy=1e-4)
+    Ts = np.array([300.0, 600.0, 900.0])
+    mus = np.array([0.01, 0.0, -0.02])
+    got = _eval_over_arrays(ph.semigrand_potential, Ts, mus)
+    want = np.array([float(ph.semigrand_potential(t, m)) for t, m in zip(Ts, mus)])
+    np.testing.assert_allclose(got, want)
+    assert got.shape == Ts.shape
+
+
+def test_eval_over_arrays_falls_back_for_scalar_only_phase():
+    """A phase that raises on an array T (like a scalar-T-fitted model) still
+    evaluates correctly via the elementwise fallback."""
+
+    class _ScalarOnlyPhase:
+        name = "s"
+
+        def semigrand_potential(self, T, mu):
+            # rejects arrays the way an lru_cache-on-scalar-T fit would
+            if np.asarray(T).ndim > 0:
+                raise TypeError("scalar T only")
+            return -0.5 * mu - 1e-3 * T
+
+        def concentration(self, T, mu):
+            return 0.5
+
+    ph = _ScalarOnlyPhase()
+    Ts = np.array([300.0, 600.0])
+    mus = np.array([0.01, -0.01])
+    got = _eval_over_arrays(ph.semigrand_potential, Ts, mus)
+    want = np.array([ph.semigrand_potential(float(t), float(m)) for t, m in zip(Ts, mus)])
+    np.testing.assert_allclose(got, want)
+
+
+def _ideal_solid_liquid():
+    """Solid/liquid ideal-solution binary (from notebooks/IdealSolution.ipynb)."""
+    from scipy.constants import Boltzmann, eV
+    from landau.phases import LinePhase, IdealSolution
+
+    kB = Boltzmann / eV
+    solid = IdealSolution(
+        "solid",
+        LinePhase("A", 0, -2.0, 1.0 * kB),
+        LinePhase("B", 1, -3.0, 1.5 * kB),
+    )
+    liquid = IdealSolution(
+        "liquid",
+        LinePhase("A(l)", 0, -1.9, 2.5 * kB),
+        LinePhase("B(l)", 1, -2.9, 2.2 * kB),
+    )
+    return solid, liquid
+
+
+def _cc_rows(solid, liquid, dc_max):
+    from landau.calculate import calc_phase_diagram, refine_phase_diagram
+
+    Ts = np.linspace(200, 1800, 25)
+    mus = np.linspace(-0.3, 0.3, 21)
+    coarse = calc_phase_diagram(
+        [solid, liquid], Ts=Ts, mu=mus, refine=False, keep_unstable=False)
+    out = refine_phase_diagram(
+        coarse, {"solid": solid, "liquid": liquid},
+        refiners=[ClausiusClapeyronRefiner(dc_max=dc_max)])
+    return out[out["refined"] == "clausius-clapeyron"]
+
+
+def test_cc_densify_matches_root_finding_on_curved_c_boundary():
+    """The vectorized densification lands its refined midpoints on the true
+    coexistence line to bisection tolerance, and dc_max controls the density."""
+    solid, liquid = _ideal_solid_liquid()
+    cc = _cc_rows(solid, liquid, dc_max=0.01)
+    locs = cc.groupby(["T", "mu"]).size().reset_index()
+    assert len(locs) > 10
+    # Every emitted point sits on the coexistence condition phi_solid ==
+    # phi_liquid to bisection tolerance (converted from mu to phi via the
+    # local slope, so ~1e-10 in mu is well under 1e-7 in phi).
+    for T_val, mu_val in zip(locs["T"], locs["mu"]):
+        gap = float(solid.semigrand_potential(T_val, mu_val)
+                    - liquid.semigrand_potential(T_val, mu_val))
+        assert abs(gap) < 1e-7
+    # Tightening dc_max increases the sampling density on the curved boundary.
+    loose = _cc_rows(solid, liquid, dc_max=1e9).groupby(["T", "mu"]).ngroups
+    tight = _cc_rows(solid, liquid, dc_max=1e-3).groupby(["T", "mu"]).ngroups
+    assert tight > loose
+
+
 def test_clausius_clapeyron_refiner_skips_straddling_simplices(two_phase_system):
     """Many Delaunay simplices straddle the same coexistence line; the
     refiner should trace it once and skip the rest."""
@@ -143,17 +270,21 @@ def test_clausius_clapeyron_refiner_skips_straddling_simplices(two_phase_system)
     assert n_points < 3 * T_span / refiner.dT_max
 
 
-def test_clausius_clapeyron_refiner_respects_dT_min(two_phase_system):
+def test_clausius_clapeyron_refiner_coarse_spacing_is_dT_max(two_phase_system):
+    """The coarse walk samples a flat-in-c boundary at exactly dT_max: the two
+    fixed-c line phases never trip dc_max, so nothing is refined below the
+    coarse grid (and dT_min is inert for this refiner)."""
     phases, mapping = two_phase_system
     df = _two_phase_diagram_df(phases)
     refiner = ClausiusClapeyronRefiner(dT_min=20.0, dT_max=50.0)
     out = refiner.run(df, mapping)
     Ts = np.sort(out["T"].unique())
     dTs = np.diff(Ts)
-    # Median step honors dT_min; the only exceptions are the truncation
-    # at each trace's boundary toward T_min / T_max.
-    assert np.median(dTs) >= 20.0
-    assert np.median(dTs) <= 50.0
+    # Interior steps are exactly dT_max; only the two steps truncated at the
+    # T_min / T_max ends are smaller, so the median is dT_max and nothing
+    # exceeds it.
+    assert np.median(dTs) == pytest.approx(50.0)
+    assert dTs.max() <= 50.0 + 1e-9
 
 
 def test_clausius_clapeyron_refiner_label():
@@ -284,7 +415,12 @@ def test_cc_refiner_dc_max_noop_on_constant_c_boundary():
     assert len(tight) == len(loose)
 
 
-# -- dc_min concentration-drift floor ----------------------------------------
+# -- coarse-first density: dT_max cap and inert dT_min / dc_min --------------
+#
+# ClausiusClapeyronRefiner walks a coarse grid and only refines finer where
+# dc_max demands, so a boundary flat in c is never sampled below the dT_max
+# spacing -- the density ceiling the sequential tracer's dc_min provided is now
+# met by construction, and dT_min / dc_min are inert for this refiner.
 
 
 @dataclass(frozen=True)
@@ -296,8 +432,8 @@ class _SteepMuFlatCPhase(Phase):
     boundary whose mu-slope is set by ``k`` alone. ``concentration`` is
     defined independently as a near-flat ``c0 + cslope * (T - T0)``; the toy
     need not satisfy ``c = -dphi/dmu``, so the boundary can be steep in mu
-    (``_dT_adapt`` pins the step at ``dT_min``) while c barely drifts —
-    exactly the regime the ``dc_min`` density ceiling targets.
+    while c barely drifts — the regime where a flat-in-c boundary must not be
+    over-sampled just because it is steep in mu.
     """
 
     a: float = 0.0
@@ -323,9 +459,8 @@ def _steep_candidate(T_min=840.0, T_max=860.0, T_c=850.0):
 
 
 def _solve_steep(dc_min, cslope=1e-3, K=0.025):
-    # mu* = K * (T - 850); |dmu/dT| = K, so _dT_adapt = half_width / K = 2 K,
-    # finer than dT_max = 5 K (the boundary is over-sampled) yet the dT_min
-    # bootstrap shift K * 1 = 0.025 stays inside the half-width bracket.
+    # mu* = K * (T - 850) is steep in mu, but c drifts only cslope per K; the
+    # coarse dT_max = 5 K walk samples it without over-refining.
     A = _SteepMuFlatCPhase(name="A", a=1.0, k=0.0, c0=0.5, cslope=cslope)
     B = _SteepMuFlatCPhase(name="B", a=0.0, k=K, c0=0.2, cslope=0.0)
     pts = ClausiusClapeyronRefiner(dc_min=dc_min).solve(
@@ -333,38 +468,28 @@ def _solve_steep(dc_min, cslope=1e-3, K=0.025):
     return A, sorted(pts, key=lambda p: p.T)
 
 
-def test_cc_refiner_dc_min_floors_concentration_drift():
-    """On a steep-in-mu, flat-in-c boundary the floor grows each steady step
-    until the plotted concentration drifts exactly dc_min (capped at dT_max)."""
-    A, pts = _solve_steep(dc_min=4e-3)
-    assert len(pts) > 4  # genuinely traced
-    order = np.argsort([p.T for p in pts])
-    Ts = np.array([p.T for p in pts])[order]
-    cs = np.array([float(A.concentration(p.T, p.mu)) for p in pts])[order]
-    # Steady steps sit on the floor: dT = dc_min / cslope = 4 K, dc = dc_min.
-    # Nothing drifts more (dc_max is slack, dT_max = 5 K is not reached); the
-    # bootstrap and the truncated end steps drift less.
-    assert np.abs(np.diff(cs)).max() == pytest.approx(4e-3, abs=1e-9)
-    assert np.diff(Ts).max() == pytest.approx(4.0, abs=1e-9)
+def test_cc_refiner_coarse_walk_caps_flat_c_density():
+    """A boundary steep in mu but flat in c is sampled at the coarse dT_max
+    spacing, not finer: the coarse-first walk caps the density by construction,
+    with no dc_min needed."""
+    A, pts = _solve_steep(dc_min=0.0)  # dc_min off
+    assert len(pts) >= 5  # genuinely traced across the window
+    Ts = np.array([p.T for p in pts])
+    # Coarsest-possible spacing is dT_max = 5 K everywhere; nothing is finer
+    # because dc (= cslope * dT = 5e-3) never exceeds the default dc_max = 0.01.
+    assert np.diff(Ts).max() == pytest.approx(5.0, abs=1e-9)
+    cs = np.array([float(A.concentration(p.T, p.mu)) for p in pts])
+    assert np.abs(np.diff(cs)).max() < 0.01
 
 
-def test_cc_refiner_dc_min_thins_oversampled_boundary():
-    """Without the floor the over-sampled steep-in-mu boundary steps at the
-    bare _dT_adapt size; the floor coarsens it to fewer points."""
-    _, dense = _solve_steep(dc_min=0.0)
-    _, thin = _solve_steep(dc_min=4e-3)
-    # Regime check: with the floor off every step is the 2 K _dT_adapt size.
-    assert np.diff(sorted(p.T for p in dense)).max() == pytest.approx(2.0, abs=1e-9)
-    assert len(thin) < len(dense)
-
-
-def test_cc_refiner_dc_min_noop_when_drift_already_met():
-    """A boundary whose bare step already drifts past dc_min never engages the
-    floor: identical point count whether it is set or off."""
-    _, off = _solve_steep(dc_min=0.0, cslope=3e-3)
-    _, on = _solve_steep(dc_min=4e-3, cslope=3e-3)
-    assert len(off) > 4  # genuinely traced
+def test_cc_refiner_dc_min_is_inert():
+    """dc_min has no effect on this refiner: setting it far above the drift
+    yields the identical sampling as leaving it off."""
+    _, off = _solve_steep(dc_min=0.0)
+    _, on = _solve_steep(dc_min=0.05)
+    assert len(off) >= 5
     assert len(on) == len(off)
+    np.testing.assert_allclose([p.T for p in on], [p.T for p in off])
 
 
 def _solve_steep_caps(dc_max, dc_min, cslope):
@@ -375,22 +500,22 @@ def _solve_steep_caps(dc_max, dc_min, cslope):
     return A, sorted(pts, key=lambda p: p.T)
 
 
-def test_cc_refiner_dc_max_takes_precedence_over_dc_min():
-    """The max bound wins: a dc_min set above dc_max still cannot drive a step
-    past the dc_max cap, so the per-step drift is pinned at dc_max."""
-    # dc_min = 0.05 alone wants dT = 0.05 / 4e-3 = 12.5 K (clamped to dT_max),
-    # but dc_max = 0.01 caps the drift at dT = 0.01 / 4e-3 = 2.5 K.
+def test_cc_refiner_dc_max_caps_drift_regardless_of_dc_min():
+    """dc_max subdivides an interval until the plotted concentration drift falls
+    under the cap, independent of the (inert) dc_min."""
+    # Coarse 5 K steps drift cslope * 5 = 0.02 > dc_max = 0.01, so each interval
+    # is halved once to 2.5 K where the drift is exactly 0.01; dc_min is inert.
     A, pts = _solve_steep_caps(dc_max=0.01, dc_min=0.05, cslope=4e-3)
     assert len(pts) > 4
     cs = np.array([float(A.concentration(p.T, p.mu)) for p in pts])
     assert np.abs(np.diff(cs)).max() == pytest.approx(0.01, abs=1e-9)
 
 
-def test_cc_refiner_dT_max_bounds_dc_min_floor():
-    """The dc_min floor never oversteps dT_max even when the drift target
-    would call for a larger step."""
-    # dc_min = 0.05 wants dT = 50 K with cslope = 1e-3; dc_max = 1.0 is slack,
-    # so only dT_max = 5 K bounds the step.
+def test_cc_refiner_flat_c_stays_at_dT_max():
+    """When dc_max is slack the boundary stays at the coarse dT_max spacing —
+    the coarse walk never oversteps or undershoots it."""
+    # cslope = 1e-3 drifts only 5e-3 over a 5 K step, well under dc_max = 1.0,
+    # so no interval is subdivided and the spacing is exactly dT_max = 5 K.
     _, pts = _solve_steep_caps(dc_max=1.0, dc_min=0.05, cslope=1e-3)
     assert len(pts) > 4
     Ts = np.sort([p.T for p in pts])


### PR DESCRIPTION
Parked record of a vectorized rewrite of the `ClausiusClapeyronRefiner` trace. It is correct and fully tested but does **not** speed up the refiner on the phases currently in the library, and regresses expensive ones. Kept because the mechanism is sound and the win lands once a phase whose `semigrand_potential` batches over an array of distinct `T` (with non-trivial per-element cost) exists. Not proposed for merge as-is.

Rebased onto main past #335 (numpy-backed `_Simplex`), #340 (CC trace early abort) and #341 (shared Delaunay tessellation); every number below re-measured at commit c21ac9e against main 26a295b on the same machine.

## What changed

`ClausiusClapeyronRefiner.solve` (only — `MiscibilityGapRefiner` keeps the shared `_CCBase._trace`):

1. **Coarse walk** — a handful of big `dT` steps in both T directions to find the coexistence line's extent (`_coarse_walk`, scalar corrector). The walk aborts once a walked point is dominated and `solve()` emits only globally stable points — the invariant #340 pinned for the sequential tracer (`test_cc_refiner_trace_aborts_in_dominated_region`); adapted in 2948738.
2. **Recursive densification** — repeatedly halve every interval still coarser than `dT_max`/`dc_max` and locate all of one level's midpoints in a single vectorized pass over `semigrand_potential` (`_densify` → `_bisect_vectorized`).

New module helpers `_eval_over_arrays` (array-`T` with an elementwise fallback for phases like `RegularSolution` that key a fit on scalar `T`) and `_bisect_vectorized` (per-element bracketed bisection, NaN where no sign change).

`dc_max` drives subdivision (overriding `dT_min`, as its cap did before). The coarse-first walk caps sampling at the `dT_max` scale in flat-c regions — which is what `dc_min` did for the sequential tracer — so `dT_min` and `dc_min` are **inert for this refiner** (still accepted, still live for `MiscibilityGapRefiner`).

## Timing analysis

All numbers from `benchmarks/bench_cc_vectorized.py` (commit c21ac9e), 5-run best, `refine_phase_diagram` with only the CC refiner. The end-to-end table and the eval attribution are the script's measurements [0] and [2] run once on `main` (26a295b) and once on this branch.

**End-to-end wall-clock**

| system | old (main) | new | output points old → new |
|---|---|---|---|
| `IdealSolution` solid/liquid (cheap `phi`) | 90 ms | 92 ms | 211 → 514 |
| `FastInterpolatingPhase` pair (expensive `phi`) | 29 ms | 855 ms | 10 → 10 |

Cheap phase: a wash on wall-clock, at 2.4× the emitted boundary density (the densification subdivides to the `dc_max` target rather than stepping at the adaptive `dT`). Expensive phase: ~30× slower — main's baseline has dropped from 255 ms to 29 ms since the first measurement here (#335 removed the per-simplex `df.iloc` cost, #340 stopped tracing metastable tails), so the scalar coarse-walk overhead stands out far more starkly than the ~4× first reported.

**Why — three diagnostics from the benchmark:**

1. *`propose()` is no longer a bottleneck anywhere.* On the ideal grid (525 points, 960 simplices) `propose()` is 2.7 ms of a 74 ms `run()` (4%) after #335 — at the first measurement it was 198 ms of 272 ms (73%). The trace's `semigrand_potential` calls now dominate for cheap phases too, so vectorizing them is aimed at the right number; it just doesn't win on these phases.

2. *The extra cost is the scalar coarse walk — which costs more evals than the whole sequential tracer it replaces, despite walking fewer points.* Same 10-point case, `_solve_fixed_T` evals per stage (measurement [2] on both checkouts):

   | | seed | extent walk | densify | total |
   |---|---|---|---|---|
   | main (`_trace`) | 80 | 80 | — | **160** |
   | this branch (`_coarse_walk`) | 80 | 944 | 20 | **1044** |

   The walk's T-step is genuinely coarse (span/8 = 200 K here), but on a candidate whose line has no extent each extension attempt retries the corrector with up to 12 bracket doublings before ending the walk — 10 candidates × 2 directions × 12 attempts ≈ the 944 evals — where the sequential tracer makes one corrector attempt per direction, fails to bracket, and stops (80). Coarser per point, ~12× denser per eval on this case.

3. *The densification does batch where the phase vectorizes over T.* On `IdealSolution` (broadcasts over `T`), the densification issues `semigrand_potential` calls of up to **128 elements** (880 of 3354 calls are multi-element; the total grew from 2832 by the ~500 scalar `_dominated` stability checks added for the #340 semantics). The vectorization the design targets does happen — it just isn't the dominant cost today.

## Dedup / eval-count anomaly

Investigated the "6× more evals, same 10 output points" flagged in review; re-verified unchanged after the rebase. The `FastInterpolatingPhase` test case is a **degenerate near-isothermal feature** at `T=725`: of 40 two-phase simplices, 10 solve and each emits a **single** point (span `[725,725]`); the other 30 straddle-skip. A one-point trace's bbox is too small to make the 10 co-located candidates straddle-skip each other, so all 10 run their coarse walk with 12× bracket expansion trying to extend a line that has no T-extent → the 944 walk evals above (the other 80 are the seed root-finds, identical on main). So: not a batching failure, but (a) coarse-walk bracket expansion is wasteful on off-line/degenerate candidates, and (b) the straddle dedup does not collapse co-located candidates on a near-isothermal feature. (b) predates this branch; (a) is this branch's walk amplifying a candidate set main's tracer bails out of cheaply.

## Known CI failure (expected on this branch)

One border-coverage integration case fails per CI run, and **which one varies between runs**. The latest-deps build jobs reproducibly fail `segments-c-T` (a stable border point 2.4% outside its phase's c-T polygon, threshold 2%; identical value on 3.11/3.12/3.13 and locally). The minimum-deps job, across two runs of test-identical code, failed once on `segments-c-T` (same 2.4%) and once on `tsp-mu-T` (5.4%, with `segments-c-T` passing); the pre-rebase branch failed `tsp-mu-T` at 3.9%. The TSP-based poly methods carry unseeded solver randomness, so the marginal point sets this branch's changed border sampling produces land either side of the 2% threshold depending on the run. All of these cases pass on current main (`Segments × μ-T` remains the only pre-existing xfail). Left unfixed by design: resolving it means cleaning up the coarse-walk sampling, i.e. reviving this parked work. It is the concrete blocker to address before this branch is picked back up.

## Tests

`tests/unit/test_refine.py` (58 pass, including main's #340 pin `test_cc_refiner_trace_aborts_in_dominated_region`, which 2948738 adapts the coarse walk to): direct tests for `_bisect_vectorized` (batch roots, bracket expansion, NaN on no sign change) and `_eval_over_arrays` (vectorized + scalar-only fallback); a densification-accuracy test (every refined midpoint on `phi_solid == phi_liquid` to `<1e-7`, and `dc_max` controls density); the `dc_min` block pins the coarse-first behavior (flat-c boundary capped at `dT_max` with `dc_min` off; `dc_min` inert; `dc_max` still caps drift). Full `unit`/`regression` suites green (633 pass); `integration` green (8 pass, 1 xfail) except the run-varying border-coverage case noted above.

## Where this goes

- #335, #340 and #341 have landed on main and are in this branch's baseline now. The sequential tracer they left behind is ~9× faster on the expensive-phase benchmark than when this branch was first measured, which raises the bar for reviving it.
- This branch is worth resuming if/when a phase with an internally-vectorized-over-`T` `semigrand_potential` lands; the coarse-walk waste (item 2 / anomaly-a / the border-coverage failure) should be trimmed first — bounding the bracket expansion (or reusing main's single-attempt bail-out) recovers most of the 944-vs-80 gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)