### PR TITLE
perf(refine): abort CC trace when the pair goes metastable

### DIFF
--- a/benchmarks/bench_cc_early_abort.py
+++ b/benchmarks/bench_cc_early_abort.py
@@ -1,0 +1,91 @@
+"""Work skipped by the ClausiusClapeyronRefiner early abort.
+
+``_CCBase._trace`` used to walk each two-phase coexistence line all the way to
+the sampled T bound and let ``run`` discard the points where a third phase is
+more stable (the metastable tail past a triple point). The trace now stops as
+soon as it enters a dominated region, so those root-finds are never done. The
+final ``run`` output is unchanged — only the wasted work is removed.
+
+This driver traces a three-phase system whose A-B line is stable only above its
+triple point, and reports the run wall-clock plus, per coexistence pair, the
+fraction of the sampled T range that is metastable (and so no longer traced).
+
+Run ``python benchmarks/bench_cc_early_abort.py`` from the repo root. Measured
+against ``main`` (pre-abort) on the default grid: run() 40.2 ms -> 33.6 ms,
+identical 210-row output; the A-B trace shrinks from 220-480 K to 300-480 K.
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pandas as pd
+
+from landau.phases import LinePhase
+from landau.refine import ClausiusClapeyronRefiner, _dominated
+
+
+def three_phase_system():
+    """Three line phases meeting at a single triple point (T=300, mu=0.2)."""
+    return {
+        "A": LinePhase(name="A", fixed_concentration=0.0, line_energy=-1.0, line_entropy=0.004),
+        "B": LinePhase(name="B", fixed_concentration=0.5, line_energy=-1.2, line_entropy=0.003),
+        "C": LinePhase(name="C", fixed_concentration=1.0, line_energy=-1.7, line_entropy=0.001),
+    }
+
+
+def coarse_df(phases, Ts, mus):
+    rows = []
+    for T in Ts:
+        for mu in mus:
+            phis = {n: float(p.semigrand_potential(T, mu)) for n, p in phases.items()}
+            n = min(phis, key=phis.get)
+            rows.append({"T": T, "mu": mu, "phi": phis[n],
+                         "c": float(phases[n].concentration(T, mu)),
+                         "phase": n, "stable": True})
+    return pd.DataFrame(rows)
+
+
+def _best(fn, repeats=5):
+    best = np.inf
+    out = None
+    for _ in range(repeats):
+        t = time.perf_counter()
+        out = fn()
+        best = min(best, time.perf_counter() - t)
+    return best * 1e3, out
+
+
+def main() -> None:
+    phases = three_phase_system()
+    Ts = np.linspace(220, 480, 20)
+    mus = np.linspace(-0.05, 0.55, 20)
+    df = coarse_df(phases, Ts, mus)
+    T_span = float(df["T"].max() - df["T"].min())
+
+    r = ClausiusClapeyronRefiner()
+    ms, out = _best(lambda: r.run(df, phases))
+    print(f"grid={len(df)} points   run(): {ms:.1f} ms   rows={len(out)}")
+
+    # Per pair: traced T-extent vs the metastable fraction now skipped.
+    print("per coexistence pair (traced T-range | metastable fraction skipped):")
+    seen = set()
+    for cand in r.propose(df):
+        pair = frozenset((cand.phase1, cand.phase2))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        pts = [pt for c in r.propose(df)
+               if frozenset((c.phase1, c.phase2)) == pair
+               for pt in r.solve(c, phases)]
+        if not pts:
+            continue
+        assert all(not _dominated(pt, phases) for pt in pts)
+        lo, hi = min(pt.T for pt in pts), max(pt.T for pt in pts)
+        skipped = 1.0 - (hi - lo) / T_span
+        label = "-".join(sorted(pair))
+        print(f"  {label:>10}: {lo:6.1f}-{hi:6.1f} K   {skipped:5.0%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -876,6 +876,13 @@ class _CCBase(Refiner):
           downright failures (no root in the bracket). Either way the
           trace ends silently here and any points produced so far are
           kept;
+        * walking into a region where a phase outside the pair is more
+          stable (``_dominated``): the pair's line has crossed a triple
+          point and gone metastable, so the walk stops instead of
+          tracing a tail that :meth:`run` would only discard. A stable
+          segment re-emerging past such a gap is picked up by its own
+          seed simplex (whose straddle bbox no longer overlaps this
+          shortened trace);
         * landing on an already-traced segment of the same coexistence
           line (``_point_on_line`` check on ``cand.existing``), to
           avoid retracing.
@@ -938,6 +945,10 @@ class _CCBase(Refiner):
             # straddle dedup downstream decide whether to absorb it.
             return
         T_b = T0 + dT_boot
+        # Abort as soon as the pair goes metastable (see the docstring's
+        # stop conditions) rather than tracing a tail run() would drop.
+        if _dominated(pt, phases):
+            return
         yield pt
         mu_star = step.mu_star
         dmu_dT = (mu_star - mu0) / dT_boot
@@ -996,6 +1007,9 @@ class _CCBase(Refiner):
             dmu_dT = (step.mu_star - mu_star) / dT
             T, mu_star = T_next, step.mu_star
             pt = self._emit(cand, T, step)
+            # Stop once the pair is no longer globally stable here.
+            if _dominated(pt, phases):
+                return
             yield pt
             c_now = self._emitted_concentrations(pt, phases)
             dc_dT = max((abs(a - b) for a, b in zip(c_now, c_prev)),
@@ -1015,7 +1029,11 @@ class _CCBase(Refiner):
         half_width = (mu_hi - mu_lo) / 2.0
         seed_pt = self._emit(cand, T0, step0)
         seed_c = self._emitted_concentrations(seed_pt, phases)
-        out = [seed_pt]
+        # A seed can project just past a triple point into a metastable
+        # region; emit it only if it is globally stable. The traces still run
+        # in both directions and recover the stable segment if the seed sits
+        # just inside a dominated sliver.
+        out = [] if _dominated(seed_pt, phases) else [seed_pt]
         out.extend(self._trace(cand, phases, T0, step0.mu_star, seed_c,
                                half_width, cand.T_max, +1))
         out.extend(self._trace(cand, phases, T0, step0.mu_star, seed_c,

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -160,6 +160,38 @@ def test_clausius_clapeyron_refiner_label():
     assert ClausiusClapeyronRefiner.label == "clausius-clapeyron"
 
 
+def test_cc_refiner_trace_aborts_in_dominated_region():
+    """The trace stops when the pair goes metastable past a triple point,
+    instead of walking the whole T range and leaving run() to drop the
+    dominated tail: every point solve() emits is globally stable.
+
+    Regression — without the early abort solve() walks the A-B line across the
+    triple point into C's region and emits dominated points (only filtered
+    later by run())."""
+    phases = _three_phase_system()  # triple point at (T=300, mu=0.2)
+    Ts = np.linspace(220.0, 480.0, 12)
+    mus = np.linspace(-0.05, 0.55, 15)
+    df = _coarse_df(phases, Ts, mus)
+    refiner = ClausiusClapeyronRefiner()
+    cands = list(refiner.propose(df))
+    # Across every coexistence pair, solve() emits only globally stable points:
+    # the trace aborts on domination and a seed projected into a metastable
+    # sliver is not emitted either. Without the abort the metastable tails are
+    # emitted and only dropped later by run().
+    for c in cands:
+        for pt in refiner.solve(c, phases):
+            assert not _dominated(pt, phases)
+
+    # A-B is stable only for T > 300 here (phi_C - phi_A = 0.001*T - 0.3): the
+    # stable side up toward T_max is traced, and the metastable tail below the
+    # triple point is not (without the abort it would reach T_min = 220).
+    ab = [pt for c in cands if {c.phase1, c.phase2} == {"A", "B"}
+          for pt in refiner.solve(c, phases)]
+    assert ab, "grid should contain an A-B two-phase simplex"
+    assert max(pt.T for pt in ab) > 450.0
+    assert min(pt.T for pt in ab) > 285.0
+
+
 # -- dc_max concentration-drift cap ------------------------------------------
 
 # Physical drift slope: c sweeps ~0.8 -> 0.1 across the sampled T range.


### PR DESCRIPTION
Confirmed the reported behavior: `_CCBase._trace` walked each two-phase coexistence line all the way to the sampled T bound, and domination was only filtered afterward in `run()` (`if pt.T < 0 or _dominated(pt, phases): continue`). So the metastable tail past a triple point was fully traced — one `_refine_step` root-find per step — and then discarded.

## Change

`_CCBase._trace` now stops as soon as an emitted point is `_dominated` (a phase outside the pair is more stable there): the pair's line has crossed a triple point and gone metastable, so there is nothing worth tracing further. `solve()` likewise skips a seed that projects just past a triple point into a metastable sliver. Both are shared by `ClausiusClapeyronRefiner` and `MiscibilityGapRefiner`.

A stable segment that re-emerges past such a gap is still recovered: it has its own two-phase simplex, and because the shortened trace's straddle bbox no longer overlaps it, that seed is no longer skipped and traces the segment itself.

## No output change

`run()` already dropped these points, so the final refined dataframe is identical — the change only removes wasted root-finds. Verified by the full `unit` / `regression` / `integration` suites, including `test_border_coverage.py` (the "polygon doesn't amputate a phase region" smoke test), which is unchanged.

## Numbers

`benchmarks/bench_cc_early_abort.py`, three-phase system (triple point at T=300), 20×20 grid, 5-run best:

| | before (main) | after |
|---|---|---|
| `run()` | 40.2 ms | 33.6 ms |
| rows | 210 | 210 (identical) |

Per coexistence pair, the fraction of the sampled T-range no longer traced:

```
A-B:  300.0-480.0 K   31% skipped
B-C:  300.1-480.0 K   31% skipped
A-C:  220.0-299.8 K   69% skipped
```

The saving scales with how much of each line is metastable — larger on diagrams with more triple points / longer metastable tails.

## Tests

`test_cc_refiner_trace_aborts_in_dominated_region`: on the three-phase fixture, every point `solve()` emits (across all pairs, before `run()`'s filter) is globally stable, and the A-B trace stays on its stable side (T > 300) instead of walking down to T_min = 220. Fails on `main` (the trace emits the dominated tail), passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J283DeTTzhoSz9j1Apn7vP)_