### PR TITLE
perf(refine): merge the 2-D default refiners into one Delaunay2DRefiner

### DIFF
--- a/benchmarks/bench_combined_refiner.py
+++ b/benchmarks/bench_combined_refiner.py
@@ -1,0 +1,96 @@
+"""Delaunay2DRefiner vs. the three separate default refiners.
+
+The 2-D default used to run DelaunayTripleRefiner, ClausiusClapeyronRefiner and
+MiscibilityGapRefiner separately, each tessellating the (mu, T) grid in its own
+propose. Delaunay2DRefiner merges them: one tessellation, one propose that
+yields typed candidates, one run that buckets them back per refiner. This
+driver times both on the testplots example systems and checks the emitted
+transition rows are identical.
+
+Run ``python benchmarks/bench_combined_refiner.py`` from the repo root.
+Reference (best of 6, refine_phase_diagram only, on a precomputed coarse frame):
+
+    system        3 separate   combined
+    2d_basics_mu      949 ms      498 ms   (~1.9x; tessellation-bound)
+    2d_toy           1205 ms     1128 ms   (~6%; per-T-solve-bound)
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+import landau.phases as ldp
+import landau.calculate as ldc
+import landau.interpolate as ldi
+from landau.refine import (
+    Delaunay2DRefiner, DelaunayTripleRefiner, ClausiusClapeyronRefiner,
+    MiscibilityGapRefiner,
+)
+
+SEPARATE = [DelaunayTripleRefiner(), ClausiusClapeyronRefiner(), MiscibilityGapRefiner()]
+COMBINED = [Delaunay2DRefiner()]
+
+
+def basics_mu():
+    fcc = ldp.IdealSolution("fcc", ldp.LinePhase("fccA", 0, -3.00, 1.0 * ldp.kB),
+                            ldp.LinePhase("fccB", 1, -2.00, 1.1 * ldp.kB))
+    hcp = ldp.IdealSolution("hcp", ldp.LinePhase("hcpA", 0, -2.975, 1.8 * ldp.kB),
+                            ldp.LinePhase("hcpB", 1, -1.95, 1.1 * ldp.kB))
+    lqd = ldp.IdealSolution("liquid", ldp.LinePhase("lA", 0, -2.75, 5.0 * ldp.kB),
+                            ldp.LinePhase("lB", 1, -1.75, 4.4 * ldp.kB))
+    phases = [hcp, fcc, lqd]
+    coarse = ldc.calc_phase_diagram(phases, np.linspace(200, 1000, 100),
+                                    mu=np.linspace(0.5, 1.5, 100),
+                                    refine=False, keep_unstable=True)
+    return coarse, {p.name: p for p in phases}
+
+
+def toy():
+    def line(name, c, fs, ip):
+        return ldp.TemperatureDependentLinePhase(
+            name, fixed_concentration=c, temperatures=[1, 750, 1000],
+            free_energies=fs, interpolator=ip)
+    rliq = ldp.FastInterpolatingPhase("liquid", [
+        line("l0", 0, [2.00, 1.80, 1.00], ldi.PolyFit(3)),
+        line("l2", 0.5, [2.45, 2.00, 1.42], ldi.PolyFit(3)),
+        line("l1", 1, [3.00, 2.80, 2.00], ldi.PolyFit(3))])
+    sol = ldp.IdealSolution("solid", line("s0", 0, [1.9, 1.6, 1.2], ldi.SGTE(2)),
+                            line("s1", 1, [2.9, 2.6, 2.2], ldi.SGTE(2)))
+    s3 = line("s3", 0.4, np.array([2.4, 1.85, 1.45]) - 0.05, ldi.SGTE(3))
+    phases = [rliq, sol, s3]
+    c = np.linspace(0, 1, 75)[1:-1]
+    mu = 1 + ldp.kB * 4000 * np.log(c / (1 - c))
+    coarse = ldc.calc_phase_diagram(phases, np.linspace(500, 1000, 40), mu,
+                                    refine=False, keep_unstable=True)
+    return coarse, {p.name: p for p in phases}
+
+
+def _rows_key(df):
+    d = df[df["refined"].isin(["delaunay-triple", "clausius-clapeyron", "miscibility-gap"])]
+    return sorted((r, round(t, 9), round(m, 9), p, round(c, 9))
+                  for r, t, m, p, c in zip(d["refined"], d["T"], d["mu"], d["phase"], d["c"]))
+
+
+def _best(coarse, mapping, refiners, repeats=6):
+    best = np.inf
+    out = None
+    for _ in range(repeats):
+        t = time.perf_counter()
+        out = ldc.refine_phase_diagram(coarse, mapping, refiners=refiners)
+        best = min(best, time.perf_counter() - t)
+    return best * 1e3, out
+
+
+def main() -> None:
+    print(f"{'system':>14} {'3 separate':>12} {'combined':>10}  identical")
+    for name, build in (("2d_basics_mu", basics_mu), ("2d_toy", toy)):
+        coarse, mapping = build()
+        t_sep, sep = _best(coarse, mapping, SEPARATE)
+        t_comb, comb = _best(coarse, mapping, COMBINED)
+        ok = _rows_key(sep) == _rows_key(comb)
+        print(f"{name:>14} {t_sep:>10.0f}ms {t_comb:>8.0f}ms  {ok}")
+
+
+if __name__ == "__main__":
+    main()

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -28,10 +28,19 @@ Refiners shipped here
   for an intra-phase miscibility gap (a single phase that splits
   into two coexisting compositions). Seeds from single-phase
   simplices with a wide c-spread.
+* :class:`Delaunay2DRefiner` — the default for a 2-D ``(mu, T)`` grid:
+  tessellates once and dispatches each simplex by phase count to the
+  triple / inter-phase / miscibility-gap refiner above, so the
+  triangulation is built once instead of once per refiner.
 
 The two Clausius-Clapeyron refiners share their skeleton via the
 private :class:`_CCBase` ABC; see the comment block right above it
 for a quick algorithm overview aimed at new readers.
+
+:meth:`Refiner.run` is split into ``propose`` (candidate generation)
+and ``_run_candidates`` (locate + emit) so :class:`Delaunay2DRefiner`
+can drive each constituent refiner with candidates it proposed off the
+shared tessellation.
 
 Writing a new refiner
 ---------------------
@@ -85,6 +94,7 @@ __all__ = [
     "DelaunayTripleRefiner",
     "ClausiusClapeyronRefiner",
     "MiscibilityGapRefiner",
+    "Delaunay2DRefiner",
     "default_refiners",
 ]
 
@@ -243,8 +253,14 @@ class Refiner(ABC):
     label: ClassVar[str]
 
     @abstractmethod
-    def propose(self, df: pd.DataFrame):
-        """Yield candidate objects to be handed to :meth:`solve`."""
+    def propose(self, df: pd.DataFrame, simplices=None):
+        """Yield candidate objects to be handed to :meth:`solve`.
+
+        ``simplices`` is an optional precomputed
+        ``[(_Simplex, phase_count), ...]`` list (see :func:`_delaunay_simplices`).
+        :class:`Delaunay2DRefiner` passes it so the tessellation is built once
+        and shared; a refiner that needs it and is given ``None`` builds its own.
+        """
 
     @abstractmethod
     def solve(
@@ -259,9 +275,17 @@ class Refiner(ABC):
 
     def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
         """propose → solve → filter → dataframe."""
+        return self._run_candidates(self.propose(df), phases)
+
+    def _run_candidates(self, cands, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        """solve → filter → dataframe for an already-proposed candidate stream.
+
+        Split out of :meth:`run` so :class:`Delaunay2DRefiner` can drive a
+        refiner with candidates it proposed off a shared tessellation.
+        """
         rows: list[dict] = []
         boundary_id = 0
-        for cand in self.propose(df):
+        for cand in cands:
             pts = [pt for pt in self.solve(cand, phases)
                    if pt.T >= 0 and not _dominated(pt, phases)]
             for pt in pts:
@@ -311,7 +335,7 @@ class ScanRefiner(Refiner):
         self.other = "T" if by == "mu" else "mu"
         self.label = by
 
-    def propose(self, df: pd.DataFrame) -> Iterator[_ScanCandidate]:
+    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_ScanCandidate]:
         for other_val, group in df.groupby(self.other):
             g = group.sort_values(self.by).reset_index(drop=True)
             change = g.index[g.phase != g.phase.shift(-1).ffill()]
@@ -403,8 +427,8 @@ class _Simplex:
         return out
 
 
-def _delaunay_simplices(df: pd.DataFrame):
-    """Yield ``(_Simplex, phase_count)`` for each simplex of the (mu, T) tess."""
+def _delaunay_simplices(df: pd.DataFrame) -> list[tuple["_Simplex", int]]:
+    """``[(_Simplex, phase_count), ...]`` for each simplex of the (mu, T) tess."""
     dela = Delaunay(df[["mu", "T"]])
     T = df["T"].to_numpy()
     mu = df["mu"].to_numpy()
@@ -412,8 +436,18 @@ def _delaunay_simplices(df: pd.DataFrame):
     c = df["c"].to_numpy() if "c" in df.columns else np.zeros(len(df))
     phases_arr = phase[dela.simplices]
     counts = np.array([len(set(x)) for x in phases_arr])
-    for s, n in zip(dela.simplices, counts):
-        yield _Simplex(T=T[s], mu=mu[s], phase=phase[s], c=c[s]), int(n)
+    return [(_Simplex(T=T[s], mu=mu[s], phase=phase[s], c=c[s]), int(n))
+            for s, n in zip(dela.simplices, counts)]
+
+
+def _simplices_for(df: pd.DataFrame, simplices):
+    """Precomputed simplices if given, else tessellate ``df`` fresh.
+
+    Lets :class:`Delaunay2DRefiner` build the (mu, T) tessellation once and
+    share it across its constituent refiners, each of which would otherwise
+    rebuild it in its own ``propose``.
+    """
+    return _delaunay_simplices(df) if simplices is None else simplices
 
 
 def _simplex_containment(point: TMuPoint, simplex: _Simplex) -> float:
@@ -469,8 +503,8 @@ class DelaunayLineRefiner(Refiner):
 
     label = "delaunay"
 
-    def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
-        for simplex, n in _delaunay_simplices(df):
+    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_SimplexCandidate]:
+        for simplex, n in _simplices_for(df, simplices):
             if n == 2:
                 yield _SimplexCandidate(simplex=simplex)
 
@@ -520,8 +554,8 @@ class DelaunayTripleRefiner(Refiner):
 
     label = "delaunay-triple"
 
-    def propose(self, df: pd.DataFrame) -> Iterator[_TripleCandidate]:
-        siblings = tuple(simplex for simplex, n in _delaunay_simplices(df) if n == 3)
+    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_TripleCandidate]:
+        siblings = tuple(simplex for simplex, n in _simplices_for(df, simplices) if n == 3)
         for simplex in siblings:
             yield _TripleCandidate(simplex=simplex, siblings=siblings)
 
@@ -1040,7 +1074,7 @@ class _CCBase(Refiner):
                                half_width, cand.T_min, -1))
         return out
 
-    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+    def _run_candidates(self, cands, phases: Mapping[str, Phase]) -> pd.DataFrame:
         rows: list[dict] = []
         # Per-pair list of completed traces; each trace is a tuple of
         # (T, mu) points in walk order. Keeping traces separate (rather
@@ -1051,7 +1085,7 @@ class _CCBase(Refiner):
         # One boundary_id per coexistence line (keyed by _pair_key).
         boundary_ids: dict[object, int] = {}
         next_bid = 0
-        for cand in self.propose(df):
+        for cand in cands:
             key = self._pair_key(cand)
             traces = tuple(traced.get(key, ()))
             if _simplex_straddles(cand, traces):
@@ -1127,10 +1161,10 @@ class ClausiusClapeyronRefiner(_CCBase):
 
     label = "clausius-clapeyron"
 
-    def propose(self, df: pd.DataFrame) -> Iterator[_InterCandidate]:
+    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_InterCandidate]:
         T_min = float(df["T"].min())
         T_max = float(df["T"].max())
-        for simplex, n in _delaunay_simplices(df):
+        for simplex, n in _simplices_for(df, simplices):
             if n != 2:
                 continue
             mu_lo, mu_hi, T_lo, T_hi, T_seed = _simplex_brackets(simplex)
@@ -1260,14 +1294,14 @@ class MiscibilityGapRefiner(_CCBase):
         self.gap_close = gap_close
         self.gap_share_min = gap_share_min
 
-    def propose(self, df: pd.DataFrame) -> Iterator[_GapCandidate]:
+    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_GapCandidate]:
         T_min = float(df["T"].min())
         T_max = float(df["T"].max())
         # Yield widest-c-spread simplex first: the most reliable
         # simplex seeds the trace, and neighbouring ones get straddle-
         # skipped on subsequent iterations.
         candidates: list[tuple[float, _GapCandidate]] = []
-        for simplex, n in _delaunay_simplices(df):
+        for simplex, n in _simplices_for(df, simplices):
             if n != 1:
                 continue
             mu_lo, mu_hi, T_lo, T_hi, T_seed = _simplex_brackets(simplex)
@@ -1343,27 +1377,76 @@ class MiscibilityGapRefiner(_CCBase):
             c_left=x.c_left, c_right=x.c_right)
 
 
+# -- Combined 2-D refiner -----------------------------------------------------
+
+
+class Delaunay2DRefiner(Refiner):
+    """One refiner for a 2-D (mu, T) grid: tessellate once, dispatch per simplex.
+
+    Each Delaunay simplex is handled by its phase count — triple points
+    (``n = 3``, :class:`DelaunayTripleRefiner`), inter-phase coexistence lines
+    (``n = 2``, :class:`ClausiusClapeyronRefiner`) and intra-phase miscibility
+    gaps (``n = 1``, :class:`MiscibilityGapRefiner`). This is the default 2-D
+    set (previously those three refiners run separately), collapsed into one so
+    the (mu, T) tessellation and its ``_Simplex`` objects are built once instead
+    of once per refiner.
+
+    :meth:`propose` yields ``(refiner, candidate)`` pairs off the shared
+    tessellation; :meth:`run` buckets them back per refiner so each keeps its
+    own locate-and-emit bookkeeping — the Clausius-Clapeyron straddle dedup, the
+    triple-point owner attribution — and its own ``refined`` label. The emitted
+    rows are identical to running the three refiners separately.
+    """
+
+    label = "delaunay-2d"
+
+    def __init__(self, *, triple: Refiner | None = None,
+                 clausius: Refiner | None = None, gap: Refiner | None = None):
+        self.triple = triple if triple is not None else DelaunayTripleRefiner()
+        self.clausius = clausius if clausius is not None else ClausiusClapeyronRefiner()
+        self.gap = gap if gap is not None else MiscibilityGapRefiner()
+        self._refiners = (self.triple, self.clausius, self.gap)
+
+    def propose(self, df: pd.DataFrame, simplices=None):
+        simplices = _simplices_for(df, simplices)
+        for refiner in self._refiners:
+            for cand in refiner.propose(df, simplices):
+                yield refiner, cand
+
+    def solve(self, cand, phases: Mapping[str, Phase]):
+        refiner, inner = cand
+        return refiner.solve(inner, phases)
+
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase],
+            simplices=None) -> pd.DataFrame:
+        simplices = _simplices_for(df, simplices)
+        buckets: dict = {refiner: [] for refiner in self._refiners}
+        for refiner, cand in self.propose(df, simplices):
+            buckets[refiner].append(cand)
+        frames = [
+            out for refiner in self._refiners
+            if not (out := refiner._run_candidates(buckets[refiner], phases)).empty
+        ]
+        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
 # -- Defaults -----------------------------------------------------------------
 
 
 def default_refiners(df: pd.DataFrame) -> Sequence[Refiner]:
     """Pick a sensible default refiner list for ``df``.
 
-    * Both ``mu`` and ``T`` sampled (2-D grid) → triple points
-      (:class:`DelaunayTripleRefiner`) plus dense Clausius-Clapeyron
-      traces for inter-phase boundaries and intra-phase miscibility
-      gaps.
+    * Both ``mu`` and ``T`` sampled (2-D grid) → a single
+      :class:`Delaunay2DRefiner`, which locates triple points, inter-phase
+      Clausius-Clapeyron boundaries and intra-phase miscibility gaps off one
+      shared tessellation.
     * Only one axis sampled (1-D scan) → just the
       :class:`ScanRefiner` walking that axis.
     """
     multiple_mus = len(df["mu"].unique()) > 1
     multiple_ts = len(df["T"].unique()) > 1
     if multiple_mus and multiple_ts:
-        return [
-            DelaunayTripleRefiner(),
-            ClausiusClapeyronRefiner(),
-            MiscibilityGapRefiner(),
-        ]
+        return [Delaunay2DRefiner()]
     refiners: list[Refiner] = []
     if multiple_mus:
         refiners.append(ScanRefiner(by="mu"))

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -37,10 +37,11 @@ The two Clausius-Clapeyron refiners share their skeleton via the
 private :class:`_CCBase` ABC; see the comment block right above it
 for a quick algorithm overview aimed at new readers.
 
-:meth:`Refiner.run` is split into ``propose`` (candidate generation)
-and ``_run_candidates`` (locate + emit) so :class:`Delaunay2DRefiner`
-can drive each constituent refiner with candidates it proposed off the
-shared tessellation.
+Each Delaunay-based refiner splits its ``propose`` body into a
+``_candidates(df, simplices)`` generator and exposes a
+:meth:`Refiner.run_one` (``propose``-signature-preserving) that runs it
+off a *given* tessellation, so :class:`Delaunay2DRefiner` can build the
+tessellation once and drive all three from it.
 
 Writing a new refiner
 ---------------------
@@ -253,14 +254,8 @@ class Refiner(ABC):
     label: ClassVar[str]
 
     @abstractmethod
-    def propose(self, df: pd.DataFrame, simplices=None):
-        """Yield candidate objects to be handed to :meth:`solve`.
-
-        ``simplices`` is an optional precomputed
-        ``[(_Simplex, phase_count), ...]`` list (see :func:`_delaunay_simplices`).
-        :class:`Delaunay2DRefiner` passes it so the tessellation is built once
-        and shared; a refiner that needs it and is given ``None`` builds its own.
-        """
+    def propose(self, df: pd.DataFrame):
+        """Yield candidate objects to be handed to :meth:`solve`."""
 
     @abstractmethod
     def solve(
@@ -277,11 +272,32 @@ class Refiner(ABC):
         """propose → solve → filter → dataframe."""
         return self._run_candidates(self.propose(df), phases)
 
+    def run_one(self, df: pd.DataFrame, simplices,
+                phases: Mapping[str, Phase]) -> pd.DataFrame:
+        """Run this refiner off an already-computed (mu, T) tessellation.
+
+        Same as :meth:`run` but takes the shared ``simplices`` list instead of
+        re-tessellating, so :class:`Delaunay2DRefiner` can drive its three
+        constituent refiners from one tessellation. Only the Delaunay-based
+        refiners implement :meth:`_candidates`.
+        """
+        return self._run_candidates(self._candidates(df, simplices), phases)
+
+    def _candidates(self, df: pd.DataFrame, simplices):
+        """Turn a precomputed tessellation into candidates (Delaunay refiners).
+
+        The body of :meth:`propose` for the tessellation-based refiners lives
+        here so both ``propose`` (which tessellates ``df`` itself) and
+        :meth:`run_one` (given a shared tessellation) reuse it.
+        """
+        raise NotImplementedError
+
     def _run_candidates(self, cands, phases: Mapping[str, Phase]) -> pd.DataFrame:
         """solve → filter → dataframe for an already-proposed candidate stream.
 
-        Split out of :meth:`run` so :class:`Delaunay2DRefiner` can drive a
-        refiner with candidates it proposed off a shared tessellation.
+        Split out of :meth:`run` so :meth:`run_one` (and hence
+        :class:`Delaunay2DRefiner`) can drive a refiner with candidates it
+        proposed off a shared tessellation.
         """
         rows: list[dict] = []
         boundary_id = 0
@@ -335,7 +351,7 @@ class ScanRefiner(Refiner):
         self.other = "T" if by == "mu" else "mu"
         self.label = by
 
-    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_ScanCandidate]:
+    def propose(self, df: pd.DataFrame) -> Iterator[_ScanCandidate]:
         for other_val, group in df.groupby(self.other):
             g = group.sort_values(self.by).reset_index(drop=True)
             change = g.index[g.phase != g.phase.shift(-1).ffill()]
@@ -440,16 +456,6 @@ def _delaunay_simplices(df: pd.DataFrame) -> list[tuple["_Simplex", int]]:
             for s, n in zip(dela.simplices, counts)]
 
 
-def _simplices_for(df: pd.DataFrame, simplices):
-    """Precomputed simplices if given, else tessellate ``df`` fresh.
-
-    Lets :class:`Delaunay2DRefiner` build the (mu, T) tessellation once and
-    share it across its constituent refiners, each of which would otherwise
-    rebuild it in its own ``propose``.
-    """
-    return _delaunay_simplices(df) if simplices is None else simplices
-
-
 def _simplex_containment(point: TMuPoint, simplex: _Simplex) -> float:
     """Smallest barycentric coordinate of ``(T, mu)`` w.r.t. the triangle.
 
@@ -503,8 +509,11 @@ class DelaunayLineRefiner(Refiner):
 
     label = "delaunay"
 
-    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_SimplexCandidate]:
-        for simplex, n in _simplices_for(df, simplices):
+    def propose(self, df: pd.DataFrame) -> Iterator[_SimplexCandidate]:
+        return self._candidates(df, _delaunay_simplices(df))
+
+    def _candidates(self, df, simplices) -> Iterator[_SimplexCandidate]:
+        for simplex, n in simplices:
             if n == 2:
                 yield _SimplexCandidate(simplex=simplex)
 
@@ -554,8 +563,11 @@ class DelaunayTripleRefiner(Refiner):
 
     label = "delaunay-triple"
 
-    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_TripleCandidate]:
-        siblings = tuple(simplex for simplex, n in _simplices_for(df, simplices) if n == 3)
+    def propose(self, df: pd.DataFrame) -> Iterator[_TripleCandidate]:
+        return self._candidates(df, _delaunay_simplices(df))
+
+    def _candidates(self, df, simplices) -> Iterator[_TripleCandidate]:
+        siblings = tuple(simplex for simplex, n in simplices if n == 3)
         for simplex in siblings:
             yield _TripleCandidate(simplex=simplex, siblings=siblings)
 
@@ -1161,10 +1173,13 @@ class ClausiusClapeyronRefiner(_CCBase):
 
     label = "clausius-clapeyron"
 
-    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_InterCandidate]:
+    def propose(self, df: pd.DataFrame) -> Iterator[_InterCandidate]:
+        return self._candidates(df, _delaunay_simplices(df))
+
+    def _candidates(self, df, simplices) -> Iterator[_InterCandidate]:
         T_min = float(df["T"].min())
         T_max = float(df["T"].max())
-        for simplex, n in _simplices_for(df, simplices):
+        for simplex, n in simplices:
             if n != 2:
                 continue
             mu_lo, mu_hi, T_lo, T_hi, T_seed = _simplex_brackets(simplex)
@@ -1294,14 +1309,17 @@ class MiscibilityGapRefiner(_CCBase):
         self.gap_close = gap_close
         self.gap_share_min = gap_share_min
 
-    def propose(self, df: pd.DataFrame, simplices=None) -> Iterator[_GapCandidate]:
+    def propose(self, df: pd.DataFrame) -> Iterator[_GapCandidate]:
+        return self._candidates(df, _delaunay_simplices(df))
+
+    def _candidates(self, df, simplices) -> Iterator[_GapCandidate]:
         T_min = float(df["T"].min())
         T_max = float(df["T"].max())
         # Yield widest-c-spread simplex first: the most reliable
         # simplex seeds the trace, and neighbouring ones get straddle-
         # skipped on subsequent iterations.
         candidates: list[tuple[float, _GapCandidate]] = []
-        for simplex, n in _simplices_for(df, simplices):
+        for simplex, n in simplices:
             if n != 1:
                 continue
             mu_lo, mu_hi, T_lo, T_hi, T_seed = _simplex_brackets(simplex)
@@ -1391,9 +1409,9 @@ class Delaunay2DRefiner(Refiner):
     the (mu, T) tessellation and its ``_Simplex`` objects are built once instead
     of once per refiner.
 
-    :meth:`propose` yields ``(refiner, candidate)`` pairs off the shared
-    tessellation; :meth:`run` buckets them back per refiner so each keeps its
-    own locate-and-emit bookkeeping — the Clausius-Clapeyron straddle dedup, the
+    :meth:`run` tessellates once and calls each constituent refiner's
+    :meth:`~Refiner.run_one` on that shared tessellation, so each keeps its own
+    locate-and-emit bookkeeping — the Clausius-Clapeyron straddle dedup, the
     triple-point owner attribution — and its own ``refined`` label. The emitted
     rows are identical to running the three refiners separately.
     """
@@ -1407,25 +1425,22 @@ class Delaunay2DRefiner(Refiner):
         self.gap = gap if gap is not None else MiscibilityGapRefiner()
         self._refiners = (self.triple, self.clausius, self.gap)
 
-    def propose(self, df: pd.DataFrame, simplices=None):
-        simplices = _simplices_for(df, simplices)
+    def propose(self, df: pd.DataFrame):
+        """Yield ``(refiner, candidate)`` pairs off one shared tessellation."""
+        simplices = _delaunay_simplices(df)
         for refiner in self._refiners:
-            for cand in refiner.propose(df, simplices):
+            for cand in refiner._candidates(df, simplices):
                 yield refiner, cand
 
     def solve(self, cand, phases: Mapping[str, Phase]):
         refiner, inner = cand
         return refiner.solve(inner, phases)
 
-    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase],
-            simplices=None) -> pd.DataFrame:
-        simplices = _simplices_for(df, simplices)
-        buckets: dict = {refiner: [] for refiner in self._refiners}
-        for refiner, cand in self.propose(df, simplices):
-            buckets[refiner].append(cand)
+    def run(self, df: pd.DataFrame, phases: Mapping[str, Phase]) -> pd.DataFrame:
+        simplices = _delaunay_simplices(df)
         frames = [
             out for refiner in self._refiners
-            if not (out := refiner._run_candidates(buckets[refiner], phases)).empty
+            if not (out := refiner.run_one(df, simplices, phases)).empty
         ]
         return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -14,9 +14,11 @@ from landau.refine import (
     MiscibilityGapRefiner,
     DelaunayLineRefiner,
     DelaunayTripleRefiner,
+    Delaunay2DRefiner,
     RefinedPoint,
     RefinedMiscibilityGap,
     ScanRefiner,
+    default_refiners,
 )
 from landau.refine import (
     _point_on_line,
@@ -935,6 +937,71 @@ def test_boundary_id_delaunay_triple_rows_share_id():
     assert "boundary_id" in out.columns
     # One triple point (3 rows) → all rows share the same boundary_id.
     assert out["boundary_id"].nunique() == 1
+
+
+# -- Delaunay2DRefiner (combined) ---------------------------------------------
+
+
+def _refined_rows_key(df):
+    """Order-independent fingerprint of the located transition rows."""
+    return sorted(
+        (r, round(t, 9), round(m, 9), p, round(c, 9))
+        for r, t, m, p, c in zip(df["refined"], df["T"], df["mu"],
+                                 df["phase"], df["c"]))
+
+
+def test_delaunay_2d_refiner_matches_separate_refiners():
+    """The combined refiner emits exactly what DelaunayTriple + CC + gap emit
+    separately, off one shared tessellation, each row keeping its own label."""
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 12)
+    mus = np.linspace(-0.05, 0.55, 15)
+    df = _coarse_df(phases, Ts, mus)
+
+    separate = pd.concat(
+        [DelaunayTripleRefiner().run(df, phases),
+         ClausiusClapeyronRefiner().run(df, phases),
+         MiscibilityGapRefiner().run(df, phases)],
+        ignore_index=True)
+    combined = Delaunay2DRefiner().run(df, phases)
+
+    assert not combined.empty
+    assert _refined_rows_key(combined) == _refined_rows_key(separate)
+    # both the triple-point and the Clausius-Clapeyron labels survive
+    assert {"delaunay-triple", "clausius-clapeyron"} <= set(combined["refined"])
+
+
+def test_delaunay_2d_refiner_shares_one_tessellation():
+    """propose tessellates once, not once per constituent refiner."""
+    import landau.refine as R
+    phases = _three_phase_system()
+    df = _coarse_df(phases, np.linspace(220.0, 480.0, 6), np.linspace(-0.05, 0.55, 7))
+
+    calls = {"n": 0}
+    orig = R._delaunay_simplices
+    R._delaunay_simplices = lambda d, _o=orig, _c=calls: (_c.__setitem__("n", _c["n"] + 1), _o(d))[1]
+    try:
+        list(Delaunay2DRefiner().propose(df))
+    finally:
+        R._delaunay_simplices = orig
+    assert calls["n"] == 1
+
+
+def test_default_refiners_2d_is_single_combined_refiner():
+    """A 2-D grid defaults to one Delaunay2DRefiner (not three separate)."""
+    phases = _three_phase_system()
+    df = _coarse_df(phases, np.linspace(220.0, 480.0, 6), np.linspace(-0.05, 0.55, 7))
+    refiners = default_refiners(df)
+    assert len(refiners) == 1
+    assert isinstance(refiners[0], Delaunay2DRefiner)
+
+
+def test_delaunay_2d_refiner_accepts_custom_constituents():
+    """Constituent refiners can be swapped (e.g. tuned CC step)."""
+    r = Delaunay2DRefiner(clausius=ClausiusClapeyronRefiner(dT_max=123.0))
+    assert r.clausius.dT_max == 123.0
+    assert isinstance(r.triple, DelaunayTripleRefiner)
+    assert isinstance(r.gap, MiscibilityGapRefiner)
 
 
 # -- ScanRefiner --------------------------------------------------------------

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -972,14 +972,26 @@ def test_delaunay_2d_refiner_matches_separate_refiners():
 
 
 def test_delaunay_2d_refiner_shares_one_tessellation():
-    """propose tessellates once, not once per constituent refiner."""
+    """run (and propose) tessellate once, not once per constituent refiner."""
     import landau.refine as R
     phases = _three_phase_system()
     df = _coarse_df(phases, np.linspace(220.0, 480.0, 6), np.linspace(-0.05, 0.55, 7))
 
-    calls = {"n": 0}
-    orig = R._delaunay_simplices
-    R._delaunay_simplices = lambda d, _o=orig, _c=calls: (_c.__setitem__("n", _c["n"] + 1), _o(d))[1]
+    def counting():
+        calls = {"n": 0}
+        orig = R._delaunay_simplices
+        R._delaunay_simplices = lambda d, _o=orig, _c=calls: (
+            _c.__setitem__("n", _c["n"] + 1), _o(d))[1]
+        return calls, orig
+
+    calls, orig = counting()
+    try:
+        Delaunay2DRefiner().run(df, phases)
+    finally:
+        R._delaunay_simplices = orig
+    assert calls["n"] == 1  # one tessellation for all three constituents
+
+    calls, orig = counting()
     try:
         list(Delaunay2DRefiner().propose(df))
     finally:


### PR DESCRIPTION
Alternative to #341 (which memoises `_delaunay_simplices`). Instead of caching, this merges the three default 2-D refiners into one, as suggested — a single `run` that tessellates once and drives the three constituents.

## Design

`Delaunay2DRefiner` tessellates the `(mu, T)` grid **once** and dispatches each simplex by phase count:

- `n = 3` → `DelaunayTripleRefiner` (triple points)
- `n = 2` → `ClausiusClapeyronRefiner` (inter-phase coexistence lines)
- `n = 1` → `MiscibilityGapRefiner` (intra-phase gaps)

`run` builds the tessellation and calls each constituent's `run_one(df, simplices, phases)` on that shared list, so each keeps its own locate-and-emit bookkeeping — the Clausius-Clapeyron straddle dedup, the triple-point owner attribution — and its own `refined` label. It composes the three existing refiners rather than reimplementing them, so their tested logic is reused unchanged.

To make that possible (per review — `propose`'s signature is left alone):
- Each Delaunay-based refiner factors its `propose` body into a `_candidates(df, simplices)` generator. `propose(df)` stays `propose(self, df)` and delegates to `_candidates(df, _delaunay_simplices(df))`.
- `Refiner.run_one(df, simplices, phases)` is factored out of `run` — the `propose → solve → emit` path run off a *given* tessellation (`_run_candidates(self._candidates(df, simplices), phases)`). `Refiner.run` and the `_CCBase` straddle-dedup version of `_run_candidates` are unchanged.
- `default_refiners` returns `[Delaunay2DRefiner()]` for a 2-D grid. Constituents are swappable via `Delaunay2DRefiner(triple=…, clausius=…, gap=…)`.

Standalone refiners and user-defined `Refiner` subclasses are unaffected — `propose(self, df)` is unchanged and `run` still calls `self.propose(df)`.

## No output change

The emitted rows — located transitions, `refined` labels, boundary ids — are identical to running the three refiners separately. Unit, regression, and integration suites (incl. `test_border_coverage`) pass unchanged.

## Numbers

`benchmarks/bench_combined_refiner.py` (added), `refine_phase_diagram` only, best of 6, asserting combined vs separate rows are identical:

| system | 3 separate | combined | |
|---|---|---|---|
| `2d_basics_mu` (100×100, cheap phi) | ~950 ms | ~500 ms | ~1.9× (tessellation-bound) |
| `2d_toy` (FastInterpolatingPhase) | ~1200 ms | ~1100 ms | ~6% (per-T-solve-bound) |

`basics_mu` is tessellation-bound so it nearly halves; `toy` is dominated by the CC trace's per-T solves so the tessellation is a smaller slice.

## vs. #341

Both remove the 3× tessellation. #341 is a smaller diff (a weakref last-call memo on `_delaunay_simplices`, no API change) but adds module-level cache state. This is a larger diff but stateless — the tessellation is shared by construction and there is one refiner in `default_refiners`. Pick whichever fits; I can close the other.

## Tests

`test_delaunay_2d_refiner_matches_separate_refiners` (row-for-row equality vs the three separate), `test_delaunay_2d_refiner_shares_one_tessellation` (one `_delaunay_simplices` call for a whole `run` and a whole `propose`), `test_default_refiners_2d_is_single_combined_refiner`, and a constituent-swap test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)