### PR TITLE
fix(refine): _dominated drops non-coexisting refined transitions robustly

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -190,39 +190,47 @@ def _state_row(phase: Phase, T: float, mu: float) -> dict:
     }
 
 
-# eV; largest spread in the own-phase potentials still read as one coexistence.
-# Comfortably above a converged triple/pair residual (~1e-5) and far below any
-# real domination gap, so it separates a genuine N-phase point from one where a
-# vertex doesn't belong.
+# eV; largest spread in a *triple*'s own-phase potentials still read as one
+# coexistence. Comfortably above a converged triple residual (~1e-5) and far
+# below any real domination gap. Not applied to two-phase boundaries, which may
+# be genuinely first-order (see _dominated).
 _COEXIST_TOL = 1e-3
 
 
 def _dominated(pt, phases: Mapping[str, Phase]) -> bool:
-    """True iff the refined transition ``pt`` is not a genuine coexistence and
-    should be dropped.
+    """True iff the refined transition ``pt`` is not a valid piece of the global
+    phase boundary and should be dropped.
 
-    Two failure modes:
+    A point is valid when its own phases are exactly the most stable set at
+    ``(pt.T, pt.mu)``. It is dropped when:
 
-    * Its own phases don't actually share a finite semigrand potential at
-      ``(pt.T, pt.mu)`` — one is absent (``phi = +inf``) or lies below the
-      others and merely rode along as a vertex of a Delaunay simplex, so the
-      claimed N-phase point isn't real. (This is how a pinned ordered phase
+    * An own phase is **absent** (``phi = +inf``): a phase that doesn't exist
+      here can't be a coexisting vertex. (This is how a pinned ordered phase
       reported absent outside its dome leaked into a triple point at ``c = 0``.)
-    * Some phase *outside* ``pt.phase_names()`` lies strictly below the
-      coexistence potential and is the true equilibrium.
+    * Some phase **outside** ``pt.phase_names()`` sits below the least-stable own
+      phase — then the own set isn't the top-|own| most stable, so this isn't
+      the boundary it claims to be (a Clausius-Clapeyron trace that oversteps an
+      invariant lands here).
+    * For a **triple** only, its three phases don't share one potential (spread
+      ``> _COEXIST_TOL``) — a genuine three-phase point is a single ``(T, mu)``
+      where all three are degenerate. Two-phase boundaries are exempt: a
+      first-order boundary (a pinned ordered phase appearing already below the
+      disordered one) is a real boundary where the two phases' potentials jump
+      rather than cross, and clamping it to coexistence would drop the whole
+      upper flank of the ordered dome.
 
-    Comparing every own phase to their minimum (rather than to one arbitrary
-    member) also removes a ``set``-iteration-order dependence: the previous
-    version's reference was ``next(iter(own))``, so whether a phantom vertex
-    survived depended on which name the set happened to yield first.
+    Using ``max(own_phi)`` as the reference (not one arbitrary set member) also
+    removes a ``set``-iteration-order dependence in the outside comparison.
     """
     own = pt.phase_names()
     own_phi = [phases[n].semigrand_potential(pt.T, pt.mu) for n in own]
-    ref = min(own_phi)
-    if not np.isfinite(ref) or max(own_phi) - ref > _COEXIST_TOL:
+    if not np.all(np.isfinite(own_phi)):
+        return True
+    hi = max(own_phi)
+    if len(own) >= 3 and hi - min(own_phi) > _COEXIST_TOL:
         return True
     return any(
-        p.semigrand_potential(pt.T, pt.mu) < ref
+        p.semigrand_potential(pt.T, pt.mu) < hi
         for p in phases.values()
         if p.name not in own
     )

--- a/landau/refine.py
+++ b/landau/refine.py
@@ -190,16 +190,39 @@ def _state_row(phase: Phase, T: float, mu: float) -> dict:
     }
 
 
+# eV; largest spread in the own-phase potentials still read as one coexistence.
+# Comfortably above a converged triple/pair residual (~1e-5) and far below any
+# real domination gap, so it separates a genuine N-phase point from one where a
+# vertex doesn't belong.
+_COEXIST_TOL = 1e-3
+
+
 def _dominated(pt, phases: Mapping[str, Phase]) -> bool:
-    """True iff some phase outside ``pt.phase_names()`` has a lower
-    semigrand potential at ``(pt.T, pt.mu)`` — meaning the refined
-    transition we found isn't actually globally stable, so we drop it.
+    """True iff the refined transition ``pt`` is not a genuine coexistence and
+    should be dropped.
+
+    Two failure modes:
+
+    * Its own phases don't actually share a finite semigrand potential at
+      ``(pt.T, pt.mu)`` — one is absent (``phi = +inf``) or lies below the
+      others and merely rode along as a vertex of a Delaunay simplex, so the
+      claimed N-phase point isn't real. (This is how a pinned ordered phase
+      reported absent outside its dome leaked into a triple point at ``c = 0``.)
+    * Some phase *outside* ``pt.phase_names()`` lies strictly below the
+      coexistence potential and is the true equilibrium.
+
+    Comparing every own phase to their minimum (rather than to one arbitrary
+    member) also removes a ``set``-iteration-order dependence: the previous
+    version's reference was ``next(iter(own))``, so whether a phantom vertex
+    survived depended on which name the set happened to yield first.
     """
     own = pt.phase_names()
-    own_phase = next(iter(own))
-    own_phi = phases[own_phase].semigrand_potential(pt.T, pt.mu)
+    own_phi = [phases[n].semigrand_potential(pt.T, pt.mu) for n in own]
+    ref = min(own_phi)
+    if not np.isfinite(ref) or max(own_phi) - ref > _COEXIST_TOL:
+        return True
     return any(
-        p.semigrand_potential(pt.T, pt.mu) < own_phi
+        p.semigrand_potential(pt.T, pt.mu) < ref
         for p in phases.values()
         if p.name not in own
     )

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -1020,14 +1020,36 @@ def test_dominated_rival_equal_phi_returns_false():
     assert _dominated(pt, phases) is False
 
 
-def test_dominated_skips_phases_in_own_set():
-    """Triple-point candidate. D would dominate but it is *in* ``own``, so
-    the ``if p.name not in own`` filter excludes it and no rival remains."""
+def test_dominated_own_phase_below_others_returns_true():
+    """A claimed triple point whose own phases don't share a potential is not a
+    real coexistence: D lies far below A and B at ``(T, mu)``, so only D is
+    stable there and the A+B+D point is spurious. The old code compared against
+    one arbitrary member of ``own`` and, when it wasn't D, let the point survive;
+    now the own-phase spread (1.0 eV) exceeds the coexistence tolerance and it is
+    dropped regardless of set order."""
     phases = _dom_phases(
         ("A", 0.0, 0.0), ("B", 1.0, 0.0), ("D", 0.5, -1.0),
     )
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B", "D"))
-    assert _dominated(pt, phases) is False
+    assert _dominated(pt, phases) is True
+
+
+def test_dominated_absent_own_phase_returns_true():
+    """The Au-Cu degeneracy in miniature: a pinned ordered phase reported absent
+    (``phi = +inf``) must not survive as a triple-point vertex. C is absent, so
+    A+B+C is really just A+B and the triple point is dropped."""
+    class _Absent:
+        name = "C"
+
+        def semigrand_potential(self, T, mu):
+            return float("inf")
+
+        def concentration(self, T, mu):
+            return 0.0
+
+    phases = {**_dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0)), "C": _Absent()}
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B", "C"))
+    assert _dominated(pt, phases) is True
 
 
 def test_dominated_triple_with_outside_dominator_returns_true():

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -975,11 +975,11 @@ def test_scan_refiner_splits_dominated_crossing_T_scan():
 # -- _dominated ---------------------------------------------------------------
 #
 # `_dominated(pt, phases)` is the predicate every refiner's run() uses to drop
-# a refined transition whose phases are not globally stable at (pt.T, pt.mu):
-# True iff some phase outside pt.phase_names() has a strictly lower phi there.
-# The cases below cover each branch of that contract orthogonally: empty rival
-# set, lower / equal / higher rival, the strictness of "<", the size-3 own set,
-# and the own-set filter that hides supposedly-dominating coexisting phases.
+# a refined transition that isn't a valid piece of the global phase boundary
+# at (pt.T, pt.mu). The cases below cover each branch of that contract
+# orthogonally: empty rival set, lower / equal / higher rival, the strictness
+# of "<", an absent (phi = +inf) own phase, a triple whose own phases don't
+# share one potential, an outside dominator in a triple, and multiple rivals.
 
 
 def _dom_phases(*specs):
@@ -1018,6 +1018,22 @@ def test_dominated_rival_equal_phi_returns_false():
     phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.0), ("C", 0.5, 0.0))
     pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
     assert _dominated(pt, phases) is False
+
+
+def test_dominated_outside_rival_between_own_potentials_returns_true():
+    """Two-phase boundary with unequal own potentials (phi_A=0, phi_B=0.5;
+    allowed since the coexistence-tolerance check only applies to triples).
+    Rival X sits at 0.3 - strictly between the two own potentials, so it beats
+    B but not A. The old code compared against ``next(iter(own))``, an
+    arbitrary member of the ``own`` *set*: whether this candidate survived
+    depended on which own phase that happened to be. Comparing against
+    ``max(own_phi)`` instead asks "does X beat the least-stable own phase" -
+    X beats B, so the own set is not the top-2 most stable and this must be
+    dominated regardless of ``own``'s (hash-determined, not caller-controlled)
+    iteration order."""
+    phases = _dom_phases(("A", 0.0, 0.0), ("B", 1.0, 0.5), ("X", 0.5, 0.3))
+    pt = RefinedPoint(T=300.0, mu=0.0, phases=("A", "B"))
+    assert _dominated(pt, phases) is True
 
 
 def test_dominated_own_phase_below_others_returns_true():


### PR DESCRIPTION
Two fixes to `_dominated` in `landau/refine.py` — the predicate every refiner's `run()` uses to drop a refined transition whose phases aren't the globally stable set at `(T, mu)`. Broken out of the CEF work (#324) since it's a general refiner-correctness change; #324/#326 stack on top.

## The bug

`_dominated` compared every phase to `next(iter(own))` — an arbitrary member of a **set** — and only checked phases *outside* the transition. So a three-phase Delaunay simplex could keep a phantom vertex whose phase is absent (`phi = +inf`) or otherwise not co-stable, and whether that vertex survived depended on set-iteration order — **nondeterministic**. In the Au-Cu CEF diagram this surfaced as a spurious triple point placing an ordered phase at `c = 0` (a thin spike to the axis) that appeared in some runs and not others.

## The fix

Recast the predicate as "are the own phases the most-stable set here":

- Drop when an own phase is **absent** (`phi = +inf`) — a phase that doesn't exist here can't be a coexisting vertex.
- Drop when a phase **outside** the transition sits below the *least-stable* own phase (`max(own_phi)`), i.e. the own set isn't the top-|own| most stable. Comparing to the maximum (not an arbitrary member) also removes the set-order dependence.
- For a **triple point only**, drop when the three phases don't share one potential (spread `> _COEXIST_TOL`). Two-phase boundaries are exempt: a first-order boundary — where the stable phase jumps rather than crosses — carries a finite own-phase spread and is a real boundary, so clamping it to coexistence would wrongly drop it.

## Tests

`tests/unit/test_refine.py` gains direct `_dominated` cases: a non-coexisting own phase (dropped), an absent (`phi = +inf`) vertex (dropped), and the existing outside-dominator / equal-rival / triple cases, all order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011i7RNpdn7F3Kf6BvTfne8j)_