### PR TITLE
test(refine): direct unit tests for _CCBase._predict_mu and default _dT_adapt

### DIFF
--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -27,6 +27,7 @@ from landau.refine import (
     _simplex_containment,
     _state_row,
     _Simplex,
+    _StepResult,
 )
 
 
@@ -1183,3 +1184,34 @@ def test_simplex_centroids_ordering_follows_unique_phases():
     assert list(cents) == ["zeta", "alpha"]
     assert cents["zeta"] == pytest.approx((200.0, 0.0))  # mean of two vertices
     assert cents["alpha"] == pytest.approx((500.0, 0.0))  # single vertex
+
+
+# -- _CCBase._predict_mu / default _dT_adapt -----------------------------------
+#
+# Shared predictor and step scaler for both ClausiusClapeyronRefiner and
+# MiscibilityGapRefiner (refine.py:819, refine.py:837). Only the override in
+# MiscibilityGapRefiner is exercised by the miscibility-gap pipeline tests;
+# these pin the base defaults directly via a concrete subclass instance.
+
+
+def test_predict_mu_linear_extrapolation():
+    """Default predictor is plain linear extrapolation: mu* + dmu/dT * dT."""
+    refiner = ClausiusClapeyronRefiner()
+    assert refiner._predict_mu(0.5, 0.02, 3.0) == pytest.approx(0.56)
+
+
+def test_dT_adapt_default_half_width_over_slope():
+    """Default step size is half_width / |dmu_dT|; the sign of dmu_dT does
+    not matter since only its magnitude is used."""
+    refiner = ClausiusClapeyronRefiner()
+    step = _StepResult(mu_star=0.0, extra=None)
+    assert refiner._dT_adapt(step, 0.02, half_width=0.1) == pytest.approx(5.0)
+    assert refiner._dT_adapt(step, -0.02, half_width=0.1) == pytest.approx(5.0)
+
+
+def test_dT_adapt_slope_floor_at_zero():
+    """A flat coexistence line (dmu_dT == 0) does not divide by zero; the
+    slope is floored at 1e-9 so the step saturates at half_width / 1e-9."""
+    refiner = ClausiusClapeyronRefiner()
+    step = _StepResult(mu_star=0.0, extra=None)
+    assert refiner._dT_adapt(step, 0.0, half_width=0.1) == pytest.approx(1e8)


### PR DESCRIPTION
Closes #329.

`_CCBase._predict_mu` (`landau/refine.py:819`) and the default `_CCBase._dT_adapt` (`landau/refine.py:837`) are the shared predictor and step scaler for both `ClausiusClapeyronRefiner` and `MiscibilityGapRefiner`. `MiscibilityGapRefiner` overrides `_dT_adapt` (uses `dT_max * gap**2`) and that override is exercised by the miscibility-gap pipeline tests, but the base implementations had no direct test — a regression that breaks `ClausiusClapeyronRefiner`'s scaling but not `MiscibilityGapRefiner`'s would only surface as a downstream miscount.

Three direct tests pin the defaults in isolation, instantiating `ClausiusClapeyronRefiner()` to exercise the inherited base methods:

1. **`_predict_mu` is linear extrapolation.** `mu_star=0.5`, `dmu_dT=0.02`, `dT=3.0` returns `0.56`.
2. **Default `_dT_adapt` is `half_width / |dmu_dT|`.** `half_width=0.1`, `dmu_dT=0.02` returns `5.0`; sign of `dmu_dT` does not matter (also checked at `-0.02`).
3. **Slope floor at `dmu_dT=0`.** `_dT_adapt(step, 0.0, half_width=0.1)` returns `0.1 / 1e-9 = 1e8` (does not divide by zero).

No production code changes.

## Tests

`python -m pytest tests/unit/test_refine.py` — 56 passed (3 new).
`python -m pytest tests/unit` — 613 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHwo4aGeqDcjZuypvtSkKn)_