### PR TITLE
refactor(calculate): drop unreachable fallback in _f_excess_tangent_chord

### DIFF
--- a/landau/calculate.py
+++ b/landau/calculate.py
@@ -68,8 +68,7 @@ def _f_excess_tangent_chord(dd: pd.DataFrame) -> pd.Series:
     from a line phase sitting exactly at ``c = 1`` (``f`` is convex with slope
     ``mu`` in ``c``, so the partial-coverage phase sits below its own tangent
     value at the endpoint).  For a line phase located exactly at an endpoint
-    both expressions reduce to ``f``.  Falls back to the raw ``f`` at the
-    extreme sample when no phase reaches the endpoint window.
+    both expressions reduce to ``f``.
 
     Drops ``mu = +-inf`` rows before computing.  Designed to be applied per
     temperature via :func:`_apply_series`.
@@ -90,10 +89,6 @@ def _f_excess_tangent_chord(dd: pd.DataFrame) -> pd.Series:
             f0 = min(f0, tangent0[g["c"].idxmin()])
         if g["c"].max() >= hi_thr:
             f1 = min(f1, tangent1[g["c"].idxmax()])
-    if not np.isfinite(f0):
-        f0 = dd.loc[dd["c"].idxmin(), "f"]
-    if not np.isfinite(f1):
-        f1 = dd.loc[dd["c"].idxmax(), "f"]
     return dd.f - (f0 * (1 - dd.c) + f1 * dd.c)
 
 


### PR DESCRIPTION
Closes #331.

## Problem

After PR #267 promoted `sub` to the module-level `_f_excess_tangent_chord` (`landau/calculate.py:60`), the two `if not np.isfinite(f0)` / `f1` fallbacks turned out to be structurally unreachable:

```python
lo_thr = c_min + 0.01 * c_span
hi_thr = c_max - 0.01 * c_span
...
for _, g in dd.groupby("phase"):
    if g["c"].min() <= lo_thr:   # the phase that owns c_min ALWAYS satisfies this
        f0 = min(f0, tangent0[g["c"].idxmin()])
    if g["c"].max() >= hi_thr:   # ditto for c_max
        f1 = min(f1, tangent1[g["c"].idxmax()])
if not np.isfinite(f0):
    f0 = dd.loc[dd["c"].idxmin(), "f"]   # unreachable
if not np.isfinite(f1):
    f1 = dd.loc[dd["c"].idxmax(), "f"]   # unreachable
```

Since `c_min = dd.c.min()`, the phase containing that global minimum trivially satisfies `g["c"].min() <= c_min <= lo_thr`, so `f0` is always updated to a finite value; same for `f1`. Every existing test in `test_calculate.py::test_f_excess_tangent_chord_*` covers this path and none triggers the fallback.

## Change

Removed the two unreachable blocks (and the docstring sentence describing them). No behaviour change — dead defensive code that no realistic frame can exercise is a testability liability; if a future change breaks the invariant, the failure mode should now be a loud `NaN`/`inf` in `f_excess` rather than silent recovery through an untested path.

## Tests

`python3 -m pytest tests/unit tests/regression -q` — 628 passed.
`ruff check landau/calculate.py` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A2B1B4mpB8nT21ZVFC3ZKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2B1B4mpB8nT21ZVFC3ZKG)_