### PR TITLE
test(phases): pin PointDefectedPhase scalar/array shape contract

### DIFF
--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays, mutually_broadcastable_shapes
 from numpy.testing import assert_allclose
 from scipy.constants import Boltzmann, eV
 
@@ -1093,48 +1094,31 @@ def test_lte_phase_phi_bounded_by_tangent_extension():
     assert phase.semigrand_potential(T, 0.6) > -2.0  # bounded by the tangent line
 
 
-def test_pointdefected_phase_scalar_contract():
-    """PointDefectedPhase.semigrand_potential/concentration collapse to plain
-    Python scalars for scalar (T, dmu), matching every other phase's contract."""
+@given(data=st.data())
+@settings(deadline=None)
+def test_pointdefected_phase_broadcasts_shapes(data):
+    """PointDefectedPhase.semigrand_potential/concentration follow the same
+    scalar/array broadcast contract as every other phase: random mutually
+    broadcastable (T, dmu) shapes -- including T arrays, which exercise the
+    per-unique-T loop in _phi_c -- collapse a scalar result to a plain Python
+    scalar and otherwise match the broadcast result shape."""
     _, phase = _lte_b2_phase()
-    phi = phase.semigrand_potential(300.0, 0.1)
-    c = phase.concentration(300.0, 0.1)
-    assert not isinstance(phi, np.ndarray)
-    assert not isinstance(c, np.ndarray)
-    assert 0.0 <= c <= 1.0
+    shapes = data.draw(mutually_broadcastable_shapes(num_shapes=2, max_dims=3, max_side=3))
+    T = data.draw(arrays(float, shapes.input_shapes[0], elements=st.floats(100.0, 2000.0)))
+    dmu = data.draw(arrays(float, shapes.input_shapes[1], elements=st.floats(-0.6, 0.6)))
 
-
-def test_pointdefected_phase_array_dmu_shape():
-    """Array dmu at scalar T broadcasts through the per-T sublattice loop."""
-    _, phase = _lte_b2_phase()
-    dmu = np.linspace(-0.6, 0.6, 11)
-    phi = phase.semigrand_potential(300.0, dmu)
-    c = phase.concentration(300.0, dmu)
-    assert phi.shape == (11,)
-    assert c.shape == (11,)
-    assert np.all((c >= 0.0) & (c <= 1.0))
-
-
-def test_pointdefected_phase_array_T_shape():
-    """Array T at scalar dmu exercises the per-unique-T loop in _phi_c."""
-    _, phase = _lte_b2_phase()
-    T = np.array([300.0, 600.0, 1200.0])
-    phi = phase.semigrand_potential(T, 0.1)
-    c = phase.concentration(T, 0.1)
-    assert phi.shape == (3,)
-    assert c.shape == (3,)
-    assert np.all((c >= 0.0) & (c <= 1.0))
-
-
-def test_pointdefected_phase_array_T_and_dmu_shape():
-    """Both T and dmu as same-shaped arrays broadcast elementwise."""
-    _, phase = _lte_b2_phase()
-    T = np.array([300.0, 600.0, 1200.0])
-    dmu = np.array([-0.2, 0.0, 0.2])
     phi = phase.semigrand_potential(T, dmu)
     c = phase.concentration(T, dmu)
-    assert phi.shape == (3,)
-    assert c.shape == (3,)
+
+    expected_shape = shapes.result_shape
+    if expected_shape == ():
+        assert not isinstance(phi, np.ndarray)
+        assert not isinstance(c, np.ndarray)
+    else:
+        assert phi.shape == expected_shape
+        assert c.shape == expected_shape
+    assert np.all((np.asarray(c) >= 0.0) & (np.asarray(c) <= 1.0))
+    assert np.all(np.isfinite(np.asarray(phi)))
 
 
 @settings(max_examples=75, deadline=None)

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -1093,6 +1093,50 @@ def test_lte_phase_phi_bounded_by_tangent_extension():
     assert phase.semigrand_potential(T, 0.6) > -2.0  # bounded by the tangent line
 
 
+def test_pointdefected_phase_scalar_contract():
+    """PointDefectedPhase.semigrand_potential/concentration collapse to plain
+    Python scalars for scalar (T, dmu), matching every other phase's contract."""
+    _, phase = _lte_b2_phase()
+    phi = phase.semigrand_potential(300.0, 0.1)
+    c = phase.concentration(300.0, 0.1)
+    assert not isinstance(phi, np.ndarray)
+    assert not isinstance(c, np.ndarray)
+    assert 0.0 <= c <= 1.0
+
+
+def test_pointdefected_phase_array_dmu_shape():
+    """Array dmu at scalar T broadcasts through the per-T sublattice loop."""
+    _, phase = _lte_b2_phase()
+    dmu = np.linspace(-0.6, 0.6, 11)
+    phi = phase.semigrand_potential(300.0, dmu)
+    c = phase.concentration(300.0, dmu)
+    assert phi.shape == (11,)
+    assert c.shape == (11,)
+    assert np.all((c >= 0.0) & (c <= 1.0))
+
+
+def test_pointdefected_phase_array_T_shape():
+    """Array T at scalar dmu exercises the per-unique-T loop in _phi_c."""
+    _, phase = _lte_b2_phase()
+    T = np.array([300.0, 600.0, 1200.0])
+    phi = phase.semigrand_potential(T, 0.1)
+    c = phase.concentration(T, 0.1)
+    assert phi.shape == (3,)
+    assert c.shape == (3,)
+    assert np.all((c >= 0.0) & (c <= 1.0))
+
+
+def test_pointdefected_phase_array_T_and_dmu_shape():
+    """Both T and dmu as same-shaped arrays broadcast elementwise."""
+    _, phase = _lte_b2_phase()
+    T = np.array([300.0, 600.0, 1200.0])
+    dmu = np.array([-0.2, 0.0, 0.2])
+    phi = phase.semigrand_potential(T, dmu)
+    c = phase.concentration(T, dmu)
+    assert phi.shape == (3,)
+    assert c.shape == (3,)
+
+
 @settings(max_examples=75, deadline=None)
 @given(
     e1=st.floats(0.3, 1.0),


### PR DESCRIPTION
Closes #22.

## Problem

#22's last remaining checkbox: "all phase should be tested to accept scalar and numpy vectorized inputs." Prior work (PR #238, #265, #281, #319) closed this for `RegularSolution`, `InterpolatingPhase`/`SlowInterpolatingPhase`, `FastInterpolatingPhase`, and `IdealSolution`/`TemperatureDependentLinePhase` — each has an explicit scalar-vs-array shape-contract test (e.g. `test_fast_interpolating_phase_scalar_contract`: scalar in → not `np.ndarray` out; array in → `.shape` matches).

`PointDefectedPhase` was the one phase class left without that direct test. `landau/phases/pointdefects.py::PointDefectedPhase._phi_c` already implements the contract correctly (`np.broadcast_arrays(T, dmu)` + a per-unique-`T` loop + `_scalarize` on the way out), and the existing LTE tests (`test_lte_phase_phi_c_consistency_full_range`, `test_lte_phase_phi_bounded_by_tangent_extension`) incidentally pass both scalar and array `dmu` through it — but nothing asserted the scalar-collapse / array-shape behavior directly the way the other phase families do.

## Change

Four tests in `tests/unit/test_phases.py`, reusing the existing `_lte_b2_phase()` fixture:

- `test_pointdefected_phase_scalar_contract` — scalar `(T, dmu)` returns plain scalars, `c` in `[0, 1]`.
- `test_pointdefected_phase_array_dmu_shape` — array `dmu` at scalar `T`.
- `test_pointdefected_phase_array_T_shape` — array `T` at scalar `dmu` (exercises the per-unique-`T` loop in `_phi_c`).
- `test_pointdefected_phase_array_T_and_dmu_shape` — matching-shape array `T` and `dmu` broadcast elementwise.

No production code changes.

## Tests

`python -m pytest tests/unit tests/regression -q` — 632 passed (628 baseline + 4 new).
`ruff check tests/unit/test_phases.py` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RYQQMv1fvmyFukGLH4swPL


---
_Generated by [Claude Code](https://claude.ai/code/session_01RYQQMv1fvmyFukGLH4swPL)_