### PR TITLE
test(phases): pin Surface2DInterpolatingPhase scalar/array shape contract

### DIFF
--- a/tests/unit/interpolate/test_softplus_surface.py
+++ b/tests/unit/interpolate/test_softplus_surface.py
@@ -536,6 +536,50 @@ def test_surface_phase_free_energy_is_convex():
         assert d2.min() >= -CONVEX_ATOL
 
 
+def test_surface_phase_scalar_contract():
+    """Surface2DInterpolatingPhase.semigrand_potential/concentration collapse to
+    plain Python scalars for scalar (T, dmu), matching every other phase's
+    contract (the class inherits FastInterpolatingPhase's solver unchanged, but
+    had no direct pin of this for the surface-slicing path)."""
+    lines, crange = _intermetallic_line_phases()
+    phase = Surface2DInterpolatingPhase(
+        "im", lines, concentration_range=crange, add_entropy=False,
+        surface_interpolator=SoftplusSurface2DInterpolator())
+    phi = phase.semigrand_potential(500.0, 0.05)
+    c = phase.concentration(500.0, 0.05)
+    assert not isinstance(phi, np.ndarray)
+    assert not isinstance(c, np.ndarray)
+    assert crange[0] <= c <= crange[1]
+
+
+def test_surface_phase_array_dmu_shape():
+    """Array dmu at scalar T broadcasts through the per-T slice solve."""
+    lines, crange = _intermetallic_line_phases()
+    phase = Surface2DInterpolatingPhase(
+        "im", lines, concentration_range=crange, add_entropy=False,
+        surface_interpolator=SoftplusSurface2DInterpolator())
+    dmu = np.linspace(-0.2, 0.2, 11)
+    phi = phase.semigrand_potential(500.0, dmu)
+    c = phase.concentration(500.0, dmu)
+    assert phi.shape == (11,)
+    assert c.shape == (11,)
+    assert np.all((c >= crange[0] - 1e-6) & (c <= crange[1] + 1e-6))
+
+
+def test_surface_phase_array_T_shape():
+    """Array T at scalar dmu exercises a fresh surface slice per temperature."""
+    lines, crange = _intermetallic_line_phases()
+    phase = Surface2DInterpolatingPhase(
+        "im", lines, concentration_range=crange, add_entropy=False,
+        surface_interpolator=SoftplusSurface2DInterpolator())
+    T = np.array([450.0, 600.0, 750.0])
+    phi = phase.semigrand_potential(T, 0.05)
+    c = phase.concentration(T, 0.05)
+    assert phi.shape == (3,)
+    assert c.shape == (3,)
+    assert np.all((c >= crange[0] - 1e-6) & (c <= crange[1] + 1e-6))
+
+
 def test_standardize_centers_scales_and_guards_constant():
     """``_standardize`` centres on the mean and scales by the std, returning the
     shift/scale needed to reproduce the transform; a constant input falls back to


### PR DESCRIPTION
## Problem

#22's last remaining checkbox: "all phase should be tested to accept scalar and numpy vectorized inputs." Prior work closed this for `RegularSolution` (PR #238), `InterpolatingPhase`/`SlowInterpolatingPhase` (PR #265), `FastInterpolatingPhase` (PR #281), and `IdealSolution`/`TemperatureDependentLinePhase` (PR #319). PR #351 (open) adds the same for `PointDefectedPhase`.

`Surface2DInterpolatingPhase` (PR #321) was left uncovered by all of the above — it postdates #22's original checklist and inherits `FastInterpolatingPhase`'s solver unchanged, but nothing pinned the scalar-collapse / array-shape behavior for its per-T `FittedSurface.slice_at(T)` path specifically. All three existing integration tests for this class (`test_surface_phase_solver_and_gibbs_duhem`, `test_monotone_slope_surface_phase_gibbs_duhem`, `test_surface_phase_free_energy_is_convex`) only ever call `concentration`/`semigrand_potential` with array `dmu`.

## Change

Three tests in `tests/unit/interpolate/test_softplus_surface.py`, reusing the existing `_intermetallic_line_phases()` fixture and `SoftplusSurface2DInterpolator`, mirroring the style of the `PointDefectedPhase` tests in PR #351:

- `test_surface_phase_scalar_contract` — scalar `(T, dmu)` returns plain scalars, `c` in the concentration range.
- `test_surface_phase_array_dmu_shape` — array `dmu` at scalar `T`.
- `test_surface_phase_array_T_shape` — array `T` at scalar `dmu` (exercises a fresh `slice_at(T)` per temperature).

No production code changes.

## Tests

- `pytest tests/unit/interpolate/test_softplus_surface.py tests/unit/test_phases.py -q` → 161 passed
- `pytest tests/unit tests/regression -q` → 631 passed (628 baseline + 3 new)
- `ruff check tests/unit/interpolate/test_softplus_surface.py` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTjkUQDNhZffSxn1yXBZxN)_