### PR TITLE
test(calculate): direct unit tests for _rescale_T

### DIFF
--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -13,6 +13,7 @@ from landau.calculate import (
     _border_edges,
     _f_excess_tangent_chord,
     _join_phase_unit,
+    _rescale_T,
     _split_phase_unit,
     _split_stable,
     _semigrand_average_concentration,
@@ -63,6 +64,26 @@ def test_find_one_point_no_root():
     # Search in interval (1, 10) where there is no root and signs are the same (all positive)
     with pytest.raises(ValueError, match=r"f\(a\) and f\(b\) must have different signs"):
         find_one_point(phase1, phase2, mock_potential, (1, 10))
+
+
+# --- _rescale_T tests ---
+
+def test_rescale_T_normal_range():
+    t = pd.Series([300.0, 500.0, 700.0])
+    rescaled = _rescale_T(t)
+    np.testing.assert_allclose(rescaled, [0.0, 0.5, 1.0])
+
+
+def test_rescale_T_all_equal_input_unchanged():
+    t = pd.Series([300.0, 300.0, 300.0])
+    rescaled = _rescale_T(t)
+    pd.testing.assert_series_equal(rescaled, t)
+
+
+def test_rescale_T_single_element_input_unchanged():
+    t = pd.Series([500.0])
+    rescaled = _rescale_T(t)
+    pd.testing.assert_series_equal(rescaled, t)
 
 
 # --- cluster_T_c tests ---


### PR DESCRIPTION
Closes #354.

## Problem

`_rescale_T` (`landau/calculate.py:309-313`) is the two-branch helper both `cluster_T_c` and `cluster_T_c_mu` use to normalise `T` to `[0, 1]` before agglomerative clustering. It had no direct test — only exercised indirectly through the clusterers, whose assertions are on the label output.

## Change

Three direct tests in `tests/unit/test_calculate.py`, next to the existing `cluster_T_c` tests:

- `test_rescale_T_normal_range` — `[300, 500, 700]` → `[0.0, 0.5, 1.0]`.
- `test_rescale_T_all_equal_input_unchanged` — all-equal input returns unchanged (no divide-by-zero, no NaN).
- `test_rescale_T_single_element_input_unchanged` — single-element input returns unchanged (`tmin == tmax` degenerately).

No production code changes.

## Tests

- `pytest tests/unit/test_calculate.py -k rescale_T -v` → 3 passed
- `pytest tests/unit/test_calculate.py -q` → 56 passed
- `pytest tests/unit tests/regression -q` → 624 passed, 7 skipped (pre-existing skips, unrelated)
- `ruff check tests/unit/test_calculate.py` → same single pre-existing `E402` finding as on `main` (unrelated import further down the file), nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjqHMCRCDejB8Je63GpAgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjqHMCRCDejB8Je63GpAgp)_