### PR TITLE
test(interpolate): direct unit tests for _smoothv_seed

### DIFF
--- a/tests/unit/test_softplus.py
+++ b/tests/unit/test_softplus.py
@@ -6,7 +6,9 @@ from landau.interpolate import SoftplusFit
 from landau.interpolate.basic import ConcentrationInterpolator, TemperatureInterpolator
 from landau.interpolate.softplus import (
     _flat,
+    _knee_position,
     _sigmoid,
+    _smoothv_seed,
     _softplus,
     _softplus_inv,
     _split,
@@ -303,3 +305,31 @@ class TestSoftplusInv:
         assert np.isfinite(_softplus_inv(0.0))
         assert np.isfinite(_softplus_inv(-1.0))
         assert _softplus_inv(-1.0) == _softplus_inv(0.0)
+class TestSmoothVSeed:
+    """Convex-well-aware per-slice seed against a synthetic V-well."""
+
+    def _v_well(self, c0=0.2):
+        cn = np.linspace(-1.0, 1.0, 41)
+        return cn, np.abs(cn - c0)
+
+    def test_opposite_slope_pair(self):
+        cn, H = self._v_well()
+        _, b, _, _ = _split(_smoothv_seed(cn, H, 2), 2)
+        np.testing.assert_array_equal(b, [12.0, -12.0])
+
+    def test_knee_ties_to_negative_knee_position(self):
+        cn, H = self._v_well()
+        c0 = _knee_position(cn, H)
+        _, _, c, _ = _split(_smoothv_seed(cn, H, 2), 2)
+        np.testing.assert_array_equal(c, [-c0, -c0])
+
+    def test_offset_is_median(self):
+        cn, H = self._v_well()
+        _, _, _, off = _split(_smoothv_seed(cn, H, 2), 2)
+        assert off == np.median(H)
+
+    def test_extra_terms_start_inert(self):
+        cn, H = self._v_well()
+        a, b, _, _ = _split(_smoothv_seed(cn, H, 4), 4)
+        np.testing.assert_array_equal(a[2:], [1e-4, 1e-4])
+        np.testing.assert_array_equal(b[2:], [12.0, 12.0])


### PR DESCRIPTION
Closes #356.

## Problem

`_smoothv_seed` (`landau/interpolate/softplus.py:239`) is the convex-well-aware per-slice seed used by `_fit_slice` and, transitively, the surface fit. It had no direct test — only the surface fit tests exercised it indirectly, and they cannot pin the seed's shape without unpacking the flat vector and comparing against `_knee_position`/the median.

(Issue #355, the sibling sub-issue for `_standardize`, turned out to already be covered by `test_standardize_centers_scales_and_guards_constant` in `tests/unit/interpolate/test_softplus_surface.py`, added in PR #321 — so this PR only covers #356.)

## Change

`TestSmoothVSeed` in `tests/unit/test_softplus.py`, four cases against a synthetic V-well `H(cn) = |cn - c0|`:

- **Opposite-slope pair.** For `n = 2`, `b` unpacks to `[+12.0, -12.0]` (the smooth-V identity).
- **Knee ties to `_knee_position`.** All `c[i]` values equal `-_knee_position(cn, H)`.
- **Offset is the median.** `off == np.median(H)`.
- **Extra terms start inert.** For `n = 4`, amplitudes and slopes at indices 2-3 equal `1e-4` / `+bb` (activated only if the polish needs them).

No production changes.

## Tests

- `pytest tests/unit/test_softplus.py tests/unit/interpolate/test_softplus_surface.py tests/unit/interpolate/test_softplus_fit.py -q` → 55 passed.
- `pytest tests/ -q` → 641 passed, 1 xfailed (pre-existing `Segments × μ-T` xfail).
- `ruff check tests/unit/test_softplus.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019W3268muzf31Nz1NPsNFHF)_