### PR TITLE
test(interpolate): pin single-element input for _standardize

### DIFF
--- a/tests/unit/interpolate/test_softplus_surface.py
+++ b/tests/unit/interpolate/test_softplus_surface.py
@@ -550,3 +550,11 @@ def test_standardize_centers_scales_and_guards_constant():
     xn0, _, scale0 = _standardize(np.full(5, 7.0))
     assert scale0 == 1.0
     np.testing.assert_allclose(xn0, 0.0)
+
+
+def test_standardize_single_element_input():
+    """A lone point has zero spread, so it takes the same ``x.std() or 1.0``
+    fallback as a constant array."""
+    xn, shift, scale = _standardize(np.array([500.0]))
+    assert (shift, scale) == (500.0, 1.0)
+    np.testing.assert_allclose(xn, 0.0)


### PR DESCRIPTION
Closes #355.

## What

`_standardize` (`landau/interpolate/softplus.py:174`) already had a direct test — `test_standardize_centers_scales_and_guards_constant`, added in PR #321 — covering the non-constant round-trip and the constant-input `scale=1` fallback. The third case #355 asked for, a single-element input, was missing: a lone point has zero std, so it exercises the same `x.std() or 1.0` guard as the constant-array case but wasn't pinned on its own.

Added `test_standardize_single_element_input` asserting `_standardize(np.array([500.0]))` returns `shift=500.0`, `scale=1.0` (not `0`/`nan`), `xn=0.0`.

No production changes.

## Testing

- `pytest tests/unit/interpolate/test_softplus_surface.py -k standardize -v` → 2 passed
- `pytest tests/unit` → 611 passed
- `ruff check tests/unit/interpolate/test_softplus_surface.py` → clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0157aRPnc7yutcPN7hEfKafo)_