### PR TITLE
test(plot): direct unit tests for _shapely_polygon

### DIFF
--- a/tests/unit/plot/test_polygons.py
+++ b/tests/unit/plot/test_polygons.py
@@ -16,6 +16,7 @@ import pytest
 from matplotlib.patches import Polygon
 from matplotlib.testing.decorators import check_figures_equal, remove_ticks_and_titles
 
+import shapely
 from shapely import Polygon as ShapelyPolygon
 from shapely.ops import polylabel
 
@@ -23,6 +24,7 @@ from landau import plot as plot_mod
 from landau.plot import (
     _add_inline_polygon_labels,
     _largest_inscribed_circle_center,
+    _shapely_polygon,
     _text_with_outline,
     get_phase_colors,
     get_polygons,
@@ -278,6 +280,80 @@ def test_text_with_outline_forwards_kwargs():
     assert matplotlib.colors.to_rgba(t.get_color()) == matplotlib.colors.to_rgba("red")
     assert t.get_horizontalalignment() == "center"
     plt.close(fig)
+
+
+# --- _shapely_polygon ---------------------------------------------------------
+
+
+def test_shapely_polygon_valid_polygon_returned_unchanged():
+    coords = np.array([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
+    poly = _shapely_polygon(coords)
+    assert isinstance(poly, ShapelyPolygon)
+    assert poly.area == pytest.approx(1.0)
+
+
+def test_shapely_polygon_repairs_self_intersection_to_single_polygon():
+    """A self-intersecting outline whose repair stays one connected piece.
+
+    Unlike a plain bowtie (two triangles meeting at a point, which splits
+    into a `MultiPolygon` — see the sibling test below), this outline's
+    self-intersection resolves under `shapely.make_valid`'s default
+    ("linework") algorithm to a single `Polygon`, so `_shapely_polygon`
+    returns it directly without hitting the `MultiPolygon` largest-lobe pick.
+    """
+    coords = np.array(
+        [(0, 0), (4, 0), (4, 4), (1, 4), (1, 1), (5, 1), (5, 5), (0, 5), (0, 0)],
+        dtype=float,
+    )
+    raw = ShapelyPolygon(coords)
+    assert not raw.is_valid
+    repaired = shapely.make_valid(raw)
+    assert repaired.geom_type == "Polygon"
+
+    poly = _shapely_polygon(coords)
+    assert isinstance(poly, ShapelyPolygon)
+    assert poly.area == pytest.approx(repaired.area)
+
+
+def test_shapely_polygon_repair_splits_picks_larger_lobe():
+    """A bowtie whose two triangles have unequal area: the larger one wins."""
+    coords = np.array([(0.0, 0.0), (6.0, 3.0), (6.0, 0.0), (0.0, 1.0), (0.0, 0.0)])
+    raw = ShapelyPolygon(coords)
+    assert not raw.is_valid
+    repaired = shapely.make_valid(raw)
+    assert repaired.geom_type == "MultiPolygon"
+    lobe_areas = sorted(g.area for g in repaired.geoms)
+    assert lobe_areas[0] != lobe_areas[1]  # genuinely unequal, not a tie
+
+    poly = _shapely_polygon(coords)
+    assert isinstance(poly, ShapelyPolygon)
+    assert poly.area == pytest.approx(lobe_areas[-1])
+
+
+@pytest.mark.parametrize(
+    "coords",
+    [
+        pytest.param(np.array([(0.0, 0.0), (0.5, 0.5), (1.0, 1.0)]), id="collinear"),
+        pytest.param(np.empty((0, 2)), id="empty"),
+    ],
+)
+def test_shapely_polygon_degenerate_input_returns_none(coords):
+    assert _shapely_polygon(coords) is None
+
+
+def test_shapely_polygon_too_few_points_raises():
+    """A single coordinate cannot form even a degenerate ring.
+
+    `shapely.Polygon` rejects fewer than 3 (distinct) points with a
+    `ValueError` rather than yielding an empty/zero-area geometry, so
+    `_shapely_polygon` has no `None` branch to intercept this case. Real
+    callers never hit it: both call sites hand it coordinates already
+    validated upstream (matplotlib patches built from
+    `AbstractPolyMethod._to_mpl_polygon`, which itself rejects `<3` exterior
+    coords).
+    """
+    with pytest.raises(ValueError):
+        _shapely_polygon(np.array([(0.0, 0.0)]))
 
 
 def test_inscribed_circle_center_of_unit_square_is_centroid():


### PR DESCRIPTION
Closes #365.

`_shapely_polygon(coords)` turns an `(N, 2)` coordinate array into a valid non-empty `shapely.Polygon`, repairing self-intersecting outlines via `shapely.make_valid` and picking the largest piece if the repair splits, or returning `None` for degenerate input. It backs `_largest_inscribed_circle_center` and `_add_inline_polygon_labels`, but had no direct test — its `None` branches were previously covered only via `_largest_inscribed_circle_center_returns_none_for_degenerate`, which can't distinguish "coords rejected" from "polylabel search failed".

## What's added

Six cases in `tests/unit/plot/test_polygons.py`:

- Simple valid convex polygon → returned unchanged, area matches.
- A self-intersecting outline whose `make_valid` repair stays a single `Polygon` → returned as-is, area matches the repair.
- A bowtie whose `make_valid` repair splits into a `MultiPolygon` of two unequal-area lobes → the larger lobe is returned.
- Degenerate collinear-points and empty-array input → `None` (parametrized).
- A single-coordinate input.

## Deviation from the issue spec

The issue listed a single point as another `→ None` degenerate case. Verified against actual behavior instead of assuming it: `shapely.Polygon` itself raises `ValueError` for fewer than 3 (distinct) points, before `_shapely_polygon`'s own `None` branches ever run, so it can't be pinned as a `None` case. Pinned it as a `pytest.raises(ValueError)` case instead, with a note that real callers never hit it — both call sites (`_largest_inscribed_circle_center`, `_add_inline_polygon_labels`) pass coordinates already validated upstream by `AbstractPolyMethod._to_mpl_polygon`, which rejects `<3` exterior coords before a matplotlib patch is ever built.

Also verified `shapely.make_valid` behavior directly (no `method=`/`keep_collapsed=` args, unlike `poly.py`'s repair path) to pick fixtures that actually exercise the single-`Polygon` vs `MultiPolygon` branches under `_shapely_polygon`'s own default-method call.

## Testing

- `pytest tests/unit/plot/test_polygons.py -k shapely_polygon` — 6 passed.
- Full suite: `pytest tests/` — 646 passed, 1 xfailed (pre-existing, unrelated).
- `ruff check tests/unit/plot/test_polygons.py` — clean.

No production changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015XqSbFpNq3x9ZCYCb9HMzV)_