### PR TITLE
fix(refine): fix test_simplex_brackets_* to build a _Simplex, not a DataFrame

### DIFF
--- a/landau/refine.py
+++ b/landau/refine.py
@@ -598,6 +598,8 @@ def _simplex_brackets(simplex: "_Simplex"):
     Returns ``(mu_lo, mu_hi, T_lo, T_hi, T_seed)``; both refiners use
     these as the seed simplex's mu/T extents and the seed temperature.
     """
+    if not isinstance(simplex, _Simplex):
+        raise TypeError(f"_simplex_brackets expects a _Simplex, got {type(simplex).__name__}")
     return (
         float(simplex.mu.min()),
         float(simplex.mu.max()),

--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -491,11 +491,7 @@ def test_simplex_brackets_returns_mu_T_extents_and_T_centroid():
     """The (mu_lo, mu_hi, T_lo, T_hi, T_seed) tuple is the seed simplex's
     mu/T bounding box plus the centroid T that ``_CCBase._trace`` walks
     from — verified on a hand-built 3-row simplex."""
-    simplex = pd.DataFrame({
-        "T": [100.0, 200.0, 300.0],
-        "mu": [0.5, 0.2, 0.8],
-        "phase": ["A", "B", "A"],
-    })
+    simplex = _mk_simplex(T=[100.0, 200.0, 300.0], mu=[0.5, 0.2, 0.8], phase=["A", "B", "A"])
     mu_lo, mu_hi, T_lo, T_hi, T_seed = _simplex_brackets(simplex)
     assert (mu_lo, mu_hi) == (0.2, 0.8)
     assert (T_lo, T_hi) == (100.0, 300.0)
@@ -505,13 +501,10 @@ def test_simplex_brackets_returns_mu_T_extents_and_T_centroid():
 def test_simplex_brackets_row_order_agnostic():
     """The returned bracket is symmetric in row order; a shuffled simplex
     yields the same output."""
-    rows = [
-        {"T": 300.0, "mu": 0.8},
-        {"T": 100.0, "mu": 0.5},
-        {"T": 200.0, "mu": 0.2},
-    ]
-    forward = _simplex_brackets(pd.DataFrame(rows))
-    reversed_ = _simplex_brackets(pd.DataFrame(rows[::-1]))
+    T = [300.0, 100.0, 200.0]
+    mu = [0.8, 0.5, 0.2]
+    forward = _simplex_brackets(_mk_simplex(T=T, mu=mu))
+    reversed_ = _simplex_brackets(_mk_simplex(T=T[::-1], mu=mu[::-1]))
     assert forward == reversed_
 
 
@@ -519,7 +512,7 @@ def test_simplex_brackets_returns_python_floats():
     """Every field is a plain ``float`` — the downstream refiners store
     these as dataclass fields and rely on scalar arithmetic, not numpy
     scalar types."""
-    simplex = pd.DataFrame({"T": [100, 200], "mu": [0.5, 0.7]})
+    simplex = _mk_simplex(T=[100, 200], mu=[0.5, 0.7])
     for value in _simplex_brackets(simplex):
         assert type(value) is float
 


### PR DESCRIPTION
Closes #378.

## Problem

CI is red on `main`: three `test_simplex_brackets_*` tests in `tests/unit/test_refine.py` fail on both pandas 2 and 3.

```
FAILED tests/unit/test_refine.py::test_simplex_brackets_returns_mu_T_extents_and_T_centroid
  TypeError: '<=' not supported between instances of 'float' and 'str'
FAILED tests/unit/test_refine.py::test_simplex_brackets_row_order_agnostic
  TypeError: float() argument must be a string or a real number, not 'Series'
FAILED tests/unit/test_refine.py::test_simplex_brackets_returns_python_floats
  TypeError: float() argument must be a string or a real number, not 'Series'
```

PR #328 added direct tests that construct a `pd.DataFrame` and pass it to `_simplex_brackets`. PR #335 had already refactored `_simplex_brackets` to take a `_Simplex` (`landau/refine.py:368`) whose `.T`/`.mu` are numpy arrays. On a `DataFrame`, `.T` is the **transpose** attribute, not the `"T"` column, so `float(simplex.T.min())` reduces over a transposed object-dtype array that mixes floats and the `phase` string column and raises `TypeError`.

## Fix

- Rewrote the three `test_simplex_brackets_*` cases to build a `_Simplex` via the existing `_mk_simplex` test helper (`tests/unit/test_refine.py:37`) instead of a `pd.DataFrame` — matching the function's actual current signature.
- Added an `isinstance(simplex, _Simplex)` guard to `_simplex_brackets` so a future caller passing something else gets a clear `TypeError` instead of a mangled transpose error.

## Testing

- `pytest tests/unit/test_refine.py -k test_simplex_brackets -v` — 3 passed (previously failing on `main`).
- `pytest tests/unit/test_refine.py` — 62 passed.
- `pytest` (full suite) — 667 passed, 1 xfailed (pre-existing, unrelated).
- `ruff check` on both touched files: no new findings (pre-existing unrelated `F401`/`F841` findings elsewhere in `tests/unit/test_refine.py` predate this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETiwU8RbkDGtmxJrpmePPE)_