### PR TITLE
chore(ci): allow unrestricted Bash in the @claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,5 +75,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model ${{ steps.model.outputs.model }} --effort high --allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)'
+          claude_args: '--model ${{ steps.model.outputs.model }} --effort high --allowedTools WebFetch Bash'
 


### PR DESCRIPTION
`.github/workflows/claude.yml` passed

```
--allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(git:*) Bash(gh pr:*)
```

so anything outside those four prefixes was denied in the action run. Bare `pytest` was not allowed (only `python -m pytest` was), and neither were `ls`, `rg`, `ruff`, `sphinx-build`, or `uv`.

Replaced the prefix list with plain `Bash`, which grants every command. `git rebase` was already covered by `Bash(git:*)` and stays covered.

Job permissions (`contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`) are unchanged.

Note this removes the command allowlist entirely for the `@claude` action, which only fires on an `@claude` mention from a repo commenter.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aDyCodWRTvosM9uVmuE66)_