### PR TITLE
test(interpolate): direct unit tests for SGTEInterpolation.deriv()

### DIFF
--- a/tests/unit/interpolate/test_sgte.py
+++ b/tests/unit/interpolate/test_sgte.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from landau.interpolate import SGTE, G_calphad
+from landau.interpolate import SGTE, SGTEInterpolation, G_calphad
 from hypothesis import given, strategies as st
 
 @given(
@@ -18,3 +18,28 @@ def test_SGTE_hypothesis(pl, p0, p1):
 def test_SGTE_nparam_check():
     with pytest.raises(AssertionError, match="Must fit at least two parameters!"):
         SGTE(nparam=1)
+
+
+def test_deriv_pure_polynomial():
+    # G(T) = 5 + 3T + 2T^2  =>  dG/dT = 3 + 4T (pl=0 drops the T*ln(T) term)
+    interp = SGTEInterpolation((0.0, 5.0, 3.0, 2.0))
+    T = np.array([1.0, 10.0, 100.0])
+    assert np.allclose(interp.deriv()(T), 3.0 + 4.0 * T)
+
+
+def test_deriv_log_branch():
+    # G(T) = T*ln(T) (pl=1, no polynomial terms) => dG/dT = ln(T) + 1
+    interp = SGTEInterpolation((1.0, 0.0))
+    T = np.array([1.0, 10.0, 100.0])
+    assert np.allclose(interp.deriv()(T), np.log(T) + 1.0)
+
+
+def test_deriv_scalar_and_array_shape_contract():
+    interp = SGTEInterpolation((0.5, 5.0, 3.0, 2.0))
+    scalar_out = interp.deriv()(10.0)
+    assert np.ndim(scalar_out) == 0
+    assert np.isclose(scalar_out, 0.5 * (np.log(10.0) + 1.0) + 3.0 + 4.0 * 10.0)
+
+    T = np.linspace(50, 500, 5)
+    array_out = interp.deriv()(T)
+    assert array_out.shape == T.shape


### PR DESCRIPTION
Sub-issue of #116. Closes #376.

`SGTEInterpolation.deriv()` (`landau/interpolate/basic.py:293`) is the closed-form `dG/dT` for the SGTE polynomial and had no direct test — same "leaf analytic-derivative `Interpolation` subclass, no direct test" gap closed for `NumericalDerivative` (#367) and `PolynomialInterpolation` (#375).

`G(T) = pl*T*ln(T) + Σ_i p_i*T^i`, so `dG/dT = pl*(ln(T)+1) + Σ_{i≥1} i*p_i*T^(i-1)` (product rule on the `T ln T` term; `p_0` drops out). Three new tests in `tests/unit/interpolate/test_sgte.py`:

- `test_deriv_pure_polynomial` — `pl=0`, `G = 5 + 3T + 2T²` → `dG/dT = 3 + 4T`, isolating the `Σ i*p_i*T^(i-1)` sum and the `i ≥ 1` filter.
- `test_deriv_log_branch` — `pl=1`, no polynomial terms → `dG/dT = ln(T) + 1`, isolating the product-rule term on its own.
- `test_deriv_scalar_and_array_shape_contract` — the standard `_CallableInterpolation` shape contract (scalar in → 0-d out, array in → matching shape), combining both branches.

## Testing

- `pytest tests/unit/interpolate/test_sgte.py` — 5 passed.
- `pytest tests/unit` — 687 passed.
- `ruff check tests/unit/interpolate/test_sgte.py` — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUSyTk7z1DFVBuGA8MmVFu)_