### PR TITLE
test(interpolate): direct unit tests for _scalarize

### DIFF
--- a/tests/unit/interpolate/test_basic_helpers.py
+++ b/tests/unit/interpolate/test_basic_helpers.py
@@ -1,0 +1,48 @@
+"""Direct unit tests for _scalarize, the 0-d numpy -> Python scalar collapse.
+
+_scalarize is the single site that upholds the scalar-in/scalar-out contract
+across AbstractLinePhase.concentration, IdealSolution.semigrand_potential,
+RegularSolution.semigrand_potential, InterpolatingPhase._find_phi_c, and the
+closure-based Interpolations in basic.py. Only exercised transitively before
+this file; none of those call sites can pin what _scalarize alone must do.
+"""
+
+import numpy as np
+
+from landau.interpolate.basic import _scalarize
+
+
+def test_0d_ndarray_collapses_to_python_scalar():
+    out = _scalarize(np.array(1.5))
+    assert out == 1.5
+    assert out.__class__ is float
+
+
+def test_numpy_scalar_type_is_not_an_ndarray_and_passes_through():
+    # np.float64 is a numpy scalar type, not an np.ndarray instance, so the
+    # isinstance(x, np.ndarray) guard does not catch it.
+    x = np.float64(1.5)
+    assert not isinstance(x, np.ndarray)
+    assert _scalarize(x) is x
+
+
+def test_1d_array_passes_through_unchanged():
+    x = np.array([1.0, 2.0, 3.0])
+    out = _scalarize(x)
+    assert out is x
+    assert out.shape == x.shape
+    assert out.dtype == x.dtype
+
+
+def test_python_scalar_passes_through_unchanged():
+    x = 1.5
+    assert _scalarize(x) is x
+    n = 1
+    assert _scalarize(n) is n
+
+
+def test_higher_dimensional_array_passes_through_unchanged():
+    x = np.arange(6.0).reshape(2, 3)
+    out = _scalarize(x)
+    assert out is x
+    assert out.shape == (2, 3)


### PR DESCRIPTION
Closes #377.

`_scalarize(x)` (`landau/interpolate/basic.py:25`) collapses a 0-d numpy result back to a Python scalar and passes everything else through. It upholds the scalar-in/scalar-out contract across `AbstractLinePhase.concentration`, `IdealSolution.semigrand_potential`, `RegularSolution.semigrand_potential`, both `InterpolatingPhase._find_phi_c` variants, and the closure-based `Interpolation`s in `basic.py`, but was only ever exercised transitively through those call sites.

New file `tests/unit/interpolate/test_basic_helpers.py`, five cases:
- 0-d `np.ndarray` collapses to a Python `float`.
- `np.float64` (a numpy scalar type, not an `np.ndarray` instance) is not caught by the `isinstance(x, np.ndarray)` guard and passes through unchanged — verified against the issue's proposed assertion, which assumed `np.float64` collapses; it does not, since `isinstance(np.float64(1.5), np.ndarray)` is `False`.
- 1-d array passthrough (identity, shape/dtype preserved).
- Python scalar passthrough (`is` identity for both `float` and `int`).
- Higher-dimensional (2-d) array passthrough, no shape collapse.

Ran `pytest tests/unit/interpolate/` (105 passed) and `ruff check`/`ruff format --check` on the new file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UssxUHamNrnuCHHzHRxAnP)_