### PR TITLE
test(interpolate): direct unit tests for _rbf_gradient

### DIFF
--- a/tests/unit/interpolate/test_whitney_helpers.py
+++ b/tests/unit/interpolate/test_whitney_helpers.py
@@ -7,6 +7,7 @@ from landau.interpolate.whitney import (
     _in_interval,
     _project_to_hull,
     _project_to_interval,
+    _rbf_gradient,
 )
 
 ATOL = 1e-9
@@ -89,3 +90,66 @@ class TestProjectToHull:
         x_b = _project_to_hull(np.array([-3.0, 0.5]), unit_square_hull)
         assert x_b.shape == (2,)
         np.testing.assert_allclose(x_b, [0.0, 0.5], atol=1e-6)
+
+
+class TestRbfGradient:
+    """Central finite-difference gradient of any callable ``(N, D) -> (N,)``.
+
+    Downstream ``_rbf_gradient`` is called on a fitted ``RBFInterpolator``, but
+    the helper only relies on that interface, so the tests use plain lambdas
+    with a known analytic gradient.
+    """
+
+    def test_constant_function_has_zero_gradient(self):
+        # f(x + eps) == f(x - eps) exactly, so the numerator vanishes on
+        # every axis regardless of eps or dimension.
+        f = lambda X: np.full(X.shape[0], 3.14)  # noqa: E731
+        np.testing.assert_allclose(
+            _rbf_gradient(f, np.array([0.5, -1.0, 2.0]), eps=0.1),
+            np.zeros(3),
+            atol=ATOL,
+        )
+
+    def test_linear_function_recovers_coefficients(self):
+        # Central difference is exact for polynomials of degree <= 2, so
+        # a linear f(x) = a . x returns its coefficient vector to machine
+        # precision independent of the step size.
+        a = np.array([2.0, -3.0, 0.5])
+        f = lambda X: X @ a  # noqa: E731
+        np.testing.assert_allclose(
+            _rbf_gradient(f, np.array([0.7, 1.3, -0.4]), eps=1e-2),
+            a,
+            atol=ATOL,
+        )
+
+    def test_quadratic_isotropic_gradient_is_exact(self):
+        # grad(0.5 * x . x) = x, again exact under central difference.
+        f = lambda X: 0.5 * np.einsum("ni,ni->n", X, X)  # noqa: E731
+        x = np.array([0.3, -0.6, 1.1, 2.0])
+        np.testing.assert_allclose(_rbf_gradient(f, x, eps=1e-3), x, atol=ATOL)
+
+    @pytest.mark.parametrize("D", [1, 2, 4])
+    def test_output_shape_matches_input_dim(self, D):
+        f = lambda X: np.zeros(X.shape[0])  # noqa: E731
+        grad = _rbf_gradient(f, np.zeros(D), eps=0.1)
+        assert grad.shape == (D,)
+
+    def test_partial_derivative_only_steps_along_its_own_axis(self):
+        # Each partial must probe ``rbf`` at (x + eps * e_d) and
+        # (x - eps * e_d) — the loop nulls all other axes to zero.  A
+        # recording callable exposes the six sample points the helper
+        # visits, so the axis isolation is checked directly.
+        seen = []
+
+        def f(X):
+            seen.append(X.copy())
+            return np.zeros(X.shape[0])
+
+        x = np.array([10.0, 20.0, 30.0])
+        _rbf_gradient(f, x, eps=0.5)
+        assert len(seen) == 2 * x.size
+        for row in seen:
+            diff = row[0] - x
+            nonzero = np.flatnonzero(np.abs(diff) > 1e-12)
+            assert nonzero.size == 1
+            assert np.isclose(abs(diff[nonzero[0]]), 0.5)


### PR DESCRIPTION
`_rbf_gradient(rbf, x, eps)` (`landau/interpolate/whitney.py:100`) is the central finite-difference gradient used by `WhitneyRBFInterpolator` to build the tangent-plane extension outside the training-data convex hull. It is the last free helper in that module without a direct pin — PR #373 covered `_in_hull` / `_in_interval` / `_project_to_hull` / `_project_to_interval` (#366) and left this one untested because RBF setup dominates the runtime cost of the surrounding class.

The helper only relies on the callable interface (`(N, D) -> (N,)`), so a plain lambda with a known analytic gradient is a much smaller pin than fitting an RBF; central difference is exact on polynomials of degree ≤ 2 so the recovered values equal the analytic gradient to machine precision (no tolerance tuning).

Five orthogonal cases in `tests/unit/interpolate/test_whitney_helpers.py`:

- constant callable → zero gradient (baseline: the numerator vanishes)
- linear `f(x) = a · x` → recovers `a` at `ATOL = 1e-9`
- quadratic `f(x) = 0.5 x · x` → recovers `x` at `ATOL = 1e-9`
- output shape matches input dim (parametrize `D ∈ {1, 2, 4}`)
- axis-isolation: a recording callable proves each partial only steps along its own axis, all other components stay at `x`

Closes #386.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoojfnS24QgRrp4Yg2U3S4)_