### PR TITLE
test(plot): direct unit tests for _curve_obstacles

### DIFF
--- a/tests/unit/plot/test_curve_obstacles.py
+++ b/tests/unit/plot/test_curve_obstacles.py
@@ -1,0 +1,81 @@
+"""Direct unit tests for `landau.plot._curve_obstacles` (issue #389).
+
+`_curve_obstacles` rasterises the lines and scatter markers of a matplotlib
+Axes into one shapely geometry in pixel space; `_add_inline_curve_labels`
+tests a candidate label's pixel bounding box against it. These tests pin the
+branch structure directly instead of only through the end-to-end pixel-obstacle
+sanity check in `test_excess_free_energy.py`.
+"""
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import shapely
+
+from landau.plot import _curve_obstacles
+
+
+def test_curve_obstacles_empty_axes_returns_none():
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    assert _curve_obstacles(ax) is None
+    plt.close(fig)
+
+
+def test_curve_obstacles_line_becomes_linestring_in_pixel_coords():
+    fig, ax = plt.subplots()
+    ax.plot([0.0, 1.0], [0.0, 1.0])
+    fig.canvas.draw()
+
+    geom = _curve_obstacles(ax)
+
+    assert geom.geom_type == "LineString"
+    expected = ax.transData.transform([(0.0, 0.0), (1.0, 1.0)])
+    np.testing.assert_allclose(np.array(geom.coords), expected)
+    plt.close(fig)
+
+
+def test_curve_obstacles_single_point_line_dropped():
+    fig, ax = plt.subplots()
+    ax.plot([0.0], [0.0])
+    fig.canvas.draw()
+    assert _curve_obstacles(ax) is None
+    plt.close(fig)
+
+
+def test_curve_obstacles_filters_nonfinite_rows():
+    fig, ax = plt.subplots()
+    ax.plot([0.0, np.nan, 2.0], [0.0, 1.0, 2.0])
+    fig.canvas.draw()
+
+    geom = _curve_obstacles(ax)
+
+    assert geom.geom_type == "LineString"
+    expected = ax.transData.transform([(0.0, 0.0), (2.0, 2.0)])
+    np.testing.assert_allclose(np.array(geom.coords), expected)
+    plt.close(fig)
+
+
+def test_curve_obstacles_skips_blended_transform_axhline():
+    fig, ax = plt.subplots()
+    ax.axhline(0.5, color="k")
+    fig.canvas.draw()
+    assert _curve_obstacles(ax) is None
+    plt.close(fig)
+
+
+def test_curve_obstacles_scatter_becomes_buffered_point():
+    fig, ax = plt.subplots(dpi=100)
+    ax.scatter([0.5], [0.5], s=100.0)
+    fig.canvas.draw()
+
+    geom = _curve_obstacles(ax)
+
+    assert geom.geom_type == "Polygon"
+    px, py = ax.transData.transform((0.5, 0.5))
+    radius = (np.sqrt(100.0) / 2.0) * fig.dpi / 72.0
+    assert geom.contains(shapely.Point(px, py))
+    assert geom.contains(shapely.Point(px + radius * 0.9, py))
+    assert not geom.contains(shapely.Point(px + radius * 1.5, py))
+    plt.close(fig)


### PR DESCRIPTION
Closes #389.

`_curve_obstacles(ax)` (`landau/plot.py:1142`) rasterises the lines and scatter markers of an Axes into one shapely geometry in pixel space, so `_add_inline_curve_labels` can push a label clear of both. It was only exercised transitively via `test_excess_free_energy.py::test_inline_labels_clear_of_curves_and_markers`, which pins existence of some geometry but not the branch structure.

New file `tests/unit/plot/test_curve_obstacles.py`, six cases:

- empty axes → `None`
- two-point line → `LineString` at the exact `transData`-transformed pixel coordinates
- single-point line dropped (`len(disp) < 2` gate)
- non-finite rows filtered (a 3-point line with a NaN middle point yields a 2-point `LineString` of the two finite endpoints, not 3)
- blended-transform `axhline` skipped (`get_transform() is not ax.transData`)
- scatter marker becomes a buffered `Point` — contains the marker center and a point just inside the computed radius (`sqrt(s)/2 * dpi/72`), excludes one clearly outside it

`pytest tests/unit/plot/` (207 tests) and `ruff check` on the new file both pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UXE5YqGLcxQUc3FiXPtTfq)_