### PR TITLE
test(interpolate): direct unit tests for _scipy_at_least

### DIFF
--- a/tests/unit/test_softplus.py
+++ b/tests/unit/test_softplus.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import scipy
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from landau.interpolate import SoftplusFit
@@ -7,6 +8,7 @@ from landau.interpolate.basic import ConcentrationInterpolator, TemperatureInter
 from landau.interpolate.softplus import (
     _flat,
     _knee_position,
+    _scipy_at_least,
     _sigmoid,
     _smoothv_seed,
     _softplus,
@@ -333,3 +335,39 @@ class TestSmoothVSeed:
         a, b, _, _ = _split(_smoothv_seed(cn, H, 4), 4)
         np.testing.assert_array_equal(a[2:], [1e-4, 1e-4])
         np.testing.assert_array_equal(b[2:], [12.0, 12.0])
+
+
+class TestScipyAtLeast:
+    """Version-comparison gate that picks the ``lm`` vs ``trf`` least-squares
+    solver for the softplus surface fit (``_LM_HAS_INTERNAL_SCALING``).  On a
+    garbled ``scipy.__version__`` the helper must fall back to the conservative
+    ``False`` so the older-scipy solver path is used."""
+
+    def test_returns_true_at_equality(self, monkeypatch):
+        monkeypatch.setattr(scipy, "__version__", "1.16.0")
+        assert _scipy_at_least(1, 16) is True
+
+    def test_returns_true_when_version_exceeds_threshold(self, monkeypatch):
+        monkeypatch.setattr(scipy, "__version__", "2.0.5")
+        assert _scipy_at_least(1, 16) is True
+
+    def test_returns_false_when_minor_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(scipy, "__version__", "1.15.99")
+        assert _scipy_at_least(1, 16) is False
+
+    def test_ignores_trailing_version_components(self, monkeypatch):
+        # Only the first two dot-separated parts are read; suffixes on later
+        # components (pre-release tags, dev suffixes, git hashes) must not
+        # leak into the comparison.
+        monkeypatch.setattr(scipy, "__version__", "1.16.0rc1")
+        assert _scipy_at_least(1, 16) is True
+
+    def test_returns_false_on_non_numeric_version_string(self, monkeypatch):
+        # ``int("garbled")`` raises ``ValueError`` -> conservative ``False``.
+        monkeypatch.setattr(scipy, "__version__", "garbled.version")
+        assert _scipy_at_least(1, 16) is False
+
+    def test_returns_false_when_version_attribute_missing(self, monkeypatch):
+        # ``scipy.__version__`` missing -> ``AttributeError`` -> ``False``.
+        monkeypatch.delattr(scipy, "__version__", raising=False)
+        assert _scipy_at_least(1, 16) is False


### PR DESCRIPTION
Pins the six branches of `landau.interpolate.softplus._scipy_at_least`, the version-comparison gate that picks `lm` vs `trf` in the softplus surface fit (`SoftplusSurface2DInterpolator._LM_HAS_INTERNAL_SCALING`). Previously exercised only transitively by the surface tests, so a garbled `scipy.__version__` fallback silently degraded to the older-scipy path with no test to notice.

Six orthogonal cases in `tests/unit/test_softplus.py::TestScipyAtLeast`, all monkeypatched to keep the assertions independent of the installed scipy version:

- `test_returns_true_at_equality` — `"1.16.0"` vs `(1, 16)` → `True` (boundary).
- `test_returns_true_when_version_exceeds_threshold` — `"2.0.5"` vs `(1, 16)` → `True`.
- `test_returns_false_when_minor_below_threshold` — `"1.15.99"` vs `(1, 16)` → `False`.
- `test_ignores_trailing_version_components` — `"1.16.0rc1"` vs `(1, 16)` → `True` (`[:2]` slice).
- `test_returns_false_on_non_numeric_version_string` — `"garbled.version"` → `ValueError` → `False`.
- `test_returns_false_when_version_attribute_missing` — `delattr(scipy, "__version__")` → `AttributeError` → `False`.

Refs #116.

---
_Generated by [Claude Code](https://claude.ai/code/session_019YMgExp8biYTDRhJ4y4MKu)_