### PR TITLE
test(refine): pin _delaunay_simplices cache eviction on the first frame

### DIFF
--- a/tests/unit/test_refine.py
+++ b/tests/unit/test_refine.py
@@ -823,6 +823,22 @@ def test_delaunay_simplices_memoised_per_frame():
     assert len(other) == len(first)
 
 
+def test_delaunay_simplices_cache_flips_on_fresh_frame():
+    """Once a second frame has taken the one-slot cache, revisiting the first
+    frame must recompute rather than returning the stale cached list."""
+    phases = _three_phase_system()
+    Ts = np.linspace(220.0, 480.0, 5)
+    mus = np.linspace(-0.05, 0.55, 6)
+    df = _coarse_df(phases, Ts, mus)
+    df2 = _coarse_df(phases, Ts, mus)  # equal content, different object
+
+    first = _delaunay_simplices(df)
+    _delaunay_simplices(df2)  # flips the cache onto df2
+
+    third = _delaunay_simplices(df)
+    assert third is not first  # cache now keyed on df2, so df misses and recomputes
+
+
 def test_delaunay_triple_refiner_deduplicates():
     """Triple refiner emits each triple point exactly once even when
     multiple three-phase Delaunay simplices independently detect it."""


### PR DESCRIPTION
Closes #400.

`_delaunay_simplices` (`landau/refine.py:417`) memoises the (mu, T) tessellation on the most recent frame via `_simplex_cache: (weakref.ref(df), result)`. The existing `test_delaunay_simplices_memoised_per_frame` pins the identity-hit case (same frame → cached list reused) and the recompute-on-fresh-frame case, but not the reverse direction: once a second frame has taken the one-slot cache, does revisiting the first frame recompute, or does it silently return the now-stale cached list?

Added `test_delaunay_simplices_cache_flips_on_fresh_frame`, which builds two frames `df`/`df2` with equal content but distinct identity, calls `_delaunay_simplices(df)` then `_delaunay_simplices(df2)` (flipping the cache onto `df2`), then calls `_delaunay_simplices(df)` a third time and asserts the result is not the original cached list — i.e. the weakref-identity check misses on `df` once `df2` owns the slot, so it recomputes rather than aliasing stale results.

No production code changed.

## Test plan
- `pytest tests/unit/test_refine.py -k delaunay_simplices -v` — 3 passed
- `pytest tests/unit/test_refine.py` — 63 passed
- `pytest tests/unit` — 685 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFL4WW3BCxsLw7hKzJvXKQ)_